### PR TITLE
Allow dashboard to handle SampleMetadata nodes that are missing Status

### DIFF
--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -273,9 +273,12 @@ export const SamplesList: FunctionComponent<ISampleListProps> = ({
                   return params.data?.revisable === false;
                 },
                 "validation-error": function (params) {
+                  const validationStatus =
+                    params.data?.hasStatusStatuses[0]?.validationStatus;
                   return (
                     params.data?.revisable === true &&
-                    params.data?.hasStatusStatuses[0].validationStatus === false
+                    (validationStatus === false ||
+                      validationStatus === undefined)
                   );
                 },
               }}

--- a/frontend/src/pages/requests/StatusToolTip.tsx
+++ b/frontend/src/pages/requests/StatusToolTip.tsx
@@ -19,30 +19,46 @@ export const StatusTooltip = (props: ITooltipParams) => {
     },
   ];
 
-  let { validationStatus, validationReport } = data.hasStatusStatuses[0];
+  let validationStatus;
+  let validationReportList;
 
-  let validationReportMap = new Map();
-  try {
-    validationReportMap = new Map(Object.entries(JSON.parse(validationReport)));
-  } catch (e) {
-    const cleanedReport = validationReport.replace(/[{}]/g, "");
-    const reportArray = cleanedReport.split(",");
-    for (const r of reportArray) {
-      const [key, value] = r.split("=").map((str: String) => str.trim());
-      validationReportMap.set(key, value);
+  if (data.hasStatusStatuses[0]) {
+    validationStatus = data.hasStatusStatuses[0].validationStatus;
+    const validationReport = data.hasStatusStatuses[0].validationReport;
+    let validationReportMap = new Map();
+
+    try {
+      validationReportMap = new Map(
+        Object.entries(JSON.parse(validationReport))
+      );
+    } catch (e) {
+      const cleanedReport = validationReport.replace(/[{}]/g, "");
+      const reportArray = cleanedReport.split(",");
+      for (const r of reportArray) {
+        const [key, value] = r.split("=").map((str: String) => str.trim());
+        validationReportMap.set(key, value);
+      }
     }
+
+    validationReportList = Array.from(
+      validationReportMap,
+      ([fieldName, report]) => ({ fieldName, report })
+    );
+
+    validationReportList.map((reportObj) => {
+      reportObj.fieldName = toSentenceCase(reportObj.fieldName);
+      reportObj.report = toSentenceCase(reportObj.report);
+      return reportObj;
+    });
+  } else {
+    validationStatus = false;
+    validationReportList = [
+      {
+        fieldName: "Data error",
+        report: "Validation status is missing from this sample",
+      },
+    ];
   }
-
-  const validationReportList = Array.from(
-    validationReportMap,
-    ([fieldName, report]) => ({ fieldName, report })
-  );
-
-  validationReportList.map((reportObj) => {
-    reportObj.fieldName = toSentenceCase(reportObj.fieldName);
-    reportObj.report = toSentenceCase(reportObj.report);
-    return reportObj;
-  });
 
   if (!validationStatus) {
     return (

--- a/frontend/src/pages/requests/helpers.tsx
+++ b/frontend/src/pages/requests/helpers.tsx
@@ -190,7 +190,7 @@ export const SampleDetailsColumns: ColDef<SampleMetadataExtended>[] = [
     headerName: "Status",
     cellRenderer: (params: ICellRendererParams<SampleMetadataExtended>) => {
       if (params.data?.revisable) {
-        return params.data?.hasStatusStatuses[0].validationStatus ? (
+        return params.data?.hasStatusStatuses[0]?.validationStatus ? (
           <div>
             <strong>&#10003;</strong>
           </div>
@@ -214,7 +214,8 @@ export const SampleDetailsColumns: ColDef<SampleMetadataExtended>[] = [
       colDef: {
         tooltipComponent: StatusTooltip,
         tooltipValueGetter: (params: ITooltipParams) =>
-          params.data.hasStatusStatuses[0].validationReport,
+          params.data.hasStatusStatuses[0]?.validationReport ??
+          params.data.hasStatusStatuses,
       },
     },
   },


### PR DESCRIPTION
This PR contains the bug fix for [this Zenhub issue](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/962). 

This bug causes a "white screen of death" when viewing samples that are missing a validation status and is resulted from the frontend (`SamplesList.tsx`) trying to access the `validationStatus` field. The console's error message is `caught TypeError: Cannot read properties of undefined (reading 'validationStatus')`.

With this fix, AG Grid rows of SampleMetadata that are missing Status will also show a warning icon that shows the tooltip window below upon hovering:
![Samples missing validation status tooltip demo](https://github.com/mskcc/smile-dashboard/assets/86090707/b3bb55c2-0f62-4b4f-81b3-34ca14d5ae4d)