### PR TITLE
Search with MRNs

### DIFF
--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -34,6 +34,7 @@ export interface IRecordsListProps {
   searchVariables: SampleWhere;
   customFilterUI?: JSX.Element;
   customFilterState?: boolean;
+  setCustomFilterVals?: (vals: any[]) => void;
 }
 
 const RecordsList: FunctionComponent<IRecordsListProps> = ({
@@ -49,6 +50,7 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
   searchVariables,
   customFilterUI,
   customFilterState,
+  setCustomFilterVals,
 }) => {
   const [val, setVal] = useState("");
   const [searchVal, setSearchVal] = useState<string[]>([]);
@@ -127,7 +129,11 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
 
   const handleSearch = async () => {
     const uniqueQueries = parseSearchQueries(val);
-    if (customFilterUI && customFilterState) {
+    if (
+      customFilterUI &&
+      customFilterState &&
+      setCustomFilterVals!.length > 0
+    ) {
       // TODO: change host name to env variable
       const response = await fetch("http://localhost:3000/crosswalk", {
         method: "POST",
@@ -138,6 +144,7 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
         body: JSON.stringify(uniqueQueries),
       });
       const data = await response.json();
+      setCustomFilterVals!(data);
       const cmoIds = data.map((d: any) => d.cmoId);
       setSearchVal(cmoIds);
     } else {
@@ -255,6 +262,7 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
             onInput={(event) => {
               const newVal = event.currentTarget.value;
               if (newVal === "") {
+                setCustomFilterVals && setCustomFilterVals([]);
                 setSearchVal([]);
               }
               setVal(newVal);

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -35,6 +35,7 @@ export interface IRecordsListProps {
   customFilterUI?: JSX.Element;
   customFilterState?: boolean;
   setCustomFilterVals?: (vals: any[]) => void;
+  customFilterFunc?: (vals: any[]) => Promise<string[]>;
 }
 
 const RecordsList: FunctionComponent<IRecordsListProps> = ({
@@ -51,6 +52,7 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
   customFilterUI,
   customFilterState,
   setCustomFilterVals,
+  customFilterFunc,
 }) => {
   const [val, setVal] = useState("");
   const [searchVal, setSearchVal] = useState<string[]>([]);
@@ -132,21 +134,11 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
     if (
       customFilterUI &&
       customFilterState &&
-      setCustomFilterVals!.length > 0
+      setCustomFilterVals!.length > 0 &&
+      customFilterFunc
     ) {
-      // TODO: change host name to env variable
-      const response = await fetch("http://localhost:3000/crosswalk", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-        body: JSON.stringify(uniqueQueries),
-      });
-      const data = await response.json();
-      setCustomFilterVals!(data);
-      const cmoIds = data.map((d: any) => d.cmoId);
-      setSearchVal(cmoIds);
+      const newQueries = await customFilterFunc(uniqueQueries);
+      setSearchVal(newQueries);
     } else {
       setSearchVal(uniqueQueries);
     }

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -19,6 +19,7 @@ import { SampleWhere } from "../generated/graphql";
 import { defaultRecordsColDef } from "../shared/helpers";
 import InfoIcon from "@material-ui/icons/InfoOutlined";
 import { Tooltip } from "@material-ui/core";
+import { parseSearchQueries } from "../lib/parseSearchQueries";
 
 export interface IRecordsListProps {
   lazyRecordsQuery: typeof useHookGeneric;
@@ -27,7 +28,7 @@ export interface IRecordsListProps {
   pageRoute: string;
   searchTerm: string;
   colDefs: ColDef[];
-  conditionBuilder: (val: string) => Record<string, any>[];
+  conditionBuilder: (uniqueQueries: string[]) => Record<string, any>[];
   sampleQueryParamValue: string | undefined;
   sampleQueryParamFieldName: string;
   searchVariables: SampleWhere;
@@ -69,10 +70,10 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
       getRows: (params: IServerSideGetRowsParams) => {
         const fetchInput = {
           where: {
-            OR: conditionBuilder(searchVal),
+            OR: conditionBuilder(parseSearchQueries(searchVal)),
           },
           [`${nodeName}ConnectionWhere2`]: {
-            OR: conditionBuilder(searchVal),
+            OR: conditionBuilder(parseSearchQueries(searchVal)),
           },
           options: {
             offset: params.request.startRow,
@@ -130,7 +131,7 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
             return fetchMore({
               variables: {
                 where: {
-                  OR: conditionBuilder(val),
+                  OR: conditionBuilder(parseSearchQueries(searchVal)),
                 },
                 options: {
                   offset: 0,

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -50,6 +50,7 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
   const [showDownloadModal, setShowDownloadModal] = useState(false);
   const [showClosingWarning, setShowClosingWarning] = useState(false);
   const [unsavedChanges, setUnsavedChanges] = useState(false);
+  const [searchWithMRNs, setSearchWithMRNs] = useState(false);
   const navigate = useNavigate();
 
   // note that we aren't using initial fetch
@@ -267,6 +268,22 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
         <Col md="auto">
           {remoteCount?.toLocaleString()} matching{" "}
           {remoteCount > 1 ? searchTerm : searchTerm.slice(0, -1)}
+        </Col>
+
+        <Col md="auto">
+          <div className="vr"></div>
+        </Col>
+
+        <Col md="auto" className="mt-1">
+          <Form>
+            <Form.Check
+              type="switch"
+              id="custom-switch"
+              label="Search with MRNs"
+              checked={searchWithMRNs}
+              onChange={(e) => setSearchWithMRNs(e.target.checked)}
+            />
+          </Form>
         </Col>
 
         <Col className={"text-end"}>

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -31,6 +31,7 @@ export interface IRecordsListProps {
   sampleQueryParamValue: string | undefined;
   sampleQueryParamFieldName: string;
   searchVariables: SampleWhere;
+  customFilter?: JSX.Element;
 }
 
 const RecordsList: FunctionComponent<IRecordsListProps> = ({
@@ -44,13 +45,13 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
   sampleQueryParamValue,
   sampleQueryParamFieldName,
   searchVariables,
+  customFilter,
 }) => {
   const [val, setVal] = useState("");
   const [searchVal, setSearchVal] = useState("");
   const [showDownloadModal, setShowDownloadModal] = useState(false);
   const [showClosingWarning, setShowClosingWarning] = useState(false);
   const [unsavedChanges, setUnsavedChanges] = useState(false);
-  const [searchWithMRNs, setSearchWithMRNs] = useState(false);
   const navigate = useNavigate();
 
   // note that we aren't using initial fetch
@@ -270,21 +271,7 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
           {remoteCount > 1 ? searchTerm : searchTerm.slice(0, -1)}
         </Col>
 
-        <Col md="auto">
-          <div className="vr"></div>
-        </Col>
-
-        <Col md="auto" className="mt-1">
-          <Form>
-            <Form.Check
-              type="switch"
-              id="custom-switch"
-              label="Search with MRNs"
-              checked={searchWithMRNs}
-              onChange={(e) => setSearchWithMRNs(e.target.checked)}
-            />
-          </Form>
-        </Col>
+        {customFilter}
 
         <Col className={"text-end"}>
           <Button

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -41,9 +41,9 @@ interface ISampleListProps {
   sampleQueryParamValue?: string;
 }
 
-function sampleFilterWhereVariables(value: string): SampleMetadataWhere[] {
-  const uniqueQueries = parseSearchQueries(value);
-
+function sampleFilterWhereVariables(
+  uniqueQueries: string[]
+): SampleMetadataWhere[] {
   if (uniqueQueries.length > 1) {
     return [
       { cmoSampleName_IN: uniqueQueries },
@@ -143,7 +143,7 @@ export const SamplesList: FunctionComponent<ISampleListProps> = ({
       await refetch({
         where: {
           hasMetadataSampleMetadata_SOME: {
-            OR: sampleFilterWhereVariables(searchVal),
+            OR: sampleFilterWhereVariables(parseSearchQueries(searchVal)),
             ...(sampleQueryParamFieldName && sampleQueryParamValue
               ? {
                   [sampleQueryParamFieldName]: sampleQueryParamValue,

--- a/frontend/src/lib/CSVExport.ts
+++ b/frontend/src/lib/CSVExport.ts
@@ -2,7 +2,7 @@ import { ColDef } from "ag-grid-community";
 
 export function CSVFormulate(rows: any[], columnDefinitions: ColDef[]) {
   const csvString = [
-    columnDefinitions.map((item) => item.field).join("\t"),
+    columnDefinitions.map((item) => item.headerName).join("\t"),
     ...rows
       .map((req) =>
         columnDefinitions.map((colDef) => {

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -70,14 +70,26 @@ export const PatientsPage: React.FunctionComponent = (props) => {
   const [searchWithMRNs, setSearchWithMRNs] = useState(false);
   const [patientsListColumns, setPatientsListColumns] =
     useState(PatientsListColumns);
+  const [patientIdTriplets, setPatientIdTriplets] = useState<any[]>([]);
 
   useEffect(() => {
-    if (searchWithMRNs) {
+    if (searchWithMRNs && patientIdTriplets.length > 0) {
       const colsWithMRNs = PatientsListColumns.map((column) => {
         if (column.headerName === "MRN") {
           return {
             ...column,
             hide: false,
+            valueGetter: (params: any) => {
+              const cmoId = params.data.value;
+              const patientIdTriplet = patientIdTriplets.find(
+                (triplet) => triplet.cmoId === cmoId
+              );
+              if (patientIdTriplet) {
+                return patientIdTriplet.ptMrn;
+              } else {
+                return "";
+              }
+            },
           };
         } else {
           return column;
@@ -87,7 +99,7 @@ export const PatientsPage: React.FunctionComponent = (props) => {
     } else {
       setPatientsListColumns(PatientsListColumns);
     }
-  }, [searchWithMRNs]);
+  }, [searchWithMRNs, patientIdTriplets]);
 
   const pageRoute = "/patients";
   const sampleQueryParamFieldName = "cmoPatientId";
@@ -141,6 +153,7 @@ export const PatientsPage: React.FunctionComponent = (props) => {
           </>
         }
         customFilterState={searchWithMRNs}
+        setCustomFilterVals={setPatientIdTriplets}
       />
     </>
   );

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -110,6 +110,23 @@ export const PatientsPage: React.FunctionComponent = (props) => {
     }
   }, [searchWithMRNs, patientIdsTriplets]);
 
+  async function fetchPatientIdsTriplets(
+    patientMrns: string[]
+  ): Promise<string[]> {
+    // TODO: replace with dynamic url
+    const response = await fetch("http://localhost:3000/crosswalk", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(patientMrns),
+    });
+    const data: PatientIdsTriplet[] = await response.json();
+    setPatientIdsTriplets(data);
+    return data.map((d) => d.cmoId);
+  }
+
   const pageRoute = "/patients";
   const sampleQueryParamFieldName = "cmoPatientId";
 
@@ -163,6 +180,7 @@ export const PatientsPage: React.FunctionComponent = (props) => {
         }
         customFilterState={searchWithMRNs}
         setCustomFilterVals={setPatientIdsTriplets}
+        customFilterFunc={fetchPatientIdsTriplets}
       />
     </>
   );

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -3,7 +3,7 @@ import {
   SampleWhere,
   usePatientsListLazyQuery,
 } from "../../generated/graphql";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { PatientsListColumns } from "../../shared/helpers";
 import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-alpine.css";
@@ -68,6 +68,26 @@ function patientAliasFilterWhereVariables(
 export const PatientsPage: React.FunctionComponent = (props) => {
   const params = useParams();
   const [searchWithMRNs, setSearchWithMRNs] = useState(false);
+  const [patientsListColumns, setPatientsListColumns] =
+    useState(PatientsListColumns);
+
+  useEffect(() => {
+    if (searchWithMRNs) {
+      const colsWithMRNs = PatientsListColumns.map((column) => {
+        if (column.headerName === "MRN") {
+          return {
+            ...column,
+            hide: false,
+          };
+        } else {
+          return column;
+        }
+      });
+      setPatientsListColumns(colsWithMRNs);
+    } else {
+      setPatientsListColumns(PatientsListColumns);
+    }
+  }, [searchWithMRNs]);
 
   const pageRoute = "/patients";
   const sampleQueryParamFieldName = "cmoPatientId";
@@ -82,7 +102,7 @@ export const PatientsPage: React.FunctionComponent = (props) => {
         totalCountNodeName="patientAliasesConnection"
         pageRoute={pageRoute}
         searchTerm="patients"
-        colDefs={PatientsListColumns}
+        colDefs={patientsListColumns}
         conditionBuilder={patientAliasFilterWhereVariables}
         sampleQueryParamFieldName={sampleQueryParamFieldName}
         sampleQueryParamValue={params[sampleQueryParamFieldName]}

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -13,6 +13,12 @@ import { useParams } from "react-router-dom";
 import PageHeader from "../../shared/components/PageHeader";
 import { Col, Form } from "react-bootstrap";
 
+type PatientIdsTriplet = {
+  dmpId: string;
+  cmoId: string;
+  ptMrn: string;
+};
+
 function patientAliasFilterWhereVariables(
   uniqueQueries: string[]
 ): PatientAliasWhere[] {
@@ -68,24 +74,26 @@ function patientAliasFilterWhereVariables(
 export const PatientsPage: React.FunctionComponent = (props) => {
   const params = useParams();
   const [searchWithMRNs, setSearchWithMRNs] = useState(false);
+  const [patientIdsTriplets, setPatientIdsTriplets] = useState<
+    PatientIdsTriplet[]
+  >([]);
   const [patientsListColumns, setPatientsListColumns] =
     useState(PatientsListColumns);
-  const [patientIdTriplets, setPatientIdTriplets] = useState<any[]>([]);
 
   useEffect(() => {
-    if (searchWithMRNs && patientIdTriplets.length > 0) {
+    if (searchWithMRNs && patientIdsTriplets.length > 0) {
       const colsWithMRNs = PatientsListColumns.map((column) => {
-        if (column.headerName === "MRN") {
+        if (column.headerName === "Patient MRN") {
           return {
             ...column,
             hide: false,
             valueGetter: (params: any) => {
               const cmoId = params.data.value;
-              const patientIdTriplet = patientIdTriplets.find(
+              const patientIdsTriplet = patientIdsTriplets.find(
                 (triplet) => triplet.cmoId === cmoId
               );
-              if (patientIdTriplet) {
-                return patientIdTriplet.ptMrn;
+              if (patientIdsTriplet) {
+                return patientIdsTriplet.ptMrn;
               } else {
                 return "";
               }
@@ -99,7 +107,7 @@ export const PatientsPage: React.FunctionComponent = (props) => {
     } else {
       setPatientsListColumns(PatientsListColumns);
     }
-  }, [searchWithMRNs, patientIdTriplets]);
+  }, [searchWithMRNs, patientIdsTriplets]);
 
   const pageRoute = "/patients";
   const sampleQueryParamFieldName = "cmoPatientId";
@@ -153,7 +161,7 @@ export const PatientsPage: React.FunctionComponent = (props) => {
           </>
         }
         customFilterState={searchWithMRNs}
-        setCustomFilterVals={setPatientIdTriplets}
+        setCustomFilterVals={setPatientIdsTriplets}
       />
     </>
   );

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -101,7 +101,7 @@ export const PatientsPage: React.FunctionComponent = (props) => {
             ],
           } as SampleWhere
         }
-        customFilter={
+        customFilterUI={
           <>
             <Col md="auto" className="mt-1">
               <div className="vr"></div>
@@ -120,6 +120,7 @@ export const PatientsPage: React.FunctionComponent = (props) => {
             </Col>
           </>
         }
+        customFilterState={searchWithMRNs}
       />
     </>
   );

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -11,12 +11,11 @@ import "ag-grid-enterprise";
 import RecordsList from "../../components/RecordsList";
 import { useParams } from "react-router-dom";
 import PageHeader from "../../shared/components/PageHeader";
-import { parseSearchQueries } from "../../lib/parseSearchQueries";
 import { Col, Form } from "react-bootstrap";
 
-function patientAliasFilterWhereVariables(value: string): PatientAliasWhere[] {
-  const uniqueQueries = parseSearchQueries(value);
-
+function patientAliasFilterWhereVariables(
+  uniqueQueries: string[]
+): PatientAliasWhere[] {
   if (uniqueQueries.length > 1) {
     return [
       { value_IN: uniqueQueries },

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -88,7 +88,6 @@ export const PatientsPage: React.FunctionComponent = (props) => {
             ...column,
             hide: false,
             valueGetter: (params: any) => {
-              params.columnApi.autoSizeAllColumns();
               const cmoId = params.data.value;
               const patientIdsTriplet = patientIdsTriplets.find(
                 (triplet) => triplet.cmoId === cmoId

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -3,7 +3,7 @@ import {
   SampleWhere,
   usePatientsListLazyQuery,
 } from "../../generated/graphql";
-import React from "react";
+import React, { useState } from "react";
 import { PatientsListColumns } from "../../shared/helpers";
 import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-alpine.css";
@@ -12,6 +12,7 @@ import RecordsList from "../../components/RecordsList";
 import { useParams } from "react-router-dom";
 import PageHeader from "../../shared/components/PageHeader";
 import { parseSearchQueries } from "../../lib/parseSearchQueries";
+import { Col, Form } from "react-bootstrap";
 
 function patientAliasFilterWhereVariables(value: string): PatientAliasWhere[] {
   const uniqueQueries = parseSearchQueries(value);
@@ -67,6 +68,7 @@ function patientAliasFilterWhereVariables(value: string): PatientAliasWhere[] {
 
 export const PatientsPage: React.FunctionComponent = (props) => {
   const params = useParams();
+  const [searchWithMRNs, setSearchWithMRNs] = useState(false);
 
   const pageRoute = "/patients";
   const sampleQueryParamFieldName = "cmoPatientId";
@@ -99,6 +101,25 @@ export const PatientsPage: React.FunctionComponent = (props) => {
               },
             ],
           } as SampleWhere
+        }
+        customFilter={
+          <>
+            <Col md="auto" className="mt-1">
+              <div className="vr"></div>
+            </Col>
+
+            <Col md="auto" className="mt-1">
+              <Form>
+                <Form.Check
+                  type="switch"
+                  id="custom-switch"
+                  label="Search with MRNs"
+                  checked={searchWithMRNs}
+                  onChange={(e) => setSearchWithMRNs(e.target.checked)}
+                />
+              </Form>
+            </Col>
+          </>
         }
       />
     </>

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -88,6 +88,7 @@ export const PatientsPage: React.FunctionComponent = (props) => {
             ...column,
             hide: false,
             valueGetter: (params: any) => {
+              params.columnApi.autoSizeAllColumns();
               const cmoId = params.data.value;
               const patientIdsTriplet = patientIdsTriplets.find(
                 (triplet) => triplet.cmoId === cmoId

--- a/frontend/src/pages/requests/RequestsPage.tsx
+++ b/frontend/src/pages/requests/RequestsPage.tsx
@@ -11,11 +11,8 @@ import "ag-grid-enterprise";
 import RecordsList from "../../components/RecordsList";
 import { useParams } from "react-router-dom";
 import PageHeader from "../../shared/components/PageHeader";
-import { parseSearchQueries } from "../../lib/parseSearchQueries";
 
-function requestFilterWhereVariables(value: string): RequestWhere[] {
-  const uniqueQueries = parseSearchQueries(value);
-
+function requestFilterWhereVariables(uniqueQueries: string[]): RequestWhere[] {
   if (uniqueQueries.length > 1) {
     return [
       { igoProjectId_IN: uniqueQueries },

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -153,8 +153,9 @@ export const PatientsListColumns: ColDef[] = [
     sortable: false,
   },
   {
-    headerName: "MRN",
+    headerName: "Patient MRN",
     hide: true,
+    cellStyle: { color: "crimson" },
   },
   {
     field: "cmoPatientId",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -153,6 +153,10 @@ export const PatientsListColumns: ColDef[] = [
     sortable: false,
   },
   {
+    headerName: "MRN",
+    hide: true,
+  },
+  {
     field: "cmoPatientId",
     headerName: "CMO Patient ID",
     valueGetter: function ({ data }) {

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -153,6 +153,7 @@ export const PatientsListColumns: ColDef[] = [
     sortable: false,
   },
   {
+    field: "patientMrn",
     headerName: "Patient MRN",
     hide: true,
     cellStyle: { color: "crimson" },
@@ -190,6 +191,7 @@ export const PatientsListColumns: ColDef[] = [
     sortable: false,
   },
   {
+    field: "cmoSampleIds",
     headerName: "CMO Sample IDs",
     valueGetter: function ({ data }) {
       return data["isAliasPatients"][0].hasSampleSamples.map(


### PR DESCRIPTION
This PR contains my latest in-progress work on MRN searching. Feel free to add your changes to this PR or another PR altogether for your rework.

### Current workflow from the user's perspective:
1. Enter MRN(s) into the search bar on the Patients page
2. Toggle on the `Search with MRNs` switch
3. Press Enter or click `Search`
4. Get back filtered results along with a new MRN column that shows MRNs corresponding to each CMO Patient ID and (if applicable) DMP Patient ID

This solves the PMs' need for a MRN to CMO/DMP Patient ID mapping.

### How it works under the hood:
1. After step 3 above, the MRN value(s) get passed into `parseSearchQueries()` to be parsed/cleaned up
2. The frontend calls an external API and passes these MRNs to it. This API then returns an array of MRN-CMO-DMP triplet(s). For example, the API would return the JSON below if we pass two MRNs to it (actual IDs redacted)
```
[
    {
        "dmpId": "",
        "cmoId": "",
        "ptMrn": ""
    },
    {
        "dmpId": "",
        "cmoId": "",
        "ptMrn": ""
    }
]
```
3. The frontend creates an array of only `cmoId`s found from step 2 and use them to query the database like usual
4. The frontend gets back the data from the database, cross-checks the array of triplet(s) found from step 2, and adds a new MRN column to the AG Grid table that shows the MRN corresponding to each pair of CMO and DMP IDs

### Misc. notes:
- The external API mentioned above can be found [here](https://github.com/mskcc/smile-server/pull/1015). Please reach out to Ben for help setting this API server up locally
- The `Search with MRNs` toggle was added because there isn't a specific pattern of MRNs we can write logic to recognize

Related Zenhub issue: [link](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/board)