### PR TITLE
Show billing-related fields on the Cohort and Cohort Sample views

### DIFF
--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -14,7 +14,7 @@ import { ColDef, IServerSideGetRowsParams } from "ag-grid-community";
 import { DataName, useHookLazyGeneric } from "../shared/types";
 import SamplesList from "./SamplesList";
 import { Sample, SampleWhere } from "../generated/graphql";
-import { defaultReadOnlyColDef } from "../shared/helpers";
+import { defaultColDef } from "../shared/helpers";
 import { PatientIdsTriplet } from "../pages/patients/PatientsPage";
 import { ErrorMessage, LoadingSpinner, Toolbar } from "../shared/tableElements";
 
@@ -36,7 +36,6 @@ interface IRecordsListProps {
   setShowDownloadModal: Dispatch<SetStateAction<boolean>>;
   handleDownload: () => void;
   samplesQueryParam: string | undefined;
-  samplesDefaultColDef: ColDef;
   getSamplesRowData: (samples: Sample[]) => any[];
   samplesColDefs: ColDef[];
   samplesParentWhereVariables: SampleWhere;
@@ -63,7 +62,6 @@ export default function RecordsList({
   setShowDownloadModal,
   handleDownload,
   samplesQueryParam,
-  samplesDefaultColDef,
   getSamplesRowData,
   samplesColDefs,
   samplesParentWhereVariables,
@@ -214,7 +212,6 @@ export default function RecordsList({
                 <div className={styles.popupHeight}>
                   <SamplesList
                     columnDefs={samplesColDefs}
-                    defaultColDef={samplesDefaultColDef}
                     getRowData={getSamplesRowData}
                     parentWhereVariables={samplesParentWhereVariables}
                     refetchWhereVariables={samplesRefetchWhereVariables}
@@ -260,7 +257,7 @@ export default function RecordsList({
               context={{
                 navigateFunction: navigate,
               }}
-              defaultColDef={defaultReadOnlyColDef}
+              defaultColDef={defaultColDef}
               onGridReady={(params) => {
                 params.api.sizeColumnsToFit();
               }}

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -14,6 +14,7 @@ import { CSVFormulate } from "../utils/CSVExport";
 import {
   SampleChange,
   SampleMetadataExtended,
+  defaultColDef,
   handleSearch,
 } from "../shared/helpers";
 import { AgGridReact } from "ag-grid-react";
@@ -30,7 +31,6 @@ const max_rows = 500;
 
 interface ISampleListProps {
   columnDefs: ColDef[];
-  defaultColDef: ColDef;
   getRowData: (samples: Sample[]) => any[];
   setUnsavedChanges?: (unsavedChanges: boolean) => void;
   parentWhereVariables?: SampleWhere;
@@ -40,7 +40,6 @@ interface ISampleListProps {
 
 export default function SamplesList({
   columnDefs,
-  defaultColDef,
   getRowData,
   parentWhereVariables,
   refetchWhereVariables,

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -11499,6 +11499,11 @@ export type CohortsListQuery = {
       __typename?: "CohortHasCohortSampleSamplesConnection";
       totalCount: number;
     };
+    hasCohortSampleSamples: Array<{
+      __typename?: "Sample";
+      smileSampleId: string;
+      hasTempoTempos: Array<{ __typename?: "Tempo"; billed: boolean }>;
+    }>;
   }>;
 };
 
@@ -12069,6 +12074,12 @@ export const CohortsListDocument = gql`
       }
       hasCohortSampleSamplesConnection {
         totalCount
+      }
+      hasCohortSampleSamples {
+        smileSampleId
+        hasTempoTempos {
+          billed
+        }
       }
     }
   }

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -45,6 +45,7 @@ export type BamCompleteTemposHasEventConnectionArgs = {
   after?: InputMaybe<Scalars["String"]>;
   directed?: InputMaybe<Scalars["Boolean"]>;
   first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<BamCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<BamCompleteTemposHasEventConnectionWhere>;
 };
 
@@ -107,6 +108,15 @@ export type BamCompleteSort = {
 export type BamCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "BamCompleteTempoTemposHasEventAggregationSelection";
   count: Scalars["Int"];
+  node?: Maybe<BamCompleteTempoTemposHasEventNodeAggregateSelection>;
+};
+
+export type BamCompleteTempoTemposHasEventNodeAggregateSelection = {
+  __typename?: "BamCompleteTempoTemposHasEventNodeAggregateSelection";
+  accessLevel: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNonNullable;
+  costCenter: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNonNullable;
 };
 
 export type BamCompleteTemposHasEventAggregateInput = {
@@ -117,6 +127,7 @@ export type BamCompleteTemposHasEventAggregateInput = {
   count_GTE?: InputMaybe<Scalars["Int"]>;
   count_LT?: InputMaybe<Scalars["Int"]>;
   count_LTE?: InputMaybe<Scalars["Int"]>;
+  node?: InputMaybe<BamCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type BamCompleteTemposHasEventConnectFieldInput = {
@@ -129,6 +140,10 @@ export type BamCompleteTemposHasEventConnection = {
   edges: Array<BamCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
   totalCount: Scalars["Int"];
+};
+
+export type BamCompleteTemposHasEventConnectionSort = {
+  node?: InputMaybe<TempoSort>;
 };
 
 export type BamCompleteTemposHasEventConnectionWhere = {
@@ -155,6 +170,91 @@ export type BamCompleteTemposHasEventDisconnectFieldInput = {
 export type BamCompleteTemposHasEventFieldInput = {
   connect?: InputMaybe<Array<BamCompleteTemposHasEventConnectFieldInput>>;
   create?: InputMaybe<Array<BamCompleteTemposHasEventCreateFieldInput>>;
+};
+
+export type BamCompleteTemposHasEventNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<BamCompleteTemposHasEventNodeAggregationWhereInput>>;
+  OR?: InputMaybe<Array<BamCompleteTemposHasEventNodeAggregationWhereInput>>;
+  accessLevel_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_EQUAL?: InputMaybe<Scalars["String"]>;
+  accessLevel_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_EQUAL?: InputMaybe<Scalars["String"]>;
+  billedBy_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_EQUAL?: InputMaybe<Scalars["String"]>;
+  costCenter_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_EQUAL?: InputMaybe<Scalars["String"]>;
+  custodianInformation_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type BamCompleteTemposHasEventRelationship = {
@@ -1291,6 +1391,7 @@ export type MafCompleteTemposHasEventConnectionArgs = {
   after?: InputMaybe<Scalars["String"]>;
   directed?: InputMaybe<Scalars["Boolean"]>;
   first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<MafCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<MafCompleteTemposHasEventConnectionWhere>;
 };
 
@@ -1356,6 +1457,15 @@ export type MafCompleteSort = {
 export type MafCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "MafCompleteTempoTemposHasEventAggregationSelection";
   count: Scalars["Int"];
+  node?: Maybe<MafCompleteTempoTemposHasEventNodeAggregateSelection>;
+};
+
+export type MafCompleteTempoTemposHasEventNodeAggregateSelection = {
+  __typename?: "MafCompleteTempoTemposHasEventNodeAggregateSelection";
+  accessLevel: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNonNullable;
+  costCenter: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNonNullable;
 };
 
 export type MafCompleteTemposHasEventAggregateInput = {
@@ -1366,6 +1476,7 @@ export type MafCompleteTemposHasEventAggregateInput = {
   count_GTE?: InputMaybe<Scalars["Int"]>;
   count_LT?: InputMaybe<Scalars["Int"]>;
   count_LTE?: InputMaybe<Scalars["Int"]>;
+  node?: InputMaybe<MafCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type MafCompleteTemposHasEventConnectFieldInput = {
@@ -1378,6 +1489,10 @@ export type MafCompleteTemposHasEventConnection = {
   edges: Array<MafCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
   totalCount: Scalars["Int"];
+};
+
+export type MafCompleteTemposHasEventConnectionSort = {
+  node?: InputMaybe<TempoSort>;
 };
 
 export type MafCompleteTemposHasEventConnectionWhere = {
@@ -1404,6 +1519,91 @@ export type MafCompleteTemposHasEventDisconnectFieldInput = {
 export type MafCompleteTemposHasEventFieldInput = {
   connect?: InputMaybe<Array<MafCompleteTemposHasEventConnectFieldInput>>;
   create?: InputMaybe<Array<MafCompleteTemposHasEventCreateFieldInput>>;
+};
+
+export type MafCompleteTemposHasEventNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<MafCompleteTemposHasEventNodeAggregationWhereInput>>;
+  OR?: InputMaybe<Array<MafCompleteTemposHasEventNodeAggregationWhereInput>>;
+  accessLevel_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_EQUAL?: InputMaybe<Scalars["String"]>;
+  accessLevel_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_EQUAL?: InputMaybe<Scalars["String"]>;
+  billedBy_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_EQUAL?: InputMaybe<Scalars["String"]>;
+  costCenter_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_EQUAL?: InputMaybe<Scalars["String"]>;
+  custodianInformation_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type MafCompleteTemposHasEventRelationship = {
@@ -3201,6 +3401,7 @@ export type QcCompleteTemposHasEventConnectionArgs = {
   after?: InputMaybe<Scalars["String"]>;
   directed?: InputMaybe<Scalars["Boolean"]>;
   first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<QcCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<QcCompleteTemposHasEventConnectionWhere>;
 };
 
@@ -3267,6 +3468,15 @@ export type QcCompleteSort = {
 export type QcCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "QcCompleteTempoTemposHasEventAggregationSelection";
   count: Scalars["Int"];
+  node?: Maybe<QcCompleteTempoTemposHasEventNodeAggregateSelection>;
+};
+
+export type QcCompleteTempoTemposHasEventNodeAggregateSelection = {
+  __typename?: "QcCompleteTempoTemposHasEventNodeAggregateSelection";
+  accessLevel: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNonNullable;
+  costCenter: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNonNullable;
 };
 
 export type QcCompleteTemposHasEventAggregateInput = {
@@ -3277,6 +3487,7 @@ export type QcCompleteTemposHasEventAggregateInput = {
   count_GTE?: InputMaybe<Scalars["Int"]>;
   count_LT?: InputMaybe<Scalars["Int"]>;
   count_LTE?: InputMaybe<Scalars["Int"]>;
+  node?: InputMaybe<QcCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type QcCompleteTemposHasEventConnectFieldInput = {
@@ -3289,6 +3500,10 @@ export type QcCompleteTemposHasEventConnection = {
   edges: Array<QcCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
   totalCount: Scalars["Int"];
+};
+
+export type QcCompleteTemposHasEventConnectionSort = {
+  node?: InputMaybe<TempoSort>;
 };
 
 export type QcCompleteTemposHasEventConnectionWhere = {
@@ -3315,6 +3530,91 @@ export type QcCompleteTemposHasEventDisconnectFieldInput = {
 export type QcCompleteTemposHasEventFieldInput = {
   connect?: InputMaybe<Array<QcCompleteTemposHasEventConnectFieldInput>>;
   create?: InputMaybe<Array<QcCompleteTemposHasEventCreateFieldInput>>;
+};
+
+export type QcCompleteTemposHasEventNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<QcCompleteTemposHasEventNodeAggregationWhereInput>>;
+  OR?: InputMaybe<Array<QcCompleteTemposHasEventNodeAggregationWhereInput>>;
+  accessLevel_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_EQUAL?: InputMaybe<Scalars["String"]>;
+  accessLevel_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_EQUAL?: InputMaybe<Scalars["String"]>;
+  billedBy_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_EQUAL?: InputMaybe<Scalars["String"]>;
+  costCenter_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_EQUAL?: InputMaybe<Scalars["String"]>;
+  custodianInformation_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type QcCompleteTemposHasEventRelationship = {
@@ -3699,6 +3999,7 @@ export type QueryTemposAggregateArgs = {
 export type QueryTemposConnectionArgs = {
   after?: InputMaybe<Scalars["String"]>;
   first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<InputMaybe<TempoSort>>>;
   where?: InputMaybe<TempoWhere>;
 };
 
@@ -5584,6 +5885,7 @@ export type SampleHasTempoTemposConnectionArgs = {
   after?: InputMaybe<Scalars["String"]>;
   directed?: InputMaybe<Scalars["Boolean"]>;
   first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<SampleHasTempoTemposConnectionSort>>;
   where?: InputMaybe<SampleHasTempoTemposConnectionWhere>;
 };
 
@@ -6763,6 +7065,7 @@ export type SampleHasTempoTemposAggregateInput = {
   count_GTE?: InputMaybe<Scalars["Int"]>;
   count_LT?: InputMaybe<Scalars["Int"]>;
   count_LTE?: InputMaybe<Scalars["Int"]>;
+  node?: InputMaybe<SampleHasTempoTemposNodeAggregationWhereInput>;
 };
 
 export type SampleHasTempoTemposConnectFieldInput = {
@@ -6775,6 +7078,10 @@ export type SampleHasTempoTemposConnection = {
   edges: Array<SampleHasTempoTemposRelationship>;
   pageInfo: PageInfo;
   totalCount: Scalars["Int"];
+};
+
+export type SampleHasTempoTemposConnectionSort = {
+  node?: InputMaybe<TempoSort>;
 };
 
 export type SampleHasTempoTemposConnectionWhere = {
@@ -6801,6 +7108,91 @@ export type SampleHasTempoTemposDisconnectFieldInput = {
 export type SampleHasTempoTemposFieldInput = {
   connect?: InputMaybe<Array<SampleHasTempoTemposConnectFieldInput>>;
   create?: InputMaybe<Array<SampleHasTempoTemposCreateFieldInput>>;
+};
+
+export type SampleHasTempoTemposNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<SampleHasTempoTemposNodeAggregationWhereInput>>;
+  OR?: InputMaybe<Array<SampleHasTempoTemposNodeAggregationWhereInput>>;
+  accessLevel_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_EQUAL?: InputMaybe<Scalars["String"]>;
+  accessLevel_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_EQUAL?: InputMaybe<Scalars["String"]>;
+  billedBy_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_EQUAL?: InputMaybe<Scalars["String"]>;
+  costCenter_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_EQUAL?: InputMaybe<Scalars["String"]>;
+  custodianInformation_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type SampleHasTempoTemposRelationship = {
@@ -8478,6 +8870,15 @@ export type SampleSort = {
 export type SampleTempoHasTempoTemposAggregationSelection = {
   __typename?: "SampleTempoHasTempoTemposAggregationSelection";
   count: Scalars["Int"];
+  node?: Maybe<SampleTempoHasTempoTemposNodeAggregateSelection>;
+};
+
+export type SampleTempoHasTempoTemposNodeAggregateSelection = {
+  __typename?: "SampleTempoHasTempoTemposNodeAggregateSelection";
+  accessLevel: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNonNullable;
+  costCenter: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNonNullable;
 };
 
 export type SampleUpdateInput = {
@@ -9638,6 +10039,11 @@ export type StringAggregateSelectionNullable = {
 
 export type Tempo = {
   __typename?: "Tempo";
+  accessLevel: Scalars["String"];
+  billed: Scalars["Boolean"];
+  billedBy: Scalars["String"];
+  costCenter: Scalars["String"];
+  custodianInformation: Scalars["String"];
   hasEventBamCompletes: Array<BamComplete>;
   hasEventBamCompletesAggregate?: Maybe<TempoBamCompleteHasEventBamCompletesAggregationSelection>;
   hasEventBamCompletesConnection: TempoHasEventBamCompletesConnection;
@@ -9730,7 +10136,11 @@ export type TempoSamplesHasTempoConnectionArgs = {
 
 export type TempoAggregateSelection = {
   __typename?: "TempoAggregateSelection";
+  accessLevel: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNonNullable;
+  costCenter: StringAggregateSelectionNonNullable;
   count: Scalars["Int"];
+  custodianInformation: StringAggregateSelectionNonNullable;
 };
 
 export type TempoBamCompleteHasEventBamCompletesAggregationSelection = {
@@ -9763,6 +10173,11 @@ export type TempoConnectWhere = {
 };
 
 export type TempoCreateInput = {
+  accessLevel: Scalars["String"];
+  billed: Scalars["Boolean"];
+  billedBy: Scalars["String"];
+  costCenter: Scalars["String"];
+  custodianInformation: Scalars["String"];
   hasEventBamCompletes?: InputMaybe<TempoHasEventBamCompletesFieldInput>;
   hasEventMafCompletes?: InputMaybe<TempoHasEventMafCompletesFieldInput>;
   hasEventQcCompletes?: InputMaybe<TempoHasEventQcCompletesFieldInput>;
@@ -10228,6 +10643,8 @@ export type TempoMafCompleteHasEventMafCompletesNodeAggregateSelection = {
 export type TempoOptions = {
   limit?: InputMaybe<Scalars["Int"]>;
   offset?: InputMaybe<Scalars["Int"]>;
+  /** Specify one or more TempoSort objects to sort Tempos by. The sorts will be applied in the order in which they are arranged in the array. */
+  sort?: InputMaybe<Array<TempoSort>>;
 };
 
 export type TempoQcCompleteHasEventQcCompletesAggregationSelection = {
@@ -10428,7 +10845,21 @@ export type TempoSamplesHasTempoUpdateFieldInput = {
   where?: InputMaybe<TempoSamplesHasTempoConnectionWhere>;
 };
 
+/** Fields to sort Tempos by. The order in which sorts are applied is not guaranteed when specifying many fields in one TempoSort object. */
+export type TempoSort = {
+  accessLevel?: InputMaybe<SortDirection>;
+  billed?: InputMaybe<SortDirection>;
+  billedBy?: InputMaybe<SortDirection>;
+  costCenter?: InputMaybe<SortDirection>;
+  custodianInformation?: InputMaybe<SortDirection>;
+};
+
 export type TempoUpdateInput = {
+  accessLevel?: InputMaybe<Scalars["String"]>;
+  billed?: InputMaybe<Scalars["Boolean"]>;
+  billedBy?: InputMaybe<Scalars["String"]>;
+  costCenter?: InputMaybe<Scalars["String"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]>;
   hasEventBamCompletes?: InputMaybe<
     Array<TempoHasEventBamCompletesUpdateFieldInput>
   >;
@@ -10444,6 +10875,48 @@ export type TempoUpdateInput = {
 export type TempoWhere = {
   AND?: InputMaybe<Array<TempoWhere>>;
   OR?: InputMaybe<Array<TempoWhere>>;
+  accessLevel?: InputMaybe<Scalars["String"]>;
+  accessLevel_CONTAINS?: InputMaybe<Scalars["String"]>;
+  accessLevel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  accessLevel_IN?: InputMaybe<Array<Scalars["String"]>>;
+  accessLevel_NOT?: InputMaybe<Scalars["String"]>;
+  accessLevel_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  accessLevel_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  accessLevel_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  accessLevel_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  accessLevel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  billed?: InputMaybe<Scalars["Boolean"]>;
+  billedBy?: InputMaybe<Scalars["String"]>;
+  billedBy_CONTAINS?: InputMaybe<Scalars["String"]>;
+  billedBy_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  billedBy_IN?: InputMaybe<Array<Scalars["String"]>>;
+  billedBy_NOT?: InputMaybe<Scalars["String"]>;
+  billedBy_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  billedBy_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  billedBy_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  billedBy_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  billedBy_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  billed_NOT?: InputMaybe<Scalars["Boolean"]>;
+  costCenter?: InputMaybe<Scalars["String"]>;
+  costCenter_CONTAINS?: InputMaybe<Scalars["String"]>;
+  costCenter_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  costCenter_IN?: InputMaybe<Array<Scalars["String"]>>;
+  costCenter_NOT?: InputMaybe<Scalars["String"]>;
+  costCenter_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  costCenter_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  costCenter_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  costCenter_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  costCenter_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]>;
+  custodianInformation_CONTAINS?: InputMaybe<Scalars["String"]>;
+  custodianInformation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  custodianInformation_IN?: InputMaybe<Array<Scalars["String"]>>;
+  custodianInformation_NOT?: InputMaybe<Scalars["String"]>;
+  custodianInformation_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  custodianInformation_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  custodianInformation_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  custodianInformation_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  custodianInformation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   hasEventBamCompletesAggregate?: InputMaybe<TempoHasEventBamCompletesAggregateInput>;
   hasEventBamCompletesConnection_ALL?: InputMaybe<TempoHasEventBamCompletesConnectionWhere>;
   hasEventBamCompletesConnection_NONE?: InputMaybe<TempoHasEventBamCompletesConnectionWhere>;
@@ -10797,6 +11270,9 @@ export type FindSamplesByInputValueQuery = {
         };
         hasTempoTempos: Array<{
           __typename?: "Tempo";
+          billed: boolean;
+          billedBy: string;
+          costCenter: string;
           hasEventBamCompletes: Array<{
             __typename?: "BamComplete";
             date: string;
@@ -11294,6 +11770,9 @@ export const FindSamplesByInputValueDocument = gql`
             }
           }
           hasTempoTempos {
+            billed
+            billedBy
+            costCenter
             hasEventBamCompletes(options: $bamCompletesOptions) {
               date
               status

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../generated/graphql";
 import { useState } from "react";
 import {
-  CohortSamplesDetailsColumns,
+  CohortSampleDetailsColumns,
   CohortsListColumns,
   cohortSampleFilterWhereVariables,
   defaultReadOnlyColDef,
@@ -135,7 +135,7 @@ export default function CohortsPage() {
         showDownloadModal={showDownloadModal}
         setShowDownloadModal={setShowDownloadModal}
         handleDownload={() => setShowDownloadModal(true)}
-        samplesColDefs={CohortSamplesDetailsColumns}
+        samplesColDefs={CohortSampleDetailsColumns}
         samplesDefaultColDef={defaultReadOnlyColDef}
         samplesQueryParam={
           sampleQueryParamValue &&

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -10,7 +10,6 @@ import {
   CohortSampleDetailsColumns,
   CohortsListColumns,
   cohortSampleFilterWhereVariables,
-  defaultReadOnlyColDef,
   getSampleCohortDataFromSamplesQuery,
   handleSearch,
 } from "../../shared/helpers";
@@ -136,7 +135,6 @@ export default function CohortsPage() {
         setShowDownloadModal={setShowDownloadModal}
         handleDownload={() => setShowDownloadModal(true)}
         samplesColDefs={CohortSampleDetailsColumns}
-        samplesDefaultColDef={defaultReadOnlyColDef}
         samplesQueryParam={
           sampleQueryParamValue &&
           `${sampleQueryParamHeaderName} "${sampleQueryParamValue}"`

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -17,7 +17,6 @@ import { REACT_APP_EXPRESS_SERVER_ORIGIN } from "../../shared/constants";
 import {
   PatientsListColumns,
   SampleDetailsColumns,
-  defaultEditableColDef,
   getSampleMetadataFromSamplesQuery,
   sampleFilterWhereVariables,
 } from "../../shared/helpers";
@@ -287,7 +286,6 @@ export default function PatientsPage({
           setShowDownloadModal(true);
         }}
         samplesColDefs={SampleDetailsColumns}
-        samplesDefaultColDef={defaultEditableColDef}
         samplesQueryParam={
           sampleQueryParamValue &&
           `${sampleQueryParamHeaderName} ${sampleQueryParamValue}`

--- a/frontend/src/pages/requests/RequestsPage.tsx
+++ b/frontend/src/pages/requests/RequestsPage.tsx
@@ -7,7 +7,6 @@ import { useState } from "react";
 import {
   RequestsListColumns,
   SampleDetailsColumns,
-  defaultEditableColDef,
   getSampleMetadataFromSamplesQuery,
   handleSearch,
   sampleFilterWhereVariables,
@@ -85,7 +84,6 @@ export default function RequestsPage() {
         setShowDownloadModal={setShowDownloadModal}
         handleDownload={() => setShowDownloadModal(true)}
         samplesColDefs={SampleDetailsColumns}
-        samplesDefaultColDef={defaultEditableColDef}
         samplesQueryParam={
           sampleQueryParamValue &&
           `${sampleQueryParamHeaderName} ${sampleQueryParamValue}`

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -2,7 +2,6 @@ import { PageHeader } from "../../shared/components/PageHeader";
 import SamplesList from "../../components/SamplesList";
 import {
   SampleDetailsColumns,
-  defaultEditableColDef,
   getSampleMetadataFromSamplesQuery,
   sampleFilterWhereVariables,
 } from "../../shared/helpers";
@@ -15,7 +14,6 @@ export default function SamplesPage() {
 
       <SamplesList
         columnDefs={SampleDetailsColumns}
-        defaultColDef={defaultEditableColDef}
         getRowData={getSampleMetadataFromSamplesQuery}
         refetchWhereVariables={(parsedSearchVals) => {
           return {

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -587,14 +587,17 @@ export const CohortSampleDetailsColumns: ColDef[] = [
     headerName: "Initial Pipeline Run Date",
   },
   {
+    field: "billed",
     headerName: "Billed",
     editable: true,
   },
   {
+    field: "costCenter",
     headerName: "Cost Center",
     editable: true,
   },
   {
+    field: "billedBy",
     headerName: "Billed By",
   },
   {
@@ -865,6 +868,8 @@ export function getSampleCohortDataFromSamplesQuery(samples: Sample[]) {
     const deliveryDate = cohortDates?.sort()[0]; // earliest cohort date
 
     const tempo = s.hasTempoTempos?.[0];
+    const { billed, billedBy, costCenter } = tempo ?? {};
+
     const bamComplete = tempo?.hasEventBamCompletes?.[0];
     const { date: bamCompleteDate, status: bamCompleteStatus } =
       bamComplete ?? {};
@@ -887,6 +892,9 @@ export function getSampleCohortDataFromSamplesQuery(samples: Sample[]) {
     return {
       ...s.hasMetadataSampleMetadata[0],
       deliveryDate: formatCohortRelatedDate(deliveryDate),
+      billed,
+      billedBy,
+      costCenter,
       bamCompleteDate: formatCohortRelatedDate(bamCompleteDate),
       bamCompleteStatus,
       mafCompleteDate: formatCohortRelatedDate(mafCompleteDate),

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -16,6 +16,7 @@ import {
   TempoWhere,
 } from "../generated/graphql";
 import WarningIcon from "@material-ui/icons/Warning";
+import CheckIcon from "@material-ui/icons/Check";
 import { StatusTooltip } from "./components/StatusToolTip";
 import { parseUserSearchVal } from "../utils/parseSearchQueries";
 import { Dispatch, SetStateAction } from "react";
@@ -235,6 +236,39 @@ export const PatientsListColumns: ColDef[] = [
   },
 ];
 
+function LoadingIcon() {
+  return (
+    <div className="lds-ring">
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+    </div>
+  );
+}
+
+const statusCellRendererProps: ColDef = {
+  cellRenderer: (params: ICellRendererParams) => {
+    if (params.data?.revisable) {
+      return params.data?.hasStatusStatuses[0]?.validationStatus ? (
+        <CheckIcon />
+      ) : (
+        <WarningIcon />
+      );
+    } else {
+      return <LoadingIcon />;
+    }
+  },
+  cellRendererParams: {
+    colDef: {
+      tooltipComponent: StatusTooltip,
+      tooltipValueGetter: (params: ITooltipParams) =>
+        params.data.hasStatusStatuses[0]?.validationReport ??
+        params.data.hasStatusStatuses,
+    },
+  },
+};
+
 export const SampleDetailsColumns: ColDef<SampleMetadataExtended>[] = [
   {
     field: "primaryId",
@@ -243,36 +277,7 @@ export const SampleDetailsColumns: ColDef<SampleMetadataExtended>[] = [
   {
     field: "revisable",
     headerName: "Status",
-    cellRenderer: (params: ICellRendererParams<SampleMetadataExtended>) => {
-      if (params.data?.revisable) {
-        return params.data?.hasStatusStatuses[0]?.validationStatus ? (
-          <div>
-            <strong>&#10003;</strong>
-          </div>
-        ) : (
-          <div>
-            <WarningIcon />
-          </div>
-        );
-      } else {
-        return (
-          <div className="lds-ring">
-            <div></div>
-            <div></div>
-            <div></div>
-            <div></div>
-          </div>
-        );
-      }
-    },
-    cellRendererParams: {
-      colDef: {
-        tooltipComponent: StatusTooltip,
-        tooltipValueGetter: (params: ITooltipParams) =>
-          params.data.hasStatusStatuses[0]?.validationReport ??
-          params.data.hasStatusStatuses,
-      },
-    },
+    ...statusCellRendererProps,
   },
   {
     field: "cmoSampleName",
@@ -585,6 +590,11 @@ export const CohortSampleDetailsColumns: ColDef[] = [
   {
     field: "primaryId",
     headerName: "Primary ID",
+  },
+  {
+    field: "revisable",
+    headerName: "Status",
+    ...statusCellRendererProps,
   },
   {
     field: "cmoSampleName",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -518,6 +518,12 @@ export const CohortsListColumns: ColDef[] = [
   },
   {
     headerName: "Billed",
+    valueGetter: ({ data }) => {
+      return data["hasCohortSampleSamples"]?.every((sample: Sample) => {
+        return sample.hasTempoTempos?.[0]?.billed === true;
+      });
+    },
+    valueFormatter: (params) => (params.value === true ? "Yes" : "No"),
   },
   {
     headerName: "Initial Pipeline Run Date",
@@ -593,7 +599,7 @@ export const CohortSampleDetailsColumns: ColDef[] = [
     cellEditor: "agRichSelectCellEditor",
     cellEditorPopup: true,
     cellEditorParams: {
-      values: ["true", "false"],
+      values: [true, false],
     },
     valueFormatter: (params) => (params.value === true ? "Yes" : "No"),
   },

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -520,7 +520,7 @@ export const CohortsListColumns: ColDef[] = [
     headerName: "Billed",
   },
   {
-    headerName: "Delivery Date",
+    headerName: "Initial Pipeline Run Date",
     valueGetter: ({ data }) =>
       data["hasCohortCompleteCohortCompletes"]?.slice(-1)[0]?.date,
     sortable: false,
@@ -530,6 +530,7 @@ export const CohortsListColumns: ColDef[] = [
     valueGetter: ({ data }) =>
       data["hasCohortCompleteCohortCompletes"][0]?.date,
     sortable: false,
+    hide: true,
   },
   {
     headerName: "End Users",
@@ -580,7 +581,7 @@ export const CohortSampleDetailsColumns: ColDef[] = [
   },
   {
     field: "deliveryDate",
-    headerName: "Delivery Date",
+    headerName: "Initial Pipeline Run Date",
   },
   {
     headerName: "Billed",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -533,7 +533,7 @@ export const CohortsListColumns: ColDef[] = [
     valueFormatter: (params) => (params.value === true ? "Yes" : "No"),
   },
   {
-    headerName: "Initial Pipeline Run Date",
+    headerName: "Initial Cohort Delivery Date",
     valueGetter: ({ data }) => {
       const earliestCohortCompleteDate =
         data["hasCohortCompleteCohortCompletes"]?.slice(-1)[0]?.date;

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -521,8 +521,11 @@ export const CohortsListColumns: ColDef[] = [
   },
   {
     headerName: "Initial Pipeline Run Date",
-    valueGetter: ({ data }) =>
-      data["hasCohortCompleteCohortCompletes"]?.slice(-1)[0]?.date,
+    valueGetter: ({ data }) => {
+      const earliestCohortCompleteDate =
+        data["hasCohortCompleteCohortCompletes"]?.slice(-1)[0]?.date;
+      return formatCohortRelatedDate(earliestCohortCompleteDate);
+    },
     sortable: false,
   },
   {
@@ -883,13 +886,13 @@ export function getSampleCohortDataFromSamplesQuery(samples: Sample[]) {
 
     return {
       ...s.hasMetadataSampleMetadata[0],
-      deliveryDate,
-      bamCompleteDate,
+      deliveryDate: formatCohortRelatedDate(deliveryDate),
+      bamCompleteDate: formatCohortRelatedDate(bamCompleteDate),
       bamCompleteStatus,
-      mafCompleteDate,
+      mafCompleteDate: formatCohortRelatedDate(mafCompleteDate),
       mafCompleteStatus,
       mafCompleteNormalPrimaryId,
-      qcCompleteDate,
+      qcCompleteDate: formatCohortRelatedDate(qcCompleteDate),
       qcCompleteResult,
       qcCompleteReason,
       qcCompleteStatus,
@@ -903,4 +906,8 @@ export function handleSearch(
 ) {
   const parsedSearchVals = parseUserSearchVal(userSearchVal);
   setParsedSearchVals(parsedSearchVals);
+}
+
+function formatCohortRelatedDate(date: string) {
+  return date?.split(" ")[0];
 }

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -4,6 +4,7 @@ import {
   ICellRendererParams,
   IHeaderParams,
   RowNode,
+  ITooltipParams,
 } from "ag-grid-community";
 import { Button } from "react-bootstrap";
 import "ag-grid-enterprise";
@@ -16,7 +17,6 @@ import {
 } from "../generated/graphql";
 import WarningIcon from "@material-ui/icons/Warning";
 import { StatusTooltip } from "./components/StatusToolTip";
-import { ITooltipParams } from "ag-grid-community";
 import { parseUserSearchVal } from "../utils/parseSearchQueries";
 import { Dispatch, SetStateAction } from "react";
 
@@ -590,6 +590,12 @@ export const CohortSampleDetailsColumns: ColDef[] = [
     field: "billed",
     headerName: "Billed",
     editable: true,
+    cellEditor: "agRichSelectCellEditor",
+    cellEditorPopup: true,
+    cellEditorParams: {
+      values: ["true", "false"],
+    },
+    valueFormatter: (params) => (params.value === true ? "Yes" : "No"),
   },
   {
     field: "costCenter",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -745,6 +745,12 @@ export function cohortSampleFilterWhereVariables(
   if (parsedSearchVals.length > 1) {
     tempoWhere = [
       {
+        billedBy_IN: parsedSearchVals,
+      },
+      {
+        costCenter_IN: parsedSearchVals,
+      },
+      {
         hasEventBamCompletes_SOME: {
           date_IN: parsedSearchVals,
         },
@@ -792,6 +798,12 @@ export function cohortSampleFilterWhereVariables(
     ];
   } else {
     tempoWhere = [
+      {
+        billedBy_CONTAINS: parsedSearchVals[0],
+      },
+      {
+        costCenter_CONTAINS: parsedSearchVals[0],
+      },
       {
         hasEventBamCompletes_SOME: {
           date_CONTAINS: parsedSearchVals[0],

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -517,6 +517,9 @@ export const CohortsListColumns: ColDef[] = [
     sortable: false,
   },
   {
+    headerName: "Billed",
+  },
+  {
     headerName: "Delivery Date",
     valueGetter: ({ data }) =>
       data["hasCohortCompleteCohortCompletes"]?.slice(-1)[0]?.date,
@@ -566,7 +569,7 @@ export const CohortsListColumns: ColDef[] = [
   },
 ];
 
-export const CohortSamplesDetailsColumns: ColDef[] = [
+export const CohortSampleDetailsColumns: ColDef[] = [
   {
     field: "primaryId",
     headerName: "Primary ID",
@@ -578,6 +581,17 @@ export const CohortSamplesDetailsColumns: ColDef[] = [
   {
     field: "deliveryDate",
     headerName: "Delivery Date",
+  },
+  {
+    headerName: "Billed",
+    editable: true,
+  },
+  {
+    headerName: "Cost Center",
+    editable: true,
+  },
+  {
+    headerName: "Billed By",
   },
   {
     field: "bamCompleteDate",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -247,28 +247,6 @@ function LoadingIcon() {
   );
 }
 
-const statusCellRendererProps: ColDef = {
-  cellRenderer: (params: ICellRendererParams) => {
-    if (params.data?.revisable) {
-      return params.data?.hasStatusStatuses[0]?.validationStatus ? (
-        <CheckIcon />
-      ) : (
-        <WarningIcon />
-      );
-    } else {
-      return <LoadingIcon />;
-    }
-  },
-  cellRendererParams: {
-    colDef: {
-      tooltipComponent: StatusTooltip,
-      tooltipValueGetter: (params: ITooltipParams) =>
-        params.data.hasStatusStatuses[0]?.validationReport ??
-        params.data.hasStatusStatuses,
-    },
-  },
-};
-
 export const SampleDetailsColumns: ColDef<SampleMetadataExtended>[] = [
   {
     field: "primaryId",
@@ -277,7 +255,25 @@ export const SampleDetailsColumns: ColDef<SampleMetadataExtended>[] = [
   {
     field: "revisable",
     headerName: "Status",
-    ...statusCellRendererProps,
+    cellRenderer: (params: ICellRendererParams) => {
+      if (params.data?.revisable) {
+        return params.data?.hasStatusStatuses[0]?.validationStatus ? (
+          <CheckIcon />
+        ) : (
+          <WarningIcon />
+        );
+      } else {
+        return <LoadingIcon />;
+      }
+    },
+    cellRendererParams: {
+      colDef: {
+        tooltipComponent: StatusTooltip,
+        tooltipValueGetter: (params: ITooltipParams) =>
+          params.data.hasStatusStatuses[0]?.validationReport ??
+          params.data.hasStatusStatuses,
+      },
+    },
   },
   {
     field: "cmoSampleName",
@@ -590,11 +586,6 @@ export const CohortSampleDetailsColumns: ColDef[] = [
   {
     field: "primaryId",
     headerName: "Primary ID",
-  },
-  {
-    field: "revisable",
-    headerName: "Status",
-    ...statusCellRendererProps,
   },
   {
     field: "cmoSampleName",

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -44,6 +44,7 @@ export type BamCompleteTemposHasEventConnectionArgs = {
   after?: InputMaybe<Scalars["String"]>;
   directed?: InputMaybe<Scalars["Boolean"]>;
   first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<BamCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<BamCompleteTemposHasEventConnectionWhere>;
 };
 
@@ -106,6 +107,15 @@ export type BamCompleteSort = {
 export type BamCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "BamCompleteTempoTemposHasEventAggregationSelection";
   count: Scalars["Int"];
+  node?: Maybe<BamCompleteTempoTemposHasEventNodeAggregateSelection>;
+};
+
+export type BamCompleteTempoTemposHasEventNodeAggregateSelection = {
+  __typename?: "BamCompleteTempoTemposHasEventNodeAggregateSelection";
+  accessLevel: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNonNullable;
+  costCenter: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNonNullable;
 };
 
 export type BamCompleteTemposHasEventAggregateInput = {
@@ -116,6 +126,7 @@ export type BamCompleteTemposHasEventAggregateInput = {
   count_GTE?: InputMaybe<Scalars["Int"]>;
   count_LT?: InputMaybe<Scalars["Int"]>;
   count_LTE?: InputMaybe<Scalars["Int"]>;
+  node?: InputMaybe<BamCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type BamCompleteTemposHasEventConnectFieldInput = {
@@ -128,6 +139,10 @@ export type BamCompleteTemposHasEventConnection = {
   edges: Array<BamCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
   totalCount: Scalars["Int"];
+};
+
+export type BamCompleteTemposHasEventConnectionSort = {
+  node?: InputMaybe<TempoSort>;
 };
 
 export type BamCompleteTemposHasEventConnectionWhere = {
@@ -154,6 +169,91 @@ export type BamCompleteTemposHasEventDisconnectFieldInput = {
 export type BamCompleteTemposHasEventFieldInput = {
   connect?: InputMaybe<Array<BamCompleteTemposHasEventConnectFieldInput>>;
   create?: InputMaybe<Array<BamCompleteTemposHasEventCreateFieldInput>>;
+};
+
+export type BamCompleteTemposHasEventNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<BamCompleteTemposHasEventNodeAggregationWhereInput>>;
+  OR?: InputMaybe<Array<BamCompleteTemposHasEventNodeAggregationWhereInput>>;
+  accessLevel_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_EQUAL?: InputMaybe<Scalars["String"]>;
+  accessLevel_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_EQUAL?: InputMaybe<Scalars["String"]>;
+  billedBy_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_EQUAL?: InputMaybe<Scalars["String"]>;
+  costCenter_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_EQUAL?: InputMaybe<Scalars["String"]>;
+  custodianInformation_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type BamCompleteTemposHasEventRelationship = {
@@ -1290,6 +1390,7 @@ export type MafCompleteTemposHasEventConnectionArgs = {
   after?: InputMaybe<Scalars["String"]>;
   directed?: InputMaybe<Scalars["Boolean"]>;
   first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<MafCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<MafCompleteTemposHasEventConnectionWhere>;
 };
 
@@ -1355,6 +1456,15 @@ export type MafCompleteSort = {
 export type MafCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "MafCompleteTempoTemposHasEventAggregationSelection";
   count: Scalars["Int"];
+  node?: Maybe<MafCompleteTempoTemposHasEventNodeAggregateSelection>;
+};
+
+export type MafCompleteTempoTemposHasEventNodeAggregateSelection = {
+  __typename?: "MafCompleteTempoTemposHasEventNodeAggregateSelection";
+  accessLevel: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNonNullable;
+  costCenter: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNonNullable;
 };
 
 export type MafCompleteTemposHasEventAggregateInput = {
@@ -1365,6 +1475,7 @@ export type MafCompleteTemposHasEventAggregateInput = {
   count_GTE?: InputMaybe<Scalars["Int"]>;
   count_LT?: InputMaybe<Scalars["Int"]>;
   count_LTE?: InputMaybe<Scalars["Int"]>;
+  node?: InputMaybe<MafCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type MafCompleteTemposHasEventConnectFieldInput = {
@@ -1377,6 +1488,10 @@ export type MafCompleteTemposHasEventConnection = {
   edges: Array<MafCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
   totalCount: Scalars["Int"];
+};
+
+export type MafCompleteTemposHasEventConnectionSort = {
+  node?: InputMaybe<TempoSort>;
 };
 
 export type MafCompleteTemposHasEventConnectionWhere = {
@@ -1403,6 +1518,91 @@ export type MafCompleteTemposHasEventDisconnectFieldInput = {
 export type MafCompleteTemposHasEventFieldInput = {
   connect?: InputMaybe<Array<MafCompleteTemposHasEventConnectFieldInput>>;
   create?: InputMaybe<Array<MafCompleteTemposHasEventCreateFieldInput>>;
+};
+
+export type MafCompleteTemposHasEventNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<MafCompleteTemposHasEventNodeAggregationWhereInput>>;
+  OR?: InputMaybe<Array<MafCompleteTemposHasEventNodeAggregationWhereInput>>;
+  accessLevel_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_EQUAL?: InputMaybe<Scalars["String"]>;
+  accessLevel_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_EQUAL?: InputMaybe<Scalars["String"]>;
+  billedBy_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_EQUAL?: InputMaybe<Scalars["String"]>;
+  costCenter_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_EQUAL?: InputMaybe<Scalars["String"]>;
+  custodianInformation_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type MafCompleteTemposHasEventRelationship = {
@@ -3200,6 +3400,7 @@ export type QcCompleteTemposHasEventConnectionArgs = {
   after?: InputMaybe<Scalars["String"]>;
   directed?: InputMaybe<Scalars["Boolean"]>;
   first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<QcCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<QcCompleteTemposHasEventConnectionWhere>;
 };
 
@@ -3266,6 +3467,15 @@ export type QcCompleteSort = {
 export type QcCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "QcCompleteTempoTemposHasEventAggregationSelection";
   count: Scalars["Int"];
+  node?: Maybe<QcCompleteTempoTemposHasEventNodeAggregateSelection>;
+};
+
+export type QcCompleteTempoTemposHasEventNodeAggregateSelection = {
+  __typename?: "QcCompleteTempoTemposHasEventNodeAggregateSelection";
+  accessLevel: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNonNullable;
+  costCenter: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNonNullable;
 };
 
 export type QcCompleteTemposHasEventAggregateInput = {
@@ -3276,6 +3486,7 @@ export type QcCompleteTemposHasEventAggregateInput = {
   count_GTE?: InputMaybe<Scalars["Int"]>;
   count_LT?: InputMaybe<Scalars["Int"]>;
   count_LTE?: InputMaybe<Scalars["Int"]>;
+  node?: InputMaybe<QcCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type QcCompleteTemposHasEventConnectFieldInput = {
@@ -3288,6 +3499,10 @@ export type QcCompleteTemposHasEventConnection = {
   edges: Array<QcCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
   totalCount: Scalars["Int"];
+};
+
+export type QcCompleteTemposHasEventConnectionSort = {
+  node?: InputMaybe<TempoSort>;
 };
 
 export type QcCompleteTemposHasEventConnectionWhere = {
@@ -3314,6 +3529,91 @@ export type QcCompleteTemposHasEventDisconnectFieldInput = {
 export type QcCompleteTemposHasEventFieldInput = {
   connect?: InputMaybe<Array<QcCompleteTemposHasEventConnectFieldInput>>;
   create?: InputMaybe<Array<QcCompleteTemposHasEventCreateFieldInput>>;
+};
+
+export type QcCompleteTemposHasEventNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<QcCompleteTemposHasEventNodeAggregationWhereInput>>;
+  OR?: InputMaybe<Array<QcCompleteTemposHasEventNodeAggregationWhereInput>>;
+  accessLevel_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_EQUAL?: InputMaybe<Scalars["String"]>;
+  accessLevel_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_EQUAL?: InputMaybe<Scalars["String"]>;
+  billedBy_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_EQUAL?: InputMaybe<Scalars["String"]>;
+  costCenter_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_EQUAL?: InputMaybe<Scalars["String"]>;
+  custodianInformation_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type QcCompleteTemposHasEventRelationship = {
@@ -3698,6 +3998,7 @@ export type QueryTemposAggregateArgs = {
 export type QueryTemposConnectionArgs = {
   after?: InputMaybe<Scalars["String"]>;
   first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<InputMaybe<TempoSort>>>;
   where?: InputMaybe<TempoWhere>;
 };
 
@@ -5583,6 +5884,7 @@ export type SampleHasTempoTemposConnectionArgs = {
   after?: InputMaybe<Scalars["String"]>;
   directed?: InputMaybe<Scalars["Boolean"]>;
   first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<SampleHasTempoTemposConnectionSort>>;
   where?: InputMaybe<SampleHasTempoTemposConnectionWhere>;
 };
 
@@ -6762,6 +7064,7 @@ export type SampleHasTempoTemposAggregateInput = {
   count_GTE?: InputMaybe<Scalars["Int"]>;
   count_LT?: InputMaybe<Scalars["Int"]>;
   count_LTE?: InputMaybe<Scalars["Int"]>;
+  node?: InputMaybe<SampleHasTempoTemposNodeAggregationWhereInput>;
 };
 
 export type SampleHasTempoTemposConnectFieldInput = {
@@ -6774,6 +7077,10 @@ export type SampleHasTempoTemposConnection = {
   edges: Array<SampleHasTempoTemposRelationship>;
   pageInfo: PageInfo;
   totalCount: Scalars["Int"];
+};
+
+export type SampleHasTempoTemposConnectionSort = {
+  node?: InputMaybe<TempoSort>;
 };
 
 export type SampleHasTempoTemposConnectionWhere = {
@@ -6800,6 +7107,91 @@ export type SampleHasTempoTemposDisconnectFieldInput = {
 export type SampleHasTempoTemposFieldInput = {
   connect?: InputMaybe<Array<SampleHasTempoTemposConnectFieldInput>>;
   create?: InputMaybe<Array<SampleHasTempoTemposCreateFieldInput>>;
+};
+
+export type SampleHasTempoTemposNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<SampleHasTempoTemposNodeAggregationWhereInput>>;
+  OR?: InputMaybe<Array<SampleHasTempoTemposNodeAggregationWhereInput>>;
+  accessLevel_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  accessLevel_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  accessLevel_EQUAL?: InputMaybe<Scalars["String"]>;
+  accessLevel_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  accessLevel_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  billedBy_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  billedBy_EQUAL?: InputMaybe<Scalars["String"]>;
+  billedBy_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_LTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  billedBy_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  costCenter_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  costCenter_EQUAL?: InputMaybe<Scalars["String"]>;
+  costCenter_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_LTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  costCenter_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  custodianInformation_EQUAL?: InputMaybe<Scalars["String"]>;
+  custodianInformation_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_LTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  custodianInformation_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type SampleHasTempoTemposRelationship = {
@@ -8477,6 +8869,15 @@ export type SampleSort = {
 export type SampleTempoHasTempoTemposAggregationSelection = {
   __typename?: "SampleTempoHasTempoTemposAggregationSelection";
   count: Scalars["Int"];
+  node?: Maybe<SampleTempoHasTempoTemposNodeAggregateSelection>;
+};
+
+export type SampleTempoHasTempoTemposNodeAggregateSelection = {
+  __typename?: "SampleTempoHasTempoTemposNodeAggregateSelection";
+  accessLevel: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNonNullable;
+  costCenter: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNonNullable;
 };
 
 export type SampleUpdateInput = {
@@ -9637,6 +10038,11 @@ export type StringAggregateSelectionNullable = {
 
 export type Tempo = {
   __typename?: "Tempo";
+  accessLevel: Scalars["String"];
+  billed: Scalars["Boolean"];
+  billedBy: Scalars["String"];
+  costCenter: Scalars["String"];
+  custodianInformation: Scalars["String"];
   hasEventBamCompletes: Array<BamComplete>;
   hasEventBamCompletesAggregate?: Maybe<TempoBamCompleteHasEventBamCompletesAggregationSelection>;
   hasEventBamCompletesConnection: TempoHasEventBamCompletesConnection;
@@ -9729,7 +10135,11 @@ export type TempoSamplesHasTempoConnectionArgs = {
 
 export type TempoAggregateSelection = {
   __typename?: "TempoAggregateSelection";
+  accessLevel: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNonNullable;
+  costCenter: StringAggregateSelectionNonNullable;
   count: Scalars["Int"];
+  custodianInformation: StringAggregateSelectionNonNullable;
 };
 
 export type TempoBamCompleteHasEventBamCompletesAggregationSelection = {
@@ -9762,6 +10172,11 @@ export type TempoConnectWhere = {
 };
 
 export type TempoCreateInput = {
+  accessLevel: Scalars["String"];
+  billed: Scalars["Boolean"];
+  billedBy: Scalars["String"];
+  costCenter: Scalars["String"];
+  custodianInformation: Scalars["String"];
   hasEventBamCompletes?: InputMaybe<TempoHasEventBamCompletesFieldInput>;
   hasEventMafCompletes?: InputMaybe<TempoHasEventMafCompletesFieldInput>;
   hasEventQcCompletes?: InputMaybe<TempoHasEventQcCompletesFieldInput>;
@@ -10227,6 +10642,8 @@ export type TempoMafCompleteHasEventMafCompletesNodeAggregateSelection = {
 export type TempoOptions = {
   limit?: InputMaybe<Scalars["Int"]>;
   offset?: InputMaybe<Scalars["Int"]>;
+  /** Specify one or more TempoSort objects to sort Tempos by. The sorts will be applied in the order in which they are arranged in the array. */
+  sort?: InputMaybe<Array<TempoSort>>;
 };
 
 export type TempoQcCompleteHasEventQcCompletesAggregationSelection = {
@@ -10427,7 +10844,21 @@ export type TempoSamplesHasTempoUpdateFieldInput = {
   where?: InputMaybe<TempoSamplesHasTempoConnectionWhere>;
 };
 
+/** Fields to sort Tempos by. The order in which sorts are applied is not guaranteed when specifying many fields in one TempoSort object. */
+export type TempoSort = {
+  accessLevel?: InputMaybe<SortDirection>;
+  billed?: InputMaybe<SortDirection>;
+  billedBy?: InputMaybe<SortDirection>;
+  costCenter?: InputMaybe<SortDirection>;
+  custodianInformation?: InputMaybe<SortDirection>;
+};
+
 export type TempoUpdateInput = {
+  accessLevel?: InputMaybe<Scalars["String"]>;
+  billed?: InputMaybe<Scalars["Boolean"]>;
+  billedBy?: InputMaybe<Scalars["String"]>;
+  costCenter?: InputMaybe<Scalars["String"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]>;
   hasEventBamCompletes?: InputMaybe<
     Array<TempoHasEventBamCompletesUpdateFieldInput>
   >;
@@ -10443,6 +10874,48 @@ export type TempoUpdateInput = {
 export type TempoWhere = {
   AND?: InputMaybe<Array<TempoWhere>>;
   OR?: InputMaybe<Array<TempoWhere>>;
+  accessLevel?: InputMaybe<Scalars["String"]>;
+  accessLevel_CONTAINS?: InputMaybe<Scalars["String"]>;
+  accessLevel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  accessLevel_IN?: InputMaybe<Array<Scalars["String"]>>;
+  accessLevel_NOT?: InputMaybe<Scalars["String"]>;
+  accessLevel_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  accessLevel_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  accessLevel_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  accessLevel_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  accessLevel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  billed?: InputMaybe<Scalars["Boolean"]>;
+  billedBy?: InputMaybe<Scalars["String"]>;
+  billedBy_CONTAINS?: InputMaybe<Scalars["String"]>;
+  billedBy_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  billedBy_IN?: InputMaybe<Array<Scalars["String"]>>;
+  billedBy_NOT?: InputMaybe<Scalars["String"]>;
+  billedBy_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  billedBy_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  billedBy_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  billedBy_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  billedBy_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  billed_NOT?: InputMaybe<Scalars["Boolean"]>;
+  costCenter?: InputMaybe<Scalars["String"]>;
+  costCenter_CONTAINS?: InputMaybe<Scalars["String"]>;
+  costCenter_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  costCenter_IN?: InputMaybe<Array<Scalars["String"]>>;
+  costCenter_NOT?: InputMaybe<Scalars["String"]>;
+  costCenter_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  costCenter_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  costCenter_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  costCenter_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  costCenter_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]>;
+  custodianInformation_CONTAINS?: InputMaybe<Scalars["String"]>;
+  custodianInformation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  custodianInformation_IN?: InputMaybe<Array<Scalars["String"]>>;
+  custodianInformation_NOT?: InputMaybe<Scalars["String"]>;
+  custodianInformation_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  custodianInformation_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  custodianInformation_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  custodianInformation_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  custodianInformation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   hasEventBamCompletesAggregate?: InputMaybe<TempoHasEventBamCompletesAggregateInput>;
   hasEventBamCompletesConnection_ALL?: InputMaybe<TempoHasEventBamCompletesConnectionWhere>;
   hasEventBamCompletesConnection_NONE?: InputMaybe<TempoHasEventBamCompletesConnectionWhere>;
@@ -10796,6 +11269,9 @@ export type FindSamplesByInputValueQuery = {
         };
         hasTempoTempos: Array<{
           __typename?: "Tempo";
+          billed: boolean;
+          billedBy: string;
+          costCenter: string;
           hasEventBamCompletes: Array<{
             __typename?: "BamComplete";
             date: string;
@@ -11195,6 +11671,9 @@ export const FindSamplesByInputValueDocument = gql`
             }
           }
           hasTempoTempos {
+            billed
+            billedBy
+            costCenter
             hasEventBamCompletes(options: $bamCompletesOptions) {
               date
               status

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -11498,6 +11498,11 @@ export type CohortsListQuery = {
       __typename?: "CohortHasCohortSampleSamplesConnection";
       totalCount: number;
     };
+    hasCohortSampleSamples: Array<{
+      __typename?: "Sample";
+      smileSampleId: string;
+      hasTempoTempos: Array<{ __typename?: "Tempo"; billed: boolean }>;
+    }>;
   }>;
 };
 
@@ -11797,6 +11802,12 @@ export const CohortsListDocument = gql`
       }
       hasCohortSampleSamplesConnection {
         totalCount
+      }
+      hasCohortSampleSamples {
+        smileSampleId
+        hasTempoTempos {
+          billed
+        }
       }
     }
   }

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -184,6 +184,26 @@
                 "deprecationReason": null
               },
               {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "BamCompleteTemposHasEventConnectionSort",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "where",
                 "description": null,
                 "type": {
@@ -632,6 +652,93 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "BamCompleteTempoTemposHasEventNodeAggregateSelection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "BamCompleteTempoTemposHasEventNodeAggregateSelection",
+        "description": null,
+        "fields": [
+          {
+            "name": "accessLevel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -739,6 +846,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BamCompleteTemposHasEventNodeAggregationWhereInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -857,6 +976,29 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "BamCompleteTemposHasEventConnectionSort",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TempoSort",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -1073,6 +1215,1017 @@
                   "ofType": null
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "BamCompleteTemposHasEventNodeAggregationWhereInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "AND",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BamCompleteTemposHasEventNodeAggregationWhereInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OR",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BamCompleteTemposHasEventNodeAggregationWhereInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -11610,6 +12763,26 @@
                 "deprecationReason": null
               },
               {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "MafCompleteTemposHasEventConnectionSort",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "where",
                 "description": null,
                 "type": {
@@ -12102,6 +13275,93 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "MafCompleteTempoTemposHasEventNodeAggregateSelection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MafCompleteTempoTemposHasEventNodeAggregateSelection",
+        "description": null,
+        "fields": [
+          {
+            "name": "accessLevel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -12209,6 +13469,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "MafCompleteTemposHasEventNodeAggregationWhereInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -12327,6 +13599,29 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "MafCompleteTemposHasEventConnectionSort",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TempoSort",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -12543,6 +13838,1017 @@
                   "ofType": null
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "MafCompleteTemposHasEventNodeAggregationWhereInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "AND",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MafCompleteTemposHasEventNodeAggregationWhereInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OR",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MafCompleteTemposHasEventNodeAggregationWhereInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -29759,6 +32065,26 @@
                 "deprecationReason": null
               },
               {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "QcCompleteTemposHasEventConnectionSort",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "where",
                 "description": null,
                 "type": {
@@ -30295,6 +32621,93 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "QcCompleteTempoTemposHasEventNodeAggregateSelection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "QcCompleteTempoTemposHasEventNodeAggregateSelection",
+        "description": null,
+        "fields": [
+          {
+            "name": "accessLevel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -30402,6 +32815,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "QcCompleteTemposHasEventNodeAggregationWhereInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -30520,6 +32945,29 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "QcCompleteTemposHasEventConnectionSort",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TempoSort",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -30736,6 +33184,1017 @@
                   "ofType": null
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "QcCompleteTemposHasEventNodeAggregationWhereInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "AND",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "QcCompleteTemposHasEventNodeAggregationWhereInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OR",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "QcCompleteTemposHasEventNodeAggregationWhereInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -33981,6 +37440,22 @@
                   "kind": "SCALAR",
                   "name": "Int",
                   "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "TempoSort",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -53339,6 +56814,26 @@
                 "deprecationReason": null
               },
               {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "SampleHasTempoTemposConnectionSort",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "where",
                 "description": null,
                 "type": {
@@ -65734,6 +69229,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SampleHasTempoTemposNodeAggregationWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -65847,6 +69354,29 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SampleHasTempoTemposConnectionSort",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TempoSort",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -66063,6 +69593,1017 @@
                   "ofType": null
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SampleHasTempoTemposNodeAggregationWhereInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "AND",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SampleHasTempoTemposNodeAggregationWhereInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OR",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SampleHasTempoTemposNodeAggregationWhereInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -84150,6 +88691,93 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SampleTempoHasTempoTemposNodeAggregateSelection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SampleTempoHasTempoTemposNodeAggregateSelection",
+        "description": null,
+        "fields": [
+          {
+            "name": "accessLevel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -96197,6 +100825,86 @@
         "description": null,
         "fields": [
           {
+            "name": "accessLevel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "hasEventBamCompletes",
             "description": null,
             "args": [
@@ -96940,6 +101648,54 @@
         "description": null,
         "fields": [
           {
+            "name": "accessLevel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "count",
             "description": null,
             "args": [],
@@ -96949,6 +101705,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
                 "ofType": null
               }
             },
@@ -97167,6 +101939,86 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "accessLevel",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "hasEventBamCompletes",
             "description": null,
@@ -101865,6 +106717,26 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "sort",
+            "description": "Specify one or more TempoSort objects to sort Tempos by. The sorts will be applied in the order in which they are arranged in the array.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "TempoSort",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -103863,10 +108735,141 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "TempoSort",
+        "description": "Fields to sort Tempos by. The order in which sorts are applied is not guaranteed when specifying many fields in one TempoSort object.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "accessLevel",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "TempoUpdateInput",
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "accessLevel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "hasEventBamCompletes",
             "description": null,
@@ -103993,6 +108996,574 @@
                   "ofType": null
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accessLevel_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -249,5 +249,11 @@ query CohortsList(
     hasCohortSampleSamplesConnection {
       totalCount
     }
+    hasCohortSampleSamples {
+      smileSampleId
+      hasTempoTempos {
+        billed
+      }
+    }
   }
 }

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -94,6 +94,9 @@ query FindSamplesByInputValue(
           }
         }
         hasTempoTempos {
+          billed
+          billedBy
+          costCenter
           hasEventBamCompletes(options: $bamCompletesOptions) {
             date
             status


### PR DESCRIPTION
Screenshots of the new billing fields in the Cohort and Cohort Sample views:
![cohorts_view](https://github.com/mskcc/smile-dashboard/assets/86090707/622a9aaf-44ba-4ee3-a2ae-196a74279cad)
![cohort_samples_view](https://github.com/mskcc/smile-dashboard/assets/86090707/81ddf39c-0726-43b1-874c-34574d1bd886)