### PR TITLE
Temporarily disable sorting for 'nested' data fields

### DIFF
--- a/frontend/src/pages/requests/helpers.tsx
+++ b/frontend/src/pages/requests/helpers.tsx
@@ -49,6 +49,7 @@ export const RequestsListColumns: ColDef[] = [
         </Button>
       );
     },
+    sortable: false,
   },
   {
     field: "igoRequestId",
@@ -70,6 +71,7 @@ export const RequestsListColumns: ColDef[] = [
       }
       return undefined;
     },
+    sortable: false,
   },
   {
     field: "projectManagerName",
@@ -147,6 +149,7 @@ export const PatientsListColumns: ColDef[] = [
         </Button>
       );
     },
+    sortable: false,
   },
   {
     field: "cmoPatientId",
@@ -158,6 +161,7 @@ export const PatientsListColumns: ColDef[] = [
         }
       }
     },
+    sortable: false,
   },
   {
     field: "dmpPatientId",
@@ -169,6 +173,7 @@ export const PatientsListColumns: ColDef[] = [
         }
       }
     },
+    sortable: false,
   },
   {
     field: "hasSampleSamplesConnection",
@@ -176,6 +181,7 @@ export const PatientsListColumns: ColDef[] = [
     valueGetter: function ({ data }) {
       return data["isAliasPatients"][0].hasSampleSamplesConnection.totalCount;
     },
+    sortable: false,
   },
   {
     field: "primaryIds",
@@ -187,6 +193,7 @@ export const PatientsListColumns: ColDef[] = [
       }
       return sampleIds.join(", ");
     },
+    sortable: false,
   },
 ];
 


### PR DESCRIPTION
[Related Zenhub issue](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/971)

Temporarily disabling sorting for select data fields until we enable their sorting functionality as part of [this issue](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/960). Also permanently disabled sorting for the `View` column on both pages since it's not a data column.