### PR TITLE
Enable column autosizing

### DIFF
--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -15,8 +15,8 @@ import "ag-grid-enterprise";
 import { ColDef, IServerSideGetRowsParams } from "ag-grid-community";
 import { useHookGeneric } from "../shared/types";
 import { SamplesList } from "./SamplesList";
-import { SampleMetadataWhere, SampleWhere } from "../generated/graphql";
-import { defaultColDef } from "../pages/requests/helpers";
+import { SampleWhere } from "../generated/graphql";
+import { defaultRecordsColDef } from "../pages/requests/helpers";
 
 export interface IRecordsListProps {
   lazyRecordsQuery: typeof useHookGeneric;
@@ -262,6 +262,13 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
               debug={false}
               context={{
                 navigateFunction: navigate,
+              }}
+              defaultColDef={defaultRecordsColDef}
+              onGridReady={(params) => {
+                params.api.sizeColumnsToFit();
+              }}
+              onFirstDataRendered={(params) => {
+                params.columnApi.autoSizeAllColumns();
               }}
             />
           </div>

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -1,8 +1,6 @@
 import {
   SortDirection,
-  useSamplesQuery,
   Sample,
-  SampleMetadata,
   useFindSamplesByInputValueQuery,
   SampleMetadataWhere,
 } from "../generated/graphql";
@@ -16,7 +14,7 @@ import { UpdateModal } from "./UpdateModal";
 import { CSVFormulate } from "../lib/CSVExport";
 import {
   SampleDetailsColumns,
-  defaultColDef,
+  defaultSamplesColDef,
   SampleChange,
   SampleMetadataExtended,
 } from "../pages/requests/helpers";
@@ -280,12 +278,18 @@ export const SamplesList: FunctionComponent<ISampleListProps> = ({
               rowData={getSampleMetadata(samples)}
               onCellEditRequest={onCellValueChanged}
               readOnlyEdit={true}
-              defaultColDef={defaultColDef}
+              defaultColDef={defaultSamplesColDef}
               ref={gridRef}
               context={{
                 getChanges: () => changes,
               }}
               enableRangeSelection={true}
+              onGridReady={(params) => {
+                params.api.sizeColumnsToFit();
+              }}
+              onFirstDataRendered={(params) => {
+                params.columnApi.autoSizeAllColumns();
+              }}
             />
           </div>
         )}

--- a/frontend/src/pages/requests/helpers.tsx
+++ b/frontend/src/pages/requests/helpers.tsx
@@ -51,12 +51,10 @@ export const RequestsListColumns: ColDef[] = [
   {
     field: "igoRequestId",
     headerName: "IGO Request ID",
-    sortable: true,
   },
   {
     field: "igoProjectId",
     headerName: "IGO Project ID",
-    sortable: true,
   },
   {
     field: "hasSampleSamplesConnection",
@@ -74,72 +72,58 @@ export const RequestsListColumns: ColDef[] = [
   {
     field: "projectManagerName",
     headerName: "Project Manager Name",
-    sortable: true,
   },
   {
     field: "investigatorName",
     headerName: "Investigator Name",
-    sortable: true,
   },
   {
     field: "investigatorEmail",
     headerName: "Investigator Email",
-    sortable: true,
   },
   {
     field: "piEmail",
     headerName: "PI Email",
-    sortable: true,
   },
   {
     field: "dataAnalystName",
     headerName: "Data Analyst Name",
-    sortable: true,
   },
   {
     field: "dataAnalystEmail",
     headerName: "Data Analyst Email",
-    sortable: true,
   },
   {
     field: "genePanel",
     headerName: "Gene Panel",
-    sortable: true,
   },
   {
     field: "labHeadName",
     headerName: "Lab Head Name",
-    sortable: true,
   },
   {
     field: "labHeadEmail",
     headerName: "Lab Head Email",
-    sortable: true,
   },
   {
     field: "qcAccessEmails",
     headerName: "QC Access Emails",
-    sortable: true,
   },
   {
     field: "dataAccessEmails",
     headerName: "Data Access Emails",
-    sortable: true,
   },
   {
     field: "bicAnalysis",
     headerName: "BIC Analysis",
-    sortable: true,
   },
   {
     field: "isCmoRequest",
     headerName: "CMO Request?",
-    sortable: true,
   },
   {
     field: "otherContactEmails",
     headerName: "Other Contact Emails",
-    sortable: true,
   },
 ];
 
@@ -190,7 +174,6 @@ export const PatientsListColumns: ColDef[] = [
     valueGetter: function ({ data }) {
       return data["isAliasPatients"][0].smilePatientId;
     },
-    width: 400,
   },
   {
     field: "hasSampleSamplesConnection",
@@ -454,9 +437,14 @@ SampleDetailsColumns.forEach((def) => {
   };
 });
 
-export const defaultColDef: ColDef = {
+export const defaultSamplesColDef: ColDef = {
   sortable: true,
   editable: true,
+  resizable: true,
+};
+
+export const defaultRecordsColDef: ColDef = {
+  sortable: true,
   resizable: true,
 };
 


### PR DESCRIPTION
This PR enables column autosizing following [this issue](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/936).

Notes:

This implementation followed the [AG Grid doc](https://www.ag-grid.com/javascript-data-grid/column-sizing/)'s recommendation of setting `columnApi.autoSizeColumns()` after the grid is ready, via onFirstDataRendered. However, `autoSizeColumns()` only gets applied to columns/rows that are visible to users. To get around this, the AG Grid doc recommends turning off its column virtualization effect, which is something that we had discussed not wanting to do since it's hacky and could affect performance.

My solution used a workaround found [here](https://github.com/ag-grid/ag-grid/issues/1692), which involves (1) squeezing all columns to fit them into the screen via `sizeColumnsToFit()` when the grid first loads, then (2) running `autoSizeAllColumns()`. This way, all columns get autosized and not just the visible ones. Note that with this approach, the rows below the viewport are not considered, so there might be cells with enough data to the point where their contents get truncated. To cover these scenarios, I enabled all columns to be resizable.