### PR TITLE
General cleanup, polishing of current work

### DIFF
--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -296,6 +296,7 @@ export const SamplesList: FunctionComponent<ISampleListProps> = ({
                 params.columnApi.autoSizeAllColumns();
               }}
               tooltipShowDelay={0}
+              tooltipHideDelay={60000}
             />
           </div>
         )}

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -98,8 +98,9 @@ $standardMargin: 10px;
 }
 
 .tooltip-styles {
-  background-color: #f5f5f5;
+  background-color: #f8f8f8;
   font-size: large;
   padding: 12px;
-  border: 2px solid rgb(198, 197, 214);
+  border: 1px solid rgb(198, 197, 214);
+  border-radius: 4px;
 }

--- a/frontend/src/pages/requests/StatusToolTip.tsx
+++ b/frontend/src/pages/requests/StatusToolTip.tsx
@@ -2,7 +2,7 @@ import { ITooltipParams } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 
 export const StatusTooltip = (props: ITooltipParams) => {
-  const data = props.api!.getDisplayedRowAtIndex(props.rowIndex!)!.data;
+  const data = props.api.getDisplayedRowAtIndex(props.rowIndex!)!.data;
 
   const columnDefs = [
     {
@@ -15,45 +15,46 @@ export const StatusTooltip = (props: ITooltipParams) => {
       wrapText: true,
       autoHeight: true,
       flex: 2,
+      cellStyle: { wordBreak: "break-word" },
     },
   ];
 
+  let { validationStatus, validationReport } = data.hasStatusStatuses[0];
+
   let validationReportMap = new Map();
   try {
-    validationReportMap = new Map(
-      Object.entries(JSON.parse(data?.hasStatusStatuses[0].validationReport))
-    );
+    validationReportMap = new Map(Object.entries(JSON.parse(validationReport)));
   } catch (e) {
-    const cleanedReport = (data?.hasStatusStatuses[0].validationReport)
-      .replace("{", "")
-      .replace("}", "");
+    const cleanedReport = validationReport.replace(/[{}]/g, "");
     const reportArray = cleanedReport.split(",");
     for (const r of reportArray) {
-      const splitReport = r.split("=");
-      validationReportMap.set(splitReport[0].trim(), splitReport[1]);
+      const [key, value] = r.split("=").map((str: String) => str.trim());
+      validationReportMap.set(key, value);
     }
   }
 
-  type Report = {
-    fieldName: string;
-    report: string;
-  };
-  const validationReportList: Report[] = [];
+  const validationReportList = Array.from(
+    validationReportMap,
+    ([fieldName, report]) => ({ fieldName, report })
+  );
 
-  validationReportMap.forEach(function (value, key) {
-    validationReportList.push({ fieldName: key, report: value });
+  validationReportList.map((reportObj) => {
+    reportObj.fieldName = toSentenceCase(reportObj.fieldName);
+    reportObj.report = toSentenceCase(reportObj.report);
+    return reportObj;
   });
 
-  if (!data?.hasStatusStatuses[0].validationStatus) {
+  if (!validationStatus) {
     return (
       <div className="tooltip-styles">
-        <p>
-          <span>Validation report for {`${data?.primaryId}`}</span>
-        </p>
+        <p>Error report for {`${data?.primaryId}`}</p>
         <div className="ag-theme-alpine" style={{ height: 300, width: 550 }}>
           <AgGridReact
             rowData={validationReportList}
             columnDefs={columnDefs}
+            onFirstDataRendered={(params) => {
+              params.columnApi.autoSizeColumn("fieldName");
+            }}
           ></AgGridReact>
         </div>
       </div>
@@ -62,3 +63,7 @@ export const StatusTooltip = (props: ITooltipParams) => {
     return "";
   }
 };
+
+function toSentenceCase(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/frontend/src/pages/requests/helpers.tsx
+++ b/frontend/src/pages/requests/helpers.tsx
@@ -213,7 +213,8 @@ export const SampleDetailsColumns: ColDef<SampleMetadataExtended>[] = [
     cellRendererParams: {
       colDef: {
         tooltipComponent: StatusTooltip,
-        tooltipValueGetter: (params: ITooltipParams) => params,
+        tooltipValueGetter: (params: ITooltipParams) =>
+          params.data.hasStatusStatuses[0].validationReport,
       },
     },
   },

--- a/frontend/src/pages/requests/helpers.tsx
+++ b/frontend/src/pages/requests/helpers.tsx
@@ -171,13 +171,6 @@ export const PatientsListColumns: ColDef[] = [
     },
   },
   {
-    field: "isAliasPatients",
-    headerName: "Smile Patient ID",
-    valueGetter: function ({ data }) {
-      return data["isAliasPatients"][0].smilePatientId;
-    },
-  },
-  {
     field: "hasSampleSamplesConnection",
     headerName: "# Samples",
     valueGetter: function ({ data }) {

--- a/frontend/src/pages/requests/helpers.tsx
+++ b/frontend/src/pages/requests/helpers.tsx
@@ -371,13 +371,6 @@ export const SampleDetailsColumns: ColDef<SampleMetadataExtended>[] = [
     headerName: "Sex",
     editable: (params) => !protectedFields.includes(params.colDef.field!),
   },
-  {
-    field: "validationReport",
-    headerName: "Validation Report",
-    valueGetter: function ({ data }) {
-      return data?.["hasStatusStatuses"][0].validationReport;
-    },
-  },
 ];
 
 SampleDetailsColumns.forEach((def) => {


### PR DESCRIPTION
This PR contains the work for [this Zenhub issue](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/955).

Checklist and notes:

- [x] remove validationReport column
- [x] tooltip disappears too quickly (make persistent)
    - AG Grid's Tooltip API doesn't currently allow for a consistent tooltip. To get around this, I set the time after which the tooltip hides from 10s (default) to 60s. This should suffice for reading the error reports, but if/when we need to make it consistent, we can either override the API or write a popup/modal component.
- [x] make message more readable for validation report table (rename column headers > error + detailed error message, proper camel case) etc. (simple changes only)
    - Make the validation report text wrap on white space only. Previously, the text wrapping sometimes broke up words
    - General cleanup/refactoring of the code that reads the validation report text and processes it to be displayed by AG Grid
    - Convert the validation report's texts from lower case to sentence case
- [x] remove smile id from patient view