### PR TITLE
Implement bulk searching for Samples view

### DIFF
--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -25,6 +25,8 @@ import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-alpine.css";
 import "ag-grid-enterprise";
 import { CellValueChangedEvent } from "ag-grid-community";
+import { Tooltip } from "@material-ui/core";
+import InfoIcon from "@material-ui/icons/InfoOutlined";
 
 const POLLING_INTERVAL = 2000;
 const max_rows = 500;
@@ -244,6 +246,33 @@ export const SamplesList: FunctionComponent<ISampleListProps> = ({
               });
             }}
           />
+        </Col>
+
+        <Col md="auto" style={{ marginLeft: -15 }}>
+          <Tooltip
+            title={
+              <span style={{ fontSize: 12 }}>
+                After inputting your search query, click on &quot;Search&quot;
+                or press &quot;Enter&quot; to get your results. To bulk search,
+                input a list of values separated by spaces or commas (e.g.
+                &quot;value1 value2 value3&quot;)
+              </span>
+            }
+          >
+            <InfoIcon style={{ fontSize: 18, color: "grey" }} />
+          </Tooltip>
+        </Col>
+
+        <Col md="auto" style={{ marginLeft: -15 }}>
+          <Button
+            onClick={() => {
+              // setSearchVal(val);
+            }}
+            className={"btn btn-secondary"}
+            size={"sm"}
+          >
+            Search
+          </Button>
         </Col>
 
         <Col className={"text-start"}>

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -27,6 +27,7 @@ import "ag-grid-enterprise";
 import { CellValueChangedEvent } from "ag-grid-community";
 import { Tooltip } from "@material-ui/core";
 import InfoIcon from "@material-ui/icons/InfoOutlined";
+import { parseSearchQueries } from "../lib/parseSearchQueries";
 
 const POLLING_INTERVAL = 2000;
 const max_rows = 500;
@@ -41,27 +42,53 @@ interface ISampleListProps {
 }
 
 function sampleFilterWhereVariables(value: string): SampleMetadataWhere[] {
-  return [
-    { cmoSampleName_CONTAINS: value },
-    { importDate_CONTAINS: value },
-    { investigatorSampleId_CONTAINS: value },
-    { primaryId_CONTAINS: value },
-    { sampleClass_CONTAINS: value },
-    { cmoPatientId_CONTAINS: value },
-    { cmoSampleIdFields_CONTAINS: value },
-    { sampleName_CONTAINS: value },
-    { preservation_CONTAINS: value },
-    { tumorOrNormal_CONTAINS: value },
-    { oncotreeCode_CONTAINS: value },
-    { collectionYear_CONTAINS: value },
-    { sampleOrigin_CONTAINS: value },
-    { tissueLocation_CONTAINS: value },
-    { sex_CONTAINS: value },
-    { libraries_CONTAINS: value },
-    { sampleType_CONTAINS: value },
-    { species_CONTAINS: value },
-    { genePanel_CONTAINS: value },
-  ];
+  const uniqueQueries = parseSearchQueries(value);
+
+  if (uniqueQueries.length > 1) {
+    return [
+      { cmoSampleName_IN: uniqueQueries },
+      { importDate_IN: uniqueQueries },
+      { investigatorSampleId_IN: uniqueQueries },
+      { primaryId_IN: uniqueQueries },
+      { sampleClass_IN: uniqueQueries },
+      { cmoPatientId_IN: uniqueQueries },
+      { cmoSampleIdFields_IN: uniqueQueries },
+      { sampleName_IN: uniqueQueries },
+      { preservation_IN: uniqueQueries },
+      { tumorOrNormal_IN: uniqueQueries },
+      { oncotreeCode_IN: uniqueQueries },
+      { collectionYear_IN: uniqueQueries },
+      { sampleOrigin_IN: uniqueQueries },
+      { tissueLocation_IN: uniqueQueries },
+      { sex_IN: uniqueQueries },
+      { libraries_IN: uniqueQueries },
+      { sampleType_IN: uniqueQueries },
+      { species_IN: uniqueQueries },
+      { genePanel_IN: uniqueQueries },
+    ];
+  } else {
+    return [
+      { cmoSampleName_CONTAINS: uniqueQueries[0] },
+      { importDate_CONTAINS: uniqueQueries[0] },
+      { investigatorSampleId_CONTAINS: uniqueQueries[0] },
+      { primaryId_CONTAINS: uniqueQueries[0] },
+      { sampleClass_CONTAINS: uniqueQueries[0] },
+      { cmoPatientId_CONTAINS: uniqueQueries[0] },
+      { cmoSampleIdFields_CONTAINS: uniqueQueries[0] },
+      { sampleName_CONTAINS: uniqueQueries[0] },
+      { preservation_CONTAINS: uniqueQueries[0] },
+      { tumorOrNormal_CONTAINS: uniqueQueries[0] },
+      { oncotreeCode_CONTAINS: uniqueQueries[0] },
+      { collectionYear_CONTAINS: uniqueQueries[0] },
+      { sampleOrigin_CONTAINS: uniqueQueries[0] },
+      { tissueLocation_CONTAINS: uniqueQueries[0] },
+      { sex_CONTAINS: uniqueQueries[0] },
+      { libraries_CONTAINS: uniqueQueries[0] },
+      { sampleType_CONTAINS: uniqueQueries[0] },
+      { species_CONTAINS: uniqueQueries[0] },
+      { genePanel_CONTAINS: uniqueQueries[0] },
+    ];
+  }
 }
 
 function getSampleMetadata(samples: Sample[]) {
@@ -111,6 +138,7 @@ export const SamplesList: FunctionComponent<ISampleListProps> = ({
   const gridRef = useRef<any>(null);
 
   useEffect(() => {
+    gridRef.current?.api?.showLoadingOverlay();
     async function refetchSearchVal() {
       await refetch({
         where: {
@@ -125,7 +153,9 @@ export const SamplesList: FunctionComponent<ISampleListProps> = ({
         },
       });
     }
-    refetchSearchVal();
+    refetchSearchVal().then(() => {
+      gridRef.current?.api?.hideOverlay();
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchVal]);
 
@@ -229,7 +259,7 @@ export const SamplesList: FunctionComponent<ISampleListProps> = ({
             className={"d-inline-block"}
             style={{ width: "300px" }}
             type="search"
-            placeholder="Search Samples"
+            placeholder="Search samples"
             aria-label="Search"
             value={val}
             onKeyDown={(event) => {


### PR DESCRIPTION
[Related ZenHub issue](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/978).

This PR introduces bulk searching for both the standalone Samples page and the Samples modal within the Requests and Patients pages. 

Note that table data on the Requests and Patients pages are rendered server-side, while those on the Samples view are rendered client-side. AG Grid has different loading animations for each rendering style (see images below). It doesn't look like we can use the same loading animation for all these pages, unless they use the same rendering style.

Samples page's loading:
![CleanShot 133207](https://github.com/mskcc/smile-dashboard/assets/86090707/16121978-c54a-4fba-b3f3-940e9d82b301)

Requests page's loading:
![CleanShot 133120](https://github.com/mskcc/smile-dashboard/assets/86090707/621b65b2-aafe-49a2-9550-4477d33b0e08)