### PR TITLE
Refactor RecordsList and SamplesList

### DIFF
--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -1,10 +1,8 @@
 import AutoSizer from "react-virtualized-auto-sizer";
-import { Button, Col, Container, Form, Row, Modal } from "react-bootstrap";
+import { Button, Container, Modal } from "react-bootstrap";
 import { FunctionComponent, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
-import classNames from "classnames";
 import { DownloadModal } from "./DownloadModal";
-import Spinner from "react-spinkit";
 import { CSVFormulate } from "../lib/CSVExport";
 import { AgGridReact } from "ag-grid-react";
 import { useState } from "react";
@@ -17,9 +15,8 @@ import { useHookGeneric } from "../shared/types";
 import { SamplesList } from "./SamplesList";
 import { SampleWhere } from "../generated/graphql";
 import { defaultRecordsColDef } from "../shared/helpers";
-import InfoIcon from "@material-ui/icons/InfoOutlined";
-import { Tooltip } from "@material-ui/core";
 import { PatientIdsTriplet } from "../pages/patients/PatientsPage";
+import { ErrorMessage, LoadingSpinner, Toolbar } from "../shared/tableElements";
 
 export interface IRecordsListProps {
   lazyRecordsQuery: typeof useHookGeneric;
@@ -119,14 +116,9 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchVal]);
 
-  if (loading)
-    return (
-      <div className={"centralSpinner"}>
-        <Spinner fadeIn={"none"} color={"lightblue"} name="ball-grid-pulse" />
-      </div>
-    );
+  if (loading) return <LoadingSpinner />;
 
-  if (error) return <p>Error :(</p>;
+  if (error) return <ErrorMessage error={error} />;
 
   const remoteCount = data?.[totalCountNodeName]?.totalCount;
 
@@ -224,76 +216,22 @@ const RecordsList: FunctionComponent<IRecordsListProps> = ({
         </AutoSizer>
       )}
 
-      <Row
-        className={classNames(
-          "d-flex justify-content-between align-items-center",
-          "tableControlsRow"
-        )}
-      >
-        <Col></Col>
+      <Toolbar
+        searchTerm={searchTerm}
+        input={inputVal}
+        setInput={setInputVal}
+        handleSearch={handleSearch}
+        clearInput={() => {
+          setCustomFilterVals && setCustomFilterVals([]);
+          setSearchVal([]);
+        }}
+        matchingResultsCount={`${remoteCount?.toLocaleString()} matching ${
+          remoteCount > 1 ? searchTerm : searchTerm.slice(0, -1)
+        }`}
+        handleDownload={handleDownload}
+        customUI={customFilterUI}
+      />
 
-        <Col md="auto">
-          <Form.Control
-            className={"d-inline-block"}
-            style={{ width: "300px" }}
-            type="search"
-            placeholder={"Search " + searchTerm}
-            aria-label="Search"
-            defaultValue={inputVal}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") {
-                handleSearch();
-              }
-            }}
-            onInput={(event) => {
-              const newVal = event.currentTarget.value;
-              if (newVal === "") {
-                setCustomFilterVals && setCustomFilterVals([]);
-                setSearchVal([]);
-              }
-              setInputVal(newVal);
-            }}
-          />
-        </Col>
-
-        <Col md="auto" style={{ marginLeft: -15 }}>
-          <Tooltip
-            title={
-              <span style={{ fontSize: 12 }}>
-                After inputting your search query, click on &quot;Search&quot;
-                or press &quot;Enter&quot; to get your results. To bulk search,
-                input a list of values separated by spaces or commas (e.g.
-                &quot;value1 value2 value3&quot;)
-              </span>
-            }
-          >
-            <InfoIcon style={{ fontSize: 18, color: "grey" }} />
-          </Tooltip>
-        </Col>
-
-        <Col md="auto" style={{ marginLeft: -15 }}>
-          <Button
-            onClick={handleSearch}
-            className={"btn btn-secondary"}
-            size={"sm"}
-          >
-            Search
-          </Button>
-        </Col>
-
-        <Col md="auto">
-          {remoteCount?.toLocaleString()} matching{" "}
-          {remoteCount > 1 ? searchTerm : searchTerm.slice(0, -1)}
-        </Col>
-
-        {customFilterUI}
-
-        <Col className={"text-end"}>
-          <Button onClick={handleDownload} size={"sm"}>
-            Generate Report
-          </Button>
-        </Col>
-      </Row>
       <AutoSizer>
         {({ width }) => (
           <div

--- a/frontend/src/shared/tableElements.tsx
+++ b/frontend/src/shared/tableElements.tsx
@@ -1,0 +1,110 @@
+import { ApolloError } from "@apollo/client";
+import classNames from "classnames";
+import { Button, Col, Form, Row } from "react-bootstrap";
+import Spinner from "react-spinkit";
+import InfoIcon from "@material-ui/icons/InfoOutlined";
+import { Tooltip } from "@material-ui/core";
+
+export function LoadingSpinner() {
+  return (
+    <div className={"centralSpinner"}>
+      <Spinner fadeIn={"none"} color={"lightblue"} name="ball-grid-pulse" />
+    </div>
+  );
+}
+
+export function ErrorMessage({ error }: { error: ApolloError }) {
+  return (
+    <Row className="ms-2">
+      There was an error loading data ({error.name}: {error.message}).
+    </Row>
+  );
+}
+
+export function Toolbar({
+  searchTerm,
+  input,
+  setInput,
+  handleSearch,
+  clearInput,
+  matchingResultsCount,
+  handleDownload,
+  customUI,
+}: {
+  searchTerm: string;
+  input: string;
+  setInput: (input: string) => void;
+  handleSearch: () => void;
+  clearInput: () => void;
+  matchingResultsCount: string;
+  handleDownload: () => void;
+  customUI?: JSX.Element;
+}) {
+  return (
+    <Row
+      className={classNames(
+        "d-flex justify-content-between align-items-center tableControlsRow"
+      )}
+    >
+      <Col></Col>
+
+      <Col md="auto">
+        <Form.Control
+          className={"d-inline-block"}
+          style={{ width: "300px" }}
+          type="search"
+          placeholder={"Search " + searchTerm}
+          aria-label="Search"
+          value={input}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              handleSearch();
+            }
+          }}
+          onInput={(event) => {
+            const currInput = event.currentTarget.value;
+            if (currInput === "") {
+              clearInput();
+            }
+            setInput(currInput);
+          }}
+        />
+      </Col>
+
+      <Col md="auto" style={{ marginLeft: -15 }}>
+        <Tooltip
+          title={
+            <span style={{ fontSize: 12 }}>
+              After inputting your search query, click on &quot;Search&quot; or
+              press &quot;Enter&quot; to get your results. To bulk search, input
+              a list of values separated by spaces or commas (e.g. &quot;value1
+              value2 value3&quot;)
+            </span>
+          }
+        >
+          <InfoIcon style={{ fontSize: 18, color: "grey" }} />
+        </Tooltip>
+      </Col>
+
+      <Col md="auto" style={{ marginLeft: -15 }}>
+        <Button
+          onClick={handleSearch}
+          className={"btn btn-secondary"}
+          size={"sm"}
+        >
+          Search
+        </Button>
+      </Col>
+
+      <Col md="auto">{matchingResultsCount}</Col>
+
+      {customUI}
+
+      <Col className={"text-end"}>
+        <Button onClick={handleDownload} size={"sm"}>
+          Generate Report
+        </Button>
+      </Col>
+    </Row>
+  );
+}


### PR DESCRIPTION
**Context:**
 - The `RecordsList` component currently renders the (1) Requests and (2) Patients pages
 - The `SamplesList` component currently renders (1) the Samples page and (2) the Samples view modal on the Requests and Patients pages
 - This ticket's original goal is to combine these components into one

-----

**TL;DR: Instead of combining these two components into one, I recommend that we simply remove the duplicated codes between them into shared codes for now.**

Although these components render similar-looking UIs, their functionalities have some fundamental differences (examples at the end). Additionally, we will add HERA data to the SMILE dashboard in the coming sprints, and we don't know how exactly HERA data will be displayed for users yet.

If we were to combine `RecordsList` and `SamplesList`, we could end up with a component with a patchy, long list of props in the future:

```js
interface NewlyCombinedComponentProps { // this will replace both `RecordsList` and `SamplesList`
    requiredProp1: someType;
    requiredProp2: someType;
    ...
    optionalProp1ForRecordsList: someType;
    optionalProp2ForRecordsList: someType;
    optionalProp3ForRecordsList: someType;
    ...
    optionalProp1ForSamplesList: someType;
    optionalProp2ForSamplesList: someType;
    optionalProp3ForSamplesList: someType;
    ...
    optionalProp1ForHERAData: someType;
    optionalProp2ForHERAData: someType;
    optionalProp3ForHERAData: someType;
    ...
}
```

The current `RecordsList` component already has 20 props. If we load on more props, I think we might have the tradeoff of reduced developer experience and slower development time.

For now, I think it's more future-proof for us to simply take the duplicated codes inside `RecordsList` and `SamplesList` components and turn them into shared codes. After HERA, maybe we can revisit combining them into one component.

-----

Examples of differences between `RecordsList` and `SamplesList` today:
 - `RecordsList` fetches data server-side while `SamplesList` does so client-side
 - `RecordsList` is the parent component of a `SamplesList`
 - `SamplesList` has editable cells, while `RecordsList` does not

(This PR addresses [ticket 1014](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1014).)