### PR TITLE
Add Sample IDs to Patients page and make them searchable

### DIFF
--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -110,6 +110,8 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
 
   const remoteCount = data?.[totalCountNodeName]?.totalCount;
 
+  console.log(data);
+
   const handleClose = () => {
     if (unsavedChanges) {
       setShowClosingWarning(true);

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -110,8 +110,6 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
 
   const remoteCount = data?.[totalCountNodeName]?.totalCount;
 
-  console.log(data);
-
   const handleClose = () => {
     if (unsavedChanges) {
       setShowClosingWarning(true);

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -6836,7 +6836,14 @@ export type PatientsListQuery = {
     isAliasPatients: Array<{
       __typename?: "Patient";
       smilePatientId: string;
-      hasSampleSamples: Array<{ __typename?: "Sample"; smileSampleId: string }>;
+      hasSampleSamples: Array<{
+        __typename?: "Sample";
+        smileSampleId: string;
+        hasMetadataSampleMetadata: Array<{
+          __typename?: "SampleMetadata";
+          primaryId: string;
+        }>;
+      }>;
       hasSampleSamplesConnection: {
         __typename?: "PatientHasSampleSamplesConnection";
         totalCount: number;
@@ -6939,6 +6946,7 @@ export type FindSamplesByInputValueQueryVariables = Exact<{
   where?: InputMaybe<SampleWhere>;
   options?: InputMaybe<SampleMetadataOptions>;
   patientAliasesIsAliasWhere2?: InputMaybe<PatientAliasWhere>;
+  requestsHasSampleConnectionWhere2?: InputMaybe<SampleRequestsHasSampleConnectionWhere>;
 }>;
 
 export type FindSamplesByInputValueQuery = {
@@ -7346,6 +7354,9 @@ export const PatientsListDocument = gql`
         smilePatientId
         hasSampleSamples {
           smileSampleId
+          hasMetadataSampleMetadata {
+            primaryId
+          }
         }
         hasSampleSamplesConnection {
           totalCount
@@ -7511,6 +7522,7 @@ export const FindSamplesByInputValueDocument = gql`
     $where: SampleWhere
     $options: SampleMetadataOptions
     $patientAliasesIsAliasWhere2: PatientAliasWhere
+    $requestsHasSampleConnectionWhere2: SampleRequestsHasSampleConnectionWhere
   ) {
     samplesConnection(where: $where) {
       edges {
@@ -7565,6 +7577,7 @@ export const FindSamplesByInputValueDocument = gql`
  *      where: // value for 'where'
  *      options: // value for 'options'
  *      patientAliasesIsAliasWhere2: // value for 'patientAliasesIsAliasWhere2'
+ *      requestsHasSampleConnectionWhere2: // value for 'requestsHasSampleConnectionWhere2'
  *   },
  * });
  */

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -6946,7 +6946,6 @@ export type FindSamplesByInputValueQueryVariables = Exact<{
   where?: InputMaybe<SampleWhere>;
   options?: InputMaybe<SampleMetadataOptions>;
   patientAliasesIsAliasWhere2?: InputMaybe<PatientAliasWhere>;
-  requestsHasSampleConnectionWhere2?: InputMaybe<SampleRequestsHasSampleConnectionWhere>;
 }>;
 
 export type FindSamplesByInputValueQuery = {
@@ -7522,7 +7521,6 @@ export const FindSamplesByInputValueDocument = gql`
     $where: SampleWhere
     $options: SampleMetadataOptions
     $patientAliasesIsAliasWhere2: PatientAliasWhere
-    $requestsHasSampleConnectionWhere2: SampleRequestsHasSampleConnectionWhere
   ) {
     samplesConnection(where: $where) {
       edges {
@@ -7577,7 +7575,6 @@ export const FindSamplesByInputValueDocument = gql`
  *      where: // value for 'where'
  *      options: // value for 'options'
  *      patientAliasesIsAliasWhere2: // value for 'patientAliasesIsAliasWhere2'
- *      requestsHasSampleConnectionWhere2: // value for 'requestsHasSampleConnectionWhere2'
  *   },
  * });
  */

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -13,7 +13,19 @@ import { useParams } from "react-router-dom";
 import PageHeader from "../../shared/components/PageHeader";
 
 function patientAliasFilterWhereVariables(value: string): PatientAliasWhere[] {
-  return [{ namespace_CONTAINS: value }, { value_CONTAINS: value }];
+  return [
+    { namespace_CONTAINS: value },
+    { value_CONTAINS: value },
+    {
+      isAliasPatients_SOME: {
+        hasSampleSamples_SOME: {
+          hasMetadataSampleMetadata_SOME: {
+            primaryId_CONTAINS: value,
+          },
+        },
+      },
+    },
+  ];
 }
 
 export const PatientsPage: React.FunctionComponent = (props) => {

--- a/frontend/src/pages/requests/helpers.tsx
+++ b/frontend/src/pages/requests/helpers.tsx
@@ -177,6 +177,17 @@ export const PatientsListColumns: ColDef[] = [
       return data["isAliasPatients"][0].hasSampleSamplesConnection.totalCount;
     },
   },
+  {
+    field: "primaryIds",
+    headerName: "Primary IDs",
+    valueGetter: function ({ data }) {
+      let sampleIds = [];
+      for (let sample of data["isAliasPatients"][0].hasSampleSamples) {
+        sampleIds.push(sample.hasMetadataSampleMetadata[0].primaryId);
+      }
+      return sampleIds.join(", ");
+    },
+  },
 ];
 
 export const SampleDetailsColumns: ColDef<SampleMetadataExtended>[] = [

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -6945,7 +6945,6 @@ export type FindSamplesByInputValueQueryVariables = Exact<{
   where?: InputMaybe<SampleWhere>;
   options?: InputMaybe<SampleMetadataOptions>;
   patientAliasesIsAliasWhere2?: InputMaybe<PatientAliasWhere>;
-  requestsHasSampleConnectionWhere2?: InputMaybe<SampleRequestsHasSampleConnectionWhere>;
 }>;
 
 export type FindSamplesByInputValueQuery = {
@@ -7371,7 +7370,6 @@ export const FindSamplesByInputValueDocument = gql`
     $where: SampleWhere
     $options: SampleMetadataOptions
     $patientAliasesIsAliasWhere2: PatientAliasWhere
-    $requestsHasSampleConnectionWhere2: SampleRequestsHasSampleConnectionWhere
   ) {
     samplesConnection(where: $where) {
       edges {

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -6835,7 +6835,14 @@ export type PatientsListQuery = {
     isAliasPatients: Array<{
       __typename?: "Patient";
       smilePatientId: string;
-      hasSampleSamples: Array<{ __typename?: "Sample"; smileSampleId: string }>;
+      hasSampleSamples: Array<{
+        __typename?: "Sample";
+        smileSampleId: string;
+        hasMetadataSampleMetadata: Array<{
+          __typename?: "SampleMetadata";
+          primaryId: string;
+        }>;
+      }>;
       hasSampleSamplesConnection: {
         __typename?: "PatientHasSampleSamplesConnection";
         totalCount: number;
@@ -6938,6 +6945,7 @@ export type FindSamplesByInputValueQueryVariables = Exact<{
   where?: InputMaybe<SampleWhere>;
   options?: InputMaybe<SampleMetadataOptions>;
   patientAliasesIsAliasWhere2?: InputMaybe<PatientAliasWhere>;
+  requestsHasSampleConnectionWhere2?: InputMaybe<SampleRequestsHasSampleConnectionWhere>;
 }>;
 
 export type FindSamplesByInputValueQuery = {
@@ -7296,6 +7304,9 @@ export const PatientsListDocument = gql`
         smilePatientId
         hasSampleSamples {
           smileSampleId
+          hasMetadataSampleMetadata {
+            primaryId
+          }
         }
         hasSampleSamplesConnection {
           totalCount
@@ -7360,6 +7371,7 @@ export const FindSamplesByInputValueDocument = gql`
     $where: SampleWhere
     $options: SampleMetadataOptions
     $patientAliasesIsAliasWhere2: PatientAliasWhere
+    $requestsHasSampleConnectionWhere2: SampleRequestsHasSampleConnectionWhere
   ) {
     samplesConnection(where: $where) {
       edges {

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -29,6 +29,9 @@ query PatientsList(
       smilePatientId
       hasSampleSamples {
         smileSampleId
+        hasMetadataSampleMetadata {
+          primaryId
+        }
       }
       hasSampleSamplesConnection {
         totalCount

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -84,7 +84,6 @@ query FindSamplesByInputValue(
   $where: SampleWhere
   $options: SampleMetadataOptions
   $patientAliasesIsAliasWhere2: PatientAliasWhere
-  $requestsHasSampleConnectionWhere2: SampleRequestsHasSampleConnectionWhere
 ) {
   samplesConnection(where: $where) {
     edges {


### PR DESCRIPTION
This PR contains the work for [this Zenhub issue](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/959).

The `PatientsList` query was modified to allow access to Primary ID data. In `operations.graphql`, note that I also removed the `$requestsHasSampleConnectionWhere2` argument from the `FindSamplesByInputValue` query because it's not being used today.

Primary IDs were made searchable by adding the path to them as another field we inspect when searching, via function `patientAliasFilterWhereVariables()`.