### PR TITLE
Disable the MRN column on Patients table from being sortable

### DIFF
--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -157,6 +157,7 @@ export const PatientsListColumns: ColDef[] = [
     headerName: "Patient MRN",
     hide: true,
     cellStyle: { color: "crimson" },
+    sortable: false,
   },
   {
     field: "cmoPatientId",


### PR DESCRIPTION
The entire Patients table isn't sortable at the moment. For context, see https://github.com/mskcc/smile-server/issues/960.