### PR TITLE
Combine Revisable and Status columns into one

### DIFF
--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -272,6 +272,12 @@ export const SamplesList: FunctionComponent<ISampleListProps> = ({
                 locked: function (params) {
                   return params.data?.revisable === false;
                 },
+                "validation-error": function (params) {
+                  return (
+                    params.data?.revisable === true &&
+                    params.data?.hasStatusStatuses[0].validationStatus === false
+                  );
+                },
               }}
               columnDefs={SampleDetailsColumns}
               rowData={getSampleMetadata(samples)}

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -41,7 +41,7 @@ $standardMargin: 10px;
 }
 
 .locked {
-  background: #ffcccb !important;
+  background: #fffcc9 !important;
 }
 
 .unlocked {

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -52,8 +52,7 @@ $standardMargin: 10px;
   background: #fffcc9 !important;
 }
 
-.unrevisable {
-  cursor: not-allowed !important;
+.validation-error {
   background: #ffcccb !important;
 }
 

--- a/frontend/src/pages/requests/helpers.tsx
+++ b/frontend/src/pages/requests/helpers.tsx
@@ -194,58 +194,35 @@ export const SampleDetailsColumns: ColDef<SampleMetadataExtended>[] = [
     editable: (params) => !protectedFields.includes(params.colDef.field!),
   },
   {
-    field: "revisable",
-    headerName: "Revisable",
-    cellRenderer: function (
-      params: EditableCallbackParams<SampleMetadataExtended>
-    ) {
-      return params.data?.revisable ? (
-        <span>
-          <strong>&#10003;</strong> Valid
-        </span>
-      ) : (
-        <div>
+    field: "status",
+    headerName: "Status",
+    cellRenderer: (params: EditableCallbackParams<SampleMetadataExtended>) => {
+      if (params.data?.revisable) {
+        return params.data?.hasStatusStatuses[0].validationStatus ? (
+          <div>
+            <strong>&#10003;</strong>
+          </div>
+        ) : (
+          <div>
+            <WarningIcon />
+          </div>
+        );
+      } else {
+        return (
           <div className="lds-ring">
             <div></div>
             <div></div>
             <div></div>
             <div></div>
           </div>
-          &nbsp;Validating
-        </div>
-      );
+        );
+      }
     },
-    editable: false,
-  },
-  {
-    field: "validationStatus",
-    headerName: "Status",
-    cellRendererSelector: (params: ICellRendererParams<any>) => {
-      return {
-        component: () => {
-          if (params.data?.hasStatusStatuses[0].validationStatus) {
-            return (
-              <div>
-                <strong>&#10003;</strong>
-              </div>
-            );
-          } else {
-            return (
-              <div>
-                <WarningIcon />
-              </div>
-            );
-          }
-        },
-        params: {
-          colDef: {
-            tooltipComponent: StatusTooltip,
-            tooltipValueGetter: function (params: ITooltipParams) {
-              return params;
-            },
-          },
-        },
-      };
+    cellRendererParams: {
+      colDef: {
+        tooltipComponent: StatusTooltip,
+        tooltipValueGetter: (params: ITooltipParams) => params,
+      },
     },
   },
   {
@@ -472,4 +449,5 @@ const protectedFields: string[] = [
   "species",
   "validationStatus",
   "validationReport",
+  "status",
 ];

--- a/frontend/src/pages/requests/helpers.tsx
+++ b/frontend/src/pages/requests/helpers.tsx
@@ -448,5 +448,5 @@ const protectedFields: string[] = [
   "species",
   "validationStatus",
   "validationReport",
-  // "status",
+  "revisable",
 ];

--- a/frontend/src/pages/requests/helpers.tsx
+++ b/frontend/src/pages/requests/helpers.tsx
@@ -1,7 +1,6 @@
 import {
   CellClassParams,
   ColDef,
-  EditableCallbackParams,
   ICellRendererParams,
   RowNode,
 } from "ag-grid-community";
@@ -194,9 +193,9 @@ export const SampleDetailsColumns: ColDef<SampleMetadataExtended>[] = [
     editable: (params) => !protectedFields.includes(params.colDef.field!),
   },
   {
-    field: "status",
+    field: "revisable",
     headerName: "Status",
-    cellRenderer: (params: EditableCallbackParams<SampleMetadataExtended>) => {
+    cellRenderer: (params: ICellRendererParams<SampleMetadataExtended>) => {
       if (params.data?.revisable) {
         return params.data?.hasStatusStatuses[0].validationStatus ? (
           <div>
@@ -449,5 +448,5 @@ const protectedFields: string[] = [
   "species",
   "validationStatus",
   "validationReport",
-  "status",
+  // "status",
 ];


### PR DESCRIPTION
This PR contains the work for [this issue](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/951). We're combining the Revisable and Status columns into one to make information more relevant and concise for the PMs.

Desired behavior for the combined column:

- if revisable = false, show "loading" icon
- if revisable = true and validationStatus = true, show checkmark
- if revisable = true and validationStatus = false, show warning icon