### PR TITLE
Implement bulk searching for Patients view

### DIFF
--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -303,6 +303,7 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
               onFirstDataRendered={(params) => {
                 params.columnApi.autoSizeAllColumns();
               }}
+              enableRangeSelection={true}
             />
           </div>
         )}

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -11,30 +11,58 @@ import "ag-grid-enterprise";
 import RecordsList from "../../components/RecordsList";
 import { useParams } from "react-router-dom";
 import PageHeader from "../../shared/components/PageHeader";
+import { parseSearchQueries } from "../../lib/parseSearchQueries";
 
 function patientAliasFilterWhereVariables(value: string): PatientAliasWhere[] {
-  return [
-    { namespace_CONTAINS: value },
-    { value_CONTAINS: value },
-    {
-      isAliasPatients_SOME: {
-        hasSampleSamples_SOME: {
-          hasMetadataSampleMetadata_SOME: {
-            cmoSampleName_CONTAINS: value,
+  const uniqueQueries = parseSearchQueries(value);
+
+  if (uniqueQueries.length > 1) {
+    return [
+      { value_IN: uniqueQueries },
+      { namespace_IN: uniqueQueries },
+      {
+        isAliasPatients_SOME: {
+          hasSampleSamples_SOME: {
+            hasMetadataSampleMetadata_SOME: {
+              cmoSampleName_IN: uniqueQueries,
+            },
           },
         },
       },
-    },
-    {
-      isAliasPatients_SOME: {
-        hasSampleSamples_SOME: {
-          hasMetadataSampleMetadata_SOME: {
-            primaryId_CONTAINS: value,
+      {
+        isAliasPatients_SOME: {
+          hasSampleSamples_SOME: {
+            hasMetadataSampleMetadata_SOME: {
+              primaryId_IN: uniqueQueries,
+            },
           },
         },
       },
-    },
-  ];
+    ];
+  } else {
+    return [
+      { value_CONTAINS: uniqueQueries[0] },
+      { namespace_CONTAINS: uniqueQueries[0] },
+      {
+        isAliasPatients_SOME: {
+          hasSampleSamples_SOME: {
+            hasMetadataSampleMetadata_SOME: {
+              cmoSampleName_CONTAINS: uniqueQueries[0],
+            },
+          },
+        },
+      },
+      {
+        isAliasPatients_SOME: {
+          hasSampleSamples_SOME: {
+            hasMetadataSampleMetadata_SOME: {
+              primaryId_CONTAINS: uniqueQueries[0],
+            },
+          },
+        },
+      },
+    ];
+  }
 }
 
 export const PatientsPage: React.FunctionComponent = (props) => {


### PR DESCRIPTION
[Related Zenhub issue.](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/977)

This PR:
- implements bulk searching for the Patients page in a similar way as the Requests page
- also enables multi-cell selection for selecting multiple IDs (only for `RecordsList` because `SamplesList` already has this enabled)

I tested this locally with the dev server database. Performance should not be an issue: I bulk searched 5,000 values and got the results back in ~3s, which is similar to the initial page load.