### PR TITLE
Fix: duplicate records on Patients page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,7 +36,7 @@ export default function App() {
               <PatientsPage userEmail={userEmail} setUserEmail={setUserEmail} />
             }
           >
-            <Route path=":cmoPatientId" />
+            <Route path=":smilePatientId" />
           </Route>
           <Route path="/samples" element={<SamplesPage />} />
           <Route

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -28,7 +28,6 @@ import { ErrorMessage, LoadingSpinner, Toolbar } from "../shared/tableElements";
 interface IRecordsListProps {
   colDefs: ColDef[];
   dataName: DataName;
-  nodeName?: string;
   lazyRecordsQuery: typeof useHookLazyGeneric;
   lazyRecordsQueryAddlVariables?: Record<string, any>;
   prepareDataForAgGrid?: (data: any) => any;
@@ -60,7 +59,6 @@ interface IRecordsListProps {
 export default function RecordsList({
   colDefs,
   dataName,
-  nodeName = dataName,
   lazyRecordsQuery,
   lazyRecordsQueryAddlVariables,
   prepareDataForAgGrid,
@@ -98,7 +96,7 @@ export default function RecordsList({
       },
     });
 
-  const totalCountNodeName = `${nodeName}Connection`;
+  const totalCountNodeName = `${dataName}Connection`;
 
   const datasource: IServerSideDatasource = useMemo(() => {
     return {
@@ -108,7 +106,7 @@ export default function RecordsList({
           where: {
             OR: queryFilterWhereVariables(parsedSearchVals),
           },
-          [`${nodeName}ConnectionWhere2`]: {
+          [`${dataName}ConnectionWhere2`]: {
             OR: queryFilterWhereVariables(parsedSearchVals),
           },
           options: {
@@ -133,7 +131,7 @@ export default function RecordsList({
           const data = d.data;
           prepareDataForAgGrid && prepareDataForAgGrid(data);
           params.success({
-            rowData: data[nodeName],
+            rowData: data[dataName],
             rowCount: data[totalCountNodeName].totalCount,
           });
         });
@@ -172,11 +170,11 @@ export default function RecordsList({
                 },
               },
             }).then(({ data }: any) => {
-              return CSVFormulate(data[nodeName], colDefs);
+              return CSVFormulate(data[dataName], colDefs);
             });
           }}
           onComplete={() => setShowDownloadModal(false)}
-          exportFileName={`${nodeName}.tsv`}
+          exportFileName={`${dataName}.tsv`}
         />
       )}
 

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -128,8 +128,8 @@ export default function RecordsList({
               });
 
         return thisFetch.then((d) => {
-          const data = d.data;
-          prepareDataForAgGrid && prepareDataForAgGrid(data);
+          let data = d.data;
+          if (prepareDataForAgGrid) data = prepareDataForAgGrid(data);
           params.success({
             rowData: data[dataName],
             rowCount: data[totalCountNodeName].totalCount,

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -33,7 +33,7 @@ const max_rows = 500;
 
 interface ISampleListProps {
   columnDefs: ColDef[];
-  getRowData: (samples: Sample[]) => any[];
+  prepareDataForAgGrid: (samples: Sample[]) => any[];
   setUnsavedChanges?: (unsavedChanges: boolean) => void;
   parentWhereVariables?: SampleWhere;
   refetchWhereVariables: (parsedSearchVals: string[]) => SampleWhere;
@@ -45,7 +45,7 @@ interface ISampleListProps {
 
 export default function SamplesList({
   columnDefs,
-  getRowData,
+  prepareDataForAgGrid,
   parentWhereVariables,
   refetchWhereVariables,
   setUnsavedChanges,
@@ -206,7 +206,7 @@ export default function SamplesList({
         <DownloadModal
           loader={() => {
             return Promise.resolve(
-              CSVFormulate(getRowData(samples), columnDefs)
+              CSVFormulate(prepareDataForAgGrid(samples), columnDefs)
             );
           }}
           onComplete={() => {
@@ -312,7 +312,7 @@ export default function SamplesList({
                 },
               }}
               columnDefs={columnDefs}
-              rowData={getRowData(samples)}
+              rowData={prepareDataForAgGrid(samples)}
               onCellEditRequest={onCellValueChanged}
               readOnlyEdit={true}
               defaultColDef={defaultColDef}

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -11235,15 +11235,7 @@ export type FindSamplesByInputValueQuery = {
           __typename?: "SamplePatientsHasSampleConnection";
           edges: Array<{
             __typename?: "SamplePatientsHasSampleRelationship";
-            node: {
-              __typename?: "Patient";
-              smilePatientId: string;
-              patientAliasesIsAlias: Array<{
-                __typename?: "PatientAlias";
-                namespace: string;
-                value: string;
-              }>;
-            };
+            node: { __typename?: "Patient"; smilePatientId: string };
           }>;
         };
         cohortsHasCohortSampleConnection: {
@@ -11745,10 +11737,6 @@ export const FindSamplesByInputValueDocument = gql`
             edges {
               node {
                 smilePatientId
-                patientAliasesIsAlias {
-                  namespace
-                  value
-                }
               }
             }
           }

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -114,8 +114,8 @@ export type BamCompleteTempoTemposHasEventAggregationSelection = {
 export type BamCompleteTempoTemposHasEventNodeAggregateSelection = {
   __typename?: "BamCompleteTempoTemposHasEventNodeAggregateSelection";
   accessLevel: StringAggregateSelectionNonNullable;
-  billedBy: StringAggregateSelectionNonNullable;
-  costCenter: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNullable;
+  costCenter: StringAggregateSelectionNullable;
   custodianInformation: StringAggregateSelectionNonNullable;
 };
 
@@ -1463,8 +1463,8 @@ export type MafCompleteTempoTemposHasEventAggregationSelection = {
 export type MafCompleteTempoTemposHasEventNodeAggregateSelection = {
   __typename?: "MafCompleteTempoTemposHasEventNodeAggregateSelection";
   accessLevel: StringAggregateSelectionNonNullable;
-  billedBy: StringAggregateSelectionNonNullable;
-  costCenter: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNullable;
+  costCenter: StringAggregateSelectionNullable;
   custodianInformation: StringAggregateSelectionNonNullable;
 };
 
@@ -3474,8 +3474,8 @@ export type QcCompleteTempoTemposHasEventAggregationSelection = {
 export type QcCompleteTempoTemposHasEventNodeAggregateSelection = {
   __typename?: "QcCompleteTempoTemposHasEventNodeAggregateSelection";
   accessLevel: StringAggregateSelectionNonNullable;
-  billedBy: StringAggregateSelectionNonNullable;
-  costCenter: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNullable;
+  costCenter: StringAggregateSelectionNullable;
   custodianInformation: StringAggregateSelectionNonNullable;
 };
 
@@ -8876,8 +8876,8 @@ export type SampleTempoHasTempoTemposAggregationSelection = {
 export type SampleTempoHasTempoTemposNodeAggregateSelection = {
   __typename?: "SampleTempoHasTempoTemposNodeAggregateSelection";
   accessLevel: StringAggregateSelectionNonNullable;
-  billedBy: StringAggregateSelectionNonNullable;
-  costCenter: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNullable;
+  costCenter: StringAggregateSelectionNullable;
   custodianInformation: StringAggregateSelectionNonNullable;
 };
 
@@ -10040,9 +10040,9 @@ export type StringAggregateSelectionNullable = {
 export type Tempo = {
   __typename?: "Tempo";
   accessLevel: Scalars["String"];
-  billed: Scalars["Boolean"];
-  billedBy: Scalars["String"];
-  costCenter: Scalars["String"];
+  billed?: Maybe<Scalars["Boolean"]>;
+  billedBy?: Maybe<Scalars["String"]>;
+  costCenter?: Maybe<Scalars["String"]>;
   custodianInformation: Scalars["String"];
   hasEventBamCompletes: Array<BamComplete>;
   hasEventBamCompletesAggregate?: Maybe<TempoBamCompleteHasEventBamCompletesAggregationSelection>;
@@ -10137,8 +10137,8 @@ export type TempoSamplesHasTempoConnectionArgs = {
 export type TempoAggregateSelection = {
   __typename?: "TempoAggregateSelection";
   accessLevel: StringAggregateSelectionNonNullable;
-  billedBy: StringAggregateSelectionNonNullable;
-  costCenter: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNullable;
+  costCenter: StringAggregateSelectionNullable;
   count: Scalars["Int"];
   custodianInformation: StringAggregateSelectionNonNullable;
 };
@@ -10174,9 +10174,9 @@ export type TempoConnectWhere = {
 
 export type TempoCreateInput = {
   accessLevel: Scalars["String"];
-  billed: Scalars["Boolean"];
-  billedBy: Scalars["String"];
-  costCenter: Scalars["String"];
+  billed?: InputMaybe<Scalars["Boolean"]>;
+  billedBy?: InputMaybe<Scalars["String"]>;
+  costCenter?: InputMaybe<Scalars["String"]>;
   custodianInformation: Scalars["String"];
   hasEventBamCompletes?: InputMaybe<TempoHasEventBamCompletesFieldInput>;
   hasEventMafCompletes?: InputMaybe<TempoHasEventMafCompletesFieldInput>;
@@ -10889,22 +10889,22 @@ export type TempoWhere = {
   billedBy?: InputMaybe<Scalars["String"]>;
   billedBy_CONTAINS?: InputMaybe<Scalars["String"]>;
   billedBy_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  billedBy_IN?: InputMaybe<Array<Scalars["String"]>>;
+  billedBy_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   billedBy_NOT?: InputMaybe<Scalars["String"]>;
   billedBy_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
   billedBy_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  billedBy_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  billedBy_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   billedBy_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   billedBy_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   billed_NOT?: InputMaybe<Scalars["Boolean"]>;
   costCenter?: InputMaybe<Scalars["String"]>;
   costCenter_CONTAINS?: InputMaybe<Scalars["String"]>;
   costCenter_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  costCenter_IN?: InputMaybe<Array<Scalars["String"]>>;
+  costCenter_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   costCenter_NOT?: InputMaybe<Scalars["String"]>;
   costCenter_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
   costCenter_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  costCenter_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  costCenter_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   costCenter_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   costCenter_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   custodianInformation?: InputMaybe<Scalars["String"]>;
@@ -11114,43 +11114,35 @@ export type RequestsListQuery = {
 };
 
 export type PatientsListQueryVariables = Exact<{
-  options?: InputMaybe<PatientAliasOptions>;
-  where?: InputMaybe<PatientAliasWhere>;
-  patientAliasesConnectionWhere2?: InputMaybe<PatientAliasWhere>;
+  options?: InputMaybe<PatientOptions>;
+  where?: InputMaybe<PatientWhere>;
+  patientsConnectionWhere2?: InputMaybe<PatientWhere>;
 }>;
 
 export type PatientsListQuery = {
   __typename?: "Query";
-  patientAliasesConnection: {
-    __typename?: "PatientAliasesConnection";
-    totalCount: number;
-  };
-  patientAliases: Array<{
-    __typename?: "PatientAlias";
-    namespace: string;
-    value: string;
-    isAliasPatients: Array<{
-      __typename?: "Patient";
-      smilePatientId: string;
-      hasSampleSamples: Array<{
-        __typename?: "Sample";
-        smileSampleId: string;
-        hasMetadataSampleMetadata: Array<{
-          __typename?: "SampleMetadata";
-          primaryId: string;
-          cmoSampleName?: string | null;
-          additionalProperties: string;
-        }>;
+  patientsConnection: { __typename?: "PatientsConnection"; totalCount: number };
+  patients: Array<{
+    __typename?: "Patient";
+    smilePatientId: string;
+    hasSampleSamples: Array<{
+      __typename?: "Sample";
+      smileSampleId: string;
+      hasMetadataSampleMetadata: Array<{
+        __typename?: "SampleMetadata";
+        primaryId: string;
+        cmoSampleName?: string | null;
+        additionalProperties: string;
       }>;
-      hasSampleSamplesConnection: {
-        __typename?: "PatientHasSampleSamplesConnection";
-        totalCount: number;
-      };
-      patientAliasesIsAlias: Array<{
-        __typename?: "PatientAlias";
-        namespace: string;
-        value: string;
-      }>;
+    }>;
+    hasSampleSamplesConnection: {
+      __typename?: "PatientHasSampleSamplesConnection";
+      totalCount: number;
+    };
+    patientAliasesIsAlias: Array<{
+      __typename?: "PatientAlias";
+      namespace: string;
+      value: string;
     }>;
   }>;
 };
@@ -11270,9 +11262,9 @@ export type FindSamplesByInputValueQuery = {
         };
         hasTempoTempos: Array<{
           __typename?: "Tempo";
-          billed: boolean;
-          billedBy: string;
-          costCenter: string;
+          billed?: boolean | null;
+          billedBy?: string | null;
+          costCenter?: string | null;
           hasEventBamCompletes: Array<{
             __typename?: "BamComplete";
             date: string;
@@ -11502,7 +11494,7 @@ export type CohortsListQuery = {
     hasCohortSampleSamples: Array<{
       __typename?: "Sample";
       smileSampleId: string;
-      hasTempoTempos: Array<{ __typename?: "Tempo"; billed: boolean }>;
+      hasTempoTempos: Array<{ __typename?: "Tempo"; billed?: boolean | null }>;
     }>;
   }>;
 };
@@ -11642,33 +11634,29 @@ export type RequestsListQueryResult = Apollo.QueryResult<
 >;
 export const PatientsListDocument = gql`
   query PatientsList(
-    $options: PatientAliasOptions
-    $where: PatientAliasWhere
-    $patientAliasesConnectionWhere2: PatientAliasWhere
+    $options: PatientOptions
+    $where: PatientWhere
+    $patientsConnectionWhere2: PatientWhere
   ) {
-    patientAliasesConnection(where: $patientAliasesConnectionWhere2) {
+    patientsConnection(where: $patientsConnectionWhere2) {
       totalCount
     }
-    patientAliases(where: $where, options: $options) {
-      namespace
-      value
-      isAliasPatients {
-        smilePatientId
-        hasSampleSamples {
-          smileSampleId
-          hasMetadataSampleMetadata {
-            primaryId
-            cmoSampleName
-            additionalProperties
-          }
+    patients(where: $where, options: $options) {
+      smilePatientId
+      hasSampleSamples {
+        smileSampleId
+        hasMetadataSampleMetadata {
+          primaryId
+          cmoSampleName
+          additionalProperties
         }
-        hasSampleSamplesConnection {
-          totalCount
-        }
-        patientAliasesIsAlias {
-          namespace
-          value
-        }
+      }
+      hasSampleSamplesConnection {
+        totalCount
+      }
+      patientAliasesIsAlias {
+        namespace
+        value
       }
     }
   }
@@ -11688,7 +11676,7 @@ export const PatientsListDocument = gql`
  *   variables: {
  *      options: // value for 'options'
  *      where: // value for 'where'
- *      patientAliasesConnectionWhere2: // value for 'patientAliasesConnectionWhere2'
+ *      patientsConnectionWhere2: // value for 'patientsConnectionWhere2'
  *   },
  * });
  */

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -158,7 +158,7 @@ export default function CohortsPage({
             },
           } as SampleWhere
         }
-        samplesRefetchWhereVariables={(samplesParsedSearchVals: string[]) => {
+        samplesRefetchWhereVariables={(samplesParsedSearchVals) => {
           return {
             cohortsHasCohortSampleConnection_SOME: {
               node: {

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -10,7 +10,7 @@ import {
   CohortSampleDetailsColumns,
   CohortsListColumns,
   cohortSampleFilterWhereVariables,
-  getSampleCohortDataFromSamplesQuery,
+  prepareSampleCohortDataForAgGrid,
   handleSearch,
 } from "../../shared/helpers";
 import RecordsList from "../../components/RecordsList";
@@ -148,7 +148,7 @@ export default function CohortsPage({
           sampleQueryParamValue &&
           `${sampleQueryParamHeaderName} "${sampleQueryParamValue}"`
         }
-        getSamplesRowData={getSampleCohortDataFromSamplesQuery}
+        prepareSamplesDataForAgGrid={prepareSampleCohortDataForAgGrid}
         samplesParentWhereVariables={
           {
             cohortsHasCohortSampleConnection_SOME: {

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -1,5 +1,5 @@
 import {
-  PatientAliasWhere,
+  PatientWhere,
   SampleWhere,
   useGetPatientIdsTripletsLazyQuery,
   usePatientsListLazyQuery,
@@ -16,7 +16,6 @@ import { parseUserSearchVal } from "../../utils/parseSearchQueries";
 import {
   PatientsListColumns,
   SampleDetailsColumns,
-  prepareSampleMetadataForAgGrid,
   sampleFilterWhereVariables,
 } from "../../shared/helpers";
 import { getUserEmail } from "../../utils/getUserEmail";
@@ -29,51 +28,35 @@ export type PatientIdsTriplet = {
   DMP_ID: string | null;
 };
 
-function patientAliasFilterWhereVariables(
+function patientFilterWhereVariables(
   parsedSearchVals: string[]
-): PatientAliasWhere[] {
+): PatientWhere[] {
   if (parsedSearchVals.length > 1) {
     return [
-      { value_IN: parsedSearchVals },
-      { namespace_IN: parsedSearchVals },
       {
-        isAliasPatients_SOME: {
-          hasSampleSamples_SOME: {
-            hasMetadataSampleMetadata_SOME: {
-              cmoSampleName_IN: parsedSearchVals,
-            },
-          },
+        patientAliasesIsAlias_SOME: {
+          value_IN: parsedSearchVals,
         },
       },
       {
-        isAliasPatients_SOME: {
-          hasSampleSamples_SOME: {
-            hasMetadataSampleMetadata_SOME: {
-              primaryId_IN: parsedSearchVals,
-            },
+        hasSampleSamples_SOME: {
+          hasMetadataSampleMetadata_SOME: {
+            cmoSampleName_IN: parsedSearchVals,
           },
         },
       },
     ];
   } else {
     return [
-      { value_CONTAINS: parsedSearchVals[0] },
-      { namespace_CONTAINS: parsedSearchVals[0] },
       {
-        isAliasPatients_SOME: {
-          hasSampleSamples_SOME: {
-            hasMetadataSampleMetadata_SOME: {
-              cmoSampleName_CONTAINS: parsedSearchVals[0],
-            },
-          },
+        patientAliasesIsAlias_SOME: {
+          value_CONTAINS: parsedSearchVals[0],
         },
       },
       {
-        isAliasPatients_SOME: {
-          hasSampleSamples_SOME: {
-            hasMetadataSampleMetadata_SOME: {
-              primaryId_CONTAINS: parsedSearchVals[0],
-            },
+        hasSampleSamples_SOME: {
+          hasMetadataSampleMetadata_SOME: {
+            cmoSampleName_CONTAINS: parsedSearchVals[0],
           },
         },
       },
@@ -248,7 +231,7 @@ export default function PatientsPage({
   }, [phiEnabled, patientIdsTriplets, userEmail]);
 
   const dataName = "patients";
-  const nodeName = "patientAliases";
+  // const nodeName = "patientAliases"; TODO: remove nodeName prop from RecordsList
   const sampleQueryParamFieldName = "cmoPatientId";
   const sampleQueryParamHeaderName = "CMO Patient ID";
   const sampleQueryParamValue = params[sampleQueryParamFieldName];
@@ -260,9 +243,9 @@ export default function PatientsPage({
       <RecordsList
         colDefs={ActivePatientsListColumns}
         dataName={dataName}
-        nodeName={nodeName}
+        nodeName={dataName}
         lazyRecordsQuery={usePatientsListLazyQuery}
-        queryFilterWhereVariables={patientAliasFilterWhereVariables}
+        queryFilterWhereVariables={patientFilterWhereVariables}
         userSearchVal={userSearchVal}
         setUserSearchVal={setUserSearchVal}
         parsedSearchVals={parsedSearchVals}

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -231,8 +231,8 @@ export default function PatientsPage({
   }, [phiEnabled, patientIdsTriplets, userEmail]);
 
   const dataName = "patients";
-  const sampleQueryParamFieldName = "cmoPatientId";
-  const sampleQueryParamHeaderName = "CMO Patient ID";
+  const sampleQueryParamFieldName = "smilePatientId";
+  const sampleQueryParamHeaderName = "Smile Patient ID";
   const sampleQueryParamValue = params[sampleQueryParamFieldName];
 
   return (
@@ -261,7 +261,7 @@ export default function PatientsPage({
         samplesColDefs={SampleDetailsColumns}
         samplesQueryParam={
           sampleQueryParamValue &&
-          `${sampleQueryParamHeaderName} ${sampleQueryParamValue}`
+          `${sampleQueryParamHeaderName} "${sampleQueryParamValue}"`
         }
         samplesParentWhereVariables={
           {
@@ -269,26 +269,21 @@ export default function PatientsPage({
               {
                 patientsHasSampleConnection_SOME: {
                   node: {
-                    patientAliasesIsAlias_SOME: {
-                      value: sampleQueryParamValue,
-                    },
+                    [sampleQueryParamFieldName]: sampleQueryParamValue,
                   },
                 },
               },
             ],
           } as SampleWhere
         }
-        samplesRefetchWhereVariables={(parsedSearchVals) => {
+        samplesRefetchWhereVariables={(sampleParsedSearchVals) => {
           return {
-            hasMetadataSampleMetadata_SOME: {
-              OR: sampleFilterWhereVariables(parsedSearchVals),
-              ...(params[sampleQueryParamFieldName]
-                ? {
-                    [sampleQueryParamFieldName]:
-                      params[sampleQueryParamFieldName],
-                  }
-                : {}),
+            patientsHasSampleConnection_SOME: {
+              node: {
+                [sampleQueryParamFieldName]: sampleQueryParamValue,
+              },
             },
+            OR: sampleFilterWhereVariables(sampleParsedSearchVals),
           } as SampleWhere;
         }}
         setCustomSearchVals={setPatientIdsTriplets}

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -16,6 +16,7 @@ import { parseUserSearchVal } from "../../utils/parseSearchQueries";
 import {
   PatientsListColumns,
   SampleDetailsColumns,
+  preparePatientDataForAgGrid,
   sampleFilterWhereVariables,
 } from "../../shared/helpers";
 import { getUserEmail } from "../../utils/getUserEmail";
@@ -243,6 +244,7 @@ export default function PatientsPage({
         colDefs={ActivePatientsListColumns}
         dataName={dataName}
         lazyRecordsQuery={usePatientsListLazyQuery}
+        prepareDataForAgGrid={preparePatientDataForAgGrid}
         queryFilterWhereVariables={patientFilterWhereVariables}
         userSearchVal={userSearchVal}
         setUserSearchVal={setUserSearchVal}

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -231,7 +231,6 @@ export default function PatientsPage({
   }, [phiEnabled, patientIdsTriplets, userEmail]);
 
   const dataName = "patients";
-  // const nodeName = "patientAliases"; TODO: remove nodeName prop from RecordsList
   const sampleQueryParamFieldName = "cmoPatientId";
   const sampleQueryParamHeaderName = "CMO Patient ID";
   const sampleQueryParamValue = params[sampleQueryParamFieldName];
@@ -243,7 +242,6 @@ export default function PatientsPage({
       <RecordsList
         colDefs={ActivePatientsListColumns}
         dataName={dataName}
-        nodeName={dataName}
         lazyRecordsQuery={usePatientsListLazyQuery}
         queryFilterWhereVariables={patientFilterWhereVariables}
         userSearchVal={userSearchVal}

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -16,7 +16,7 @@ import { parseUserSearchVal } from "../../utils/parseSearchQueries";
 import {
   PatientsListColumns,
   SampleDetailsColumns,
-  getSampleMetadataFromSamplesQuery,
+  prepareSampleMetadataForAgGrid,
   sampleFilterWhereVariables,
 } from "../../shared/helpers";
 import { getUserEmail } from "../../utils/getUserEmail";
@@ -282,7 +282,6 @@ export default function PatientsPage({
           sampleQueryParamValue &&
           `${sampleQueryParamHeaderName} ${sampleQueryParamValue}`
         }
-        getSamplesRowData={getSampleMetadataFromSamplesQuery}
         samplesParentWhereVariables={
           {
             OR: [

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -233,7 +233,6 @@ export default function PatientsPage({
 
   const dataName = "patients";
   const sampleQueryParamFieldName = "smilePatientId";
-  const sampleQueryParamHeaderName = "Smile Patient ID";
   const sampleQueryParamValue = params[sampleQueryParamFieldName];
 
   return (
@@ -261,10 +260,7 @@ export default function PatientsPage({
           setShowDownloadModal(true);
         }}
         samplesColDefs={SampleDetailsColumns}
-        samplesQueryParam={
-          sampleQueryParamValue &&
-          `${sampleQueryParamHeaderName} "${sampleQueryParamValue}"`
-        }
+        samplesQueryParam={sampleQueryParamValue && "Patient's Samples"}
         samplesParentWhereVariables={
           {
             OR: [

--- a/frontend/src/pages/requests/RequestsPage.tsx
+++ b/frontend/src/pages/requests/RequestsPage.tsx
@@ -86,7 +86,7 @@ export default function RequestsPage() {
         samplesColDefs={SampleDetailsColumns}
         samplesQueryParam={
           sampleQueryParamValue &&
-          `${sampleQueryParamHeaderName} ${sampleQueryParamValue}`
+          `${sampleQueryParamHeaderName} "${sampleQueryParamValue}"`
         }
         prepareSamplesDataForAgGrid={prepareSampleMetadataForAgGrid}
         samplesParentWhereVariables={

--- a/frontend/src/pages/requests/RequestsPage.tsx
+++ b/frontend/src/pages/requests/RequestsPage.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import {
   RequestsListColumns,
   SampleDetailsColumns,
-  getSampleMetadataFromSamplesQuery,
+  prepareSampleMetadataForAgGrid,
   handleSearch,
   sampleFilterWhereVariables,
 } from "../../shared/helpers";
@@ -88,7 +88,7 @@ export default function RequestsPage() {
           sampleQueryParamValue &&
           `${sampleQueryParamHeaderName} ${sampleQueryParamValue}`
         }
-        getSamplesRowData={getSampleMetadataFromSamplesQuery}
+        prepareSamplesDataForAgGrid={prepareSampleMetadataForAgGrid}
         samplesParentWhereVariables={
           {
             hasMetadataSampleMetadata_SOME: {

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -2,7 +2,7 @@ import { PageHeader } from "../../shared/components/PageHeader";
 import SamplesList from "../../components/SamplesList";
 import {
   SampleDetailsColumns,
-  getSampleMetadataFromSamplesQuery,
+  prepareSampleMetadataForAgGrid,
   sampleFilterWhereVariables,
 } from "../../shared/helpers";
 import { SampleWhere } from "../../generated/graphql";
@@ -14,7 +14,7 @@ export default function SamplesPage() {
 
       <SamplesList
         columnDefs={SampleDetailsColumns}
-        getRowData={getSampleMetadataFromSamplesQuery}
+        prepareDataForAgGrid={prepareSampleMetadataForAgGrid}
         refetchWhereVariables={(parsedSearchVals) => {
           return {
             hasMetadataSampleMetadata_SOME: {

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from "react-bootstrap";
 import "ag-grid-enterprise";
 import {
+  PatientAlias,
   Sample,
   SampleMetadata,
   SampleMetadataWhere,
@@ -171,8 +172,8 @@ export const PatientsListColumns: ColDef[] = [
     field: "cmoPatientId",
     headerName: "CMO Patient ID",
     valueGetter: function ({ data }) {
-      return data["isAliasPatients"][0]["patientAliasesIsAlias"].find(
-        (patientAlias: any) => patientAlias.namespace === "cmoId"
+      return data.patientAliasesIsAlias.find(
+        (patientAlias: PatientAlias) => patientAlias.namespace === "cmoId"
       )?.value;
     },
     sortable: false,
@@ -181,8 +182,8 @@ export const PatientsListColumns: ColDef[] = [
     field: "dmpPatientId",
     headerName: "DMP Patient ID",
     valueGetter: function ({ data }) {
-      return data["isAliasPatients"][0]["patientAliasesIsAlias"].find(
-        (patientAlias: any) => patientAlias.namespace === "dmpId"
+      return data.patientAliasesIsAlias.find(
+        (patientAlias: PatientAlias) => patientAlias.namespace === "dmpId"
       )?.value;
     },
     sortable: false,
@@ -190,7 +191,7 @@ export const PatientsListColumns: ColDef[] = [
   {
     headerName: "# Samples",
     valueGetter: function ({ data }) {
-      return data["isAliasPatients"][0].hasSampleSamplesConnection.totalCount;
+      return data.hasSampleSamplesConnection.totalCount;
     },
     sortable: false,
   },
@@ -198,7 +199,7 @@ export const PatientsListColumns: ColDef[] = [
     field: "cmoSampleIds",
     headerName: "CMO Sample IDs",
     valueGetter: function ({ data }) {
-      return data["isAliasPatients"][0].hasSampleSamples.map(
+      return data.hasSampleSamples.map(
         (sample: Sample) =>
           sample.hasMetadataSampleMetadata[0].cmoSampleName ||
           sample.hasMetadataSampleMetadata[0].primaryId
@@ -210,8 +211,8 @@ export const PatientsListColumns: ColDef[] = [
     headerName: "12-245 Part A",
     valueGetter: function ({ data }) {
       return JSON.parse(
-        data["isAliasPatients"][0].hasSampleSamples[0]
-          ?.hasMetadataSampleMetadata[0]?.additionalProperties
+        data.hasSampleSamples[0]?.hasMetadataSampleMetadata[0]
+          ?.additionalProperties
       )["consent-parta"];
     },
     sortable: false,
@@ -220,8 +221,8 @@ export const PatientsListColumns: ColDef[] = [
     headerName: "12-245 Part C",
     valueGetter: function ({ data }) {
       return JSON.parse(
-        data["isAliasPatients"][0].hasSampleSamples[0]
-          ?.hasMetadataSampleMetadata[0]?.additionalProperties
+        data.hasSampleSamples[0]?.hasMetadataSampleMetadata[0]
+          ?.additionalProperties
       )["consent-partc"];
     },
     sortable: false,
@@ -230,7 +231,7 @@ export const PatientsListColumns: ColDef[] = [
     field: "smilePatientId",
     headerName: "SMILE Patient ID",
     valueGetter: function ({ data }) {
-      return data["isAliasPatients"][0].smilePatientId;
+      return data.smilePatientId;
     },
     hide: true,
   },

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -878,7 +878,7 @@ export function cohortSampleFilterWhereVariables(
   ];
 }
 
-export function getSampleMetadataFromSamplesQuery(samples: Sample[]) {
+export function prepareSampleMetadataForAgGrid(samples: Sample[]) {
   return samples.map((s) => {
     return {
       ...s.hasMetadataSampleMetadata[0],
@@ -887,7 +887,7 @@ export function getSampleMetadataFromSamplesQuery(samples: Sample[]) {
   });
 }
 
-export function getSampleCohortDataFromSamplesQuery(samples: Sample[]) {
+export function prepareSampleCohortDataForAgGrid(samples: Sample[]) {
   return samples.map((s) => {
     const cohorts = s.cohortsHasCohortSampleConnection?.edges;
     const cohortDates = cohorts?.flatMap((c) => {

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -144,15 +144,15 @@ export const RequestsListColumns: ColDef[] = [
 export const PatientsListColumns: ColDef[] = [
   {
     headerName: "View Samples",
-    cellRenderer: (params: CellClassParams<any>) => {
+    cellRenderer: (params: ICellRendererParams) => {
       return (
         <Button
           variant="outline-secondary"
           size="sm"
           onClick={() => {
-            if (params.data.value !== undefined) {
-              params.context.navigateFunction(`/patients/${params.data.value}`);
-            }
+            params.context.navigateFunction(
+              `/patients/${params.data.smilePatientId}`
+            );
           }}
         >
           View

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -1,5 +1,4 @@
 import {
-  CellClassParams,
   ColDef,
   ICellRendererParams,
   IHeaderParams,
@@ -31,7 +30,7 @@ export type SampleChange = {
   fieldName: string;
   oldValue: string;
   newValue: string;
-  rowNode: RowNode<any>;
+  rowNode: RowNode;
 };
 
 export type ChangesByPrimaryId = {
@@ -43,7 +42,7 @@ export type ChangesByPrimaryId = {
 export const RequestsListColumns: ColDef[] = [
   {
     headerName: "View Samples",
-    cellRenderer: (params: CellClassParams<any>) => {
+    cellRenderer: (params: ICellRendererParams) => {
       return (
         <Button
           variant="outline-secondary"
@@ -516,7 +515,7 @@ function setupEditableSampleFields(samplesColDefs: ColDef[]) {
 export const CohortsListColumns: ColDef[] = [
   {
     headerName: "View Samples",
-    cellRenderer: (params: CellClassParams<any>) => {
+    cellRenderer: (params: ICellRendererParams) => {
       return (
         <Button
           variant="outline-secondary"

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -113,8 +113,8 @@ export type BamCompleteTempoTemposHasEventAggregationSelection = {
 export type BamCompleteTempoTemposHasEventNodeAggregateSelection = {
   __typename?: "BamCompleteTempoTemposHasEventNodeAggregateSelection";
   accessLevel: StringAggregateSelectionNonNullable;
-  billedBy: StringAggregateSelectionNonNullable;
-  costCenter: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNullable;
+  costCenter: StringAggregateSelectionNullable;
   custodianInformation: StringAggregateSelectionNonNullable;
 };
 
@@ -1462,8 +1462,8 @@ export type MafCompleteTempoTemposHasEventAggregationSelection = {
 export type MafCompleteTempoTemposHasEventNodeAggregateSelection = {
   __typename?: "MafCompleteTempoTemposHasEventNodeAggregateSelection";
   accessLevel: StringAggregateSelectionNonNullable;
-  billedBy: StringAggregateSelectionNonNullable;
-  costCenter: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNullable;
+  costCenter: StringAggregateSelectionNullable;
   custodianInformation: StringAggregateSelectionNonNullable;
 };
 
@@ -3473,8 +3473,8 @@ export type QcCompleteTempoTemposHasEventAggregationSelection = {
 export type QcCompleteTempoTemposHasEventNodeAggregateSelection = {
   __typename?: "QcCompleteTempoTemposHasEventNodeAggregateSelection";
   accessLevel: StringAggregateSelectionNonNullable;
-  billedBy: StringAggregateSelectionNonNullable;
-  costCenter: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNullable;
+  costCenter: StringAggregateSelectionNullable;
   custodianInformation: StringAggregateSelectionNonNullable;
 };
 
@@ -8875,8 +8875,8 @@ export type SampleTempoHasTempoTemposAggregationSelection = {
 export type SampleTempoHasTempoTemposNodeAggregateSelection = {
   __typename?: "SampleTempoHasTempoTemposNodeAggregateSelection";
   accessLevel: StringAggregateSelectionNonNullable;
-  billedBy: StringAggregateSelectionNonNullable;
-  costCenter: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNullable;
+  costCenter: StringAggregateSelectionNullable;
   custodianInformation: StringAggregateSelectionNonNullable;
 };
 
@@ -10039,9 +10039,9 @@ export type StringAggregateSelectionNullable = {
 export type Tempo = {
   __typename?: "Tempo";
   accessLevel: Scalars["String"];
-  billed: Scalars["Boolean"];
-  billedBy: Scalars["String"];
-  costCenter: Scalars["String"];
+  billed?: Maybe<Scalars["Boolean"]>;
+  billedBy?: Maybe<Scalars["String"]>;
+  costCenter?: Maybe<Scalars["String"]>;
   custodianInformation: Scalars["String"];
   hasEventBamCompletes: Array<BamComplete>;
   hasEventBamCompletesAggregate?: Maybe<TempoBamCompleteHasEventBamCompletesAggregationSelection>;
@@ -10136,8 +10136,8 @@ export type TempoSamplesHasTempoConnectionArgs = {
 export type TempoAggregateSelection = {
   __typename?: "TempoAggregateSelection";
   accessLevel: StringAggregateSelectionNonNullable;
-  billedBy: StringAggregateSelectionNonNullable;
-  costCenter: StringAggregateSelectionNonNullable;
+  billedBy: StringAggregateSelectionNullable;
+  costCenter: StringAggregateSelectionNullable;
   count: Scalars["Int"];
   custodianInformation: StringAggregateSelectionNonNullable;
 };
@@ -10173,9 +10173,9 @@ export type TempoConnectWhere = {
 
 export type TempoCreateInput = {
   accessLevel: Scalars["String"];
-  billed: Scalars["Boolean"];
-  billedBy: Scalars["String"];
-  costCenter: Scalars["String"];
+  billed?: InputMaybe<Scalars["Boolean"]>;
+  billedBy?: InputMaybe<Scalars["String"]>;
+  costCenter?: InputMaybe<Scalars["String"]>;
   custodianInformation: Scalars["String"];
   hasEventBamCompletes?: InputMaybe<TempoHasEventBamCompletesFieldInput>;
   hasEventMafCompletes?: InputMaybe<TempoHasEventMafCompletesFieldInput>;
@@ -10888,22 +10888,22 @@ export type TempoWhere = {
   billedBy?: InputMaybe<Scalars["String"]>;
   billedBy_CONTAINS?: InputMaybe<Scalars["String"]>;
   billedBy_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  billedBy_IN?: InputMaybe<Array<Scalars["String"]>>;
+  billedBy_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   billedBy_NOT?: InputMaybe<Scalars["String"]>;
   billedBy_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
   billedBy_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  billedBy_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  billedBy_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   billedBy_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   billedBy_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   billed_NOT?: InputMaybe<Scalars["Boolean"]>;
   costCenter?: InputMaybe<Scalars["String"]>;
   costCenter_CONTAINS?: InputMaybe<Scalars["String"]>;
   costCenter_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  costCenter_IN?: InputMaybe<Array<Scalars["String"]>>;
+  costCenter_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   costCenter_NOT?: InputMaybe<Scalars["String"]>;
   costCenter_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
   costCenter_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  costCenter_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  costCenter_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   costCenter_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   costCenter_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   custodianInformation?: InputMaybe<Scalars["String"]>;
@@ -11113,43 +11113,35 @@ export type RequestsListQuery = {
 };
 
 export type PatientsListQueryVariables = Exact<{
-  options?: InputMaybe<PatientAliasOptions>;
-  where?: InputMaybe<PatientAliasWhere>;
-  patientAliasesConnectionWhere2?: InputMaybe<PatientAliasWhere>;
+  options?: InputMaybe<PatientOptions>;
+  where?: InputMaybe<PatientWhere>;
+  patientsConnectionWhere2?: InputMaybe<PatientWhere>;
 }>;
 
 export type PatientsListQuery = {
   __typename?: "Query";
-  patientAliasesConnection: {
-    __typename?: "PatientAliasesConnection";
-    totalCount: number;
-  };
-  patientAliases: Array<{
-    __typename?: "PatientAlias";
-    namespace: string;
-    value: string;
-    isAliasPatients: Array<{
-      __typename?: "Patient";
-      smilePatientId: string;
-      hasSampleSamples: Array<{
-        __typename?: "Sample";
-        smileSampleId: string;
-        hasMetadataSampleMetadata: Array<{
-          __typename?: "SampleMetadata";
-          primaryId: string;
-          cmoSampleName?: string | null;
-          additionalProperties: string;
-        }>;
+  patientsConnection: { __typename?: "PatientsConnection"; totalCount: number };
+  patients: Array<{
+    __typename?: "Patient";
+    smilePatientId: string;
+    hasSampleSamples: Array<{
+      __typename?: "Sample";
+      smileSampleId: string;
+      hasMetadataSampleMetadata: Array<{
+        __typename?: "SampleMetadata";
+        primaryId: string;
+        cmoSampleName?: string | null;
+        additionalProperties: string;
       }>;
-      hasSampleSamplesConnection: {
-        __typename?: "PatientHasSampleSamplesConnection";
-        totalCount: number;
-      };
-      patientAliasesIsAlias: Array<{
-        __typename?: "PatientAlias";
-        namespace: string;
-        value: string;
-      }>;
+    }>;
+    hasSampleSamplesConnection: {
+      __typename?: "PatientHasSampleSamplesConnection";
+      totalCount: number;
+    };
+    patientAliasesIsAlias: Array<{
+      __typename?: "PatientAlias";
+      namespace: string;
+      value: string;
     }>;
   }>;
 };
@@ -11269,9 +11261,9 @@ export type FindSamplesByInputValueQuery = {
         };
         hasTempoTempos: Array<{
           __typename?: "Tempo";
-          billed: boolean;
-          billedBy: string;
-          costCenter: string;
+          billed?: boolean | null;
+          billedBy?: string | null;
+          costCenter?: string | null;
           hasEventBamCompletes: Array<{
             __typename?: "BamComplete";
             date: string;
@@ -11501,7 +11493,7 @@ export type CohortsListQuery = {
     hasCohortSampleSamples: Array<{
       __typename?: "Sample";
       smileSampleId: string;
-      hasTempoTempos: Array<{ __typename?: "Tempo"; billed: boolean }>;
+      hasTempoTempos: Array<{ __typename?: "Tempo"; billed?: boolean | null }>;
     }>;
   }>;
 };
@@ -11592,33 +11584,29 @@ export type RequestsListQueryResult = Apollo.QueryResult<
 >;
 export const PatientsListDocument = gql`
   query PatientsList(
-    $options: PatientAliasOptions
-    $where: PatientAliasWhere
-    $patientAliasesConnectionWhere2: PatientAliasWhere
+    $options: PatientOptions
+    $where: PatientWhere
+    $patientsConnectionWhere2: PatientWhere
   ) {
-    patientAliasesConnection(where: $patientAliasesConnectionWhere2) {
+    patientsConnection(where: $patientsConnectionWhere2) {
       totalCount
     }
-    patientAliases(where: $where, options: $options) {
-      namespace
-      value
-      isAliasPatients {
-        smilePatientId
-        hasSampleSamples {
-          smileSampleId
-          hasMetadataSampleMetadata {
-            primaryId
-            cmoSampleName
-            additionalProperties
-          }
+    patients(where: $where, options: $options) {
+      smilePatientId
+      hasSampleSamples {
+        smileSampleId
+        hasMetadataSampleMetadata {
+          primaryId
+          cmoSampleName
+          additionalProperties
         }
-        hasSampleSamplesConnection {
-          totalCount
-        }
-        patientAliasesIsAlias {
-          namespace
-          value
-        }
+      }
+      hasSampleSamplesConnection {
+        totalCount
+      }
+      patientAliasesIsAlias {
+        namespace
+        value
       }
     }
   }

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -11234,15 +11234,7 @@ export type FindSamplesByInputValueQuery = {
           __typename?: "SamplePatientsHasSampleConnection";
           edges: Array<{
             __typename?: "SamplePatientsHasSampleRelationship";
-            node: {
-              __typename?: "Patient";
-              smilePatientId: string;
-              patientAliasesIsAlias: Array<{
-                __typename?: "PatientAlias";
-                namespace: string;
-                value: string;
-              }>;
-            };
+            node: { __typename?: "Patient"; smilePatientId: string };
           }>;
         };
         cohortsHasCohortSampleConnection: {
@@ -11646,10 +11638,6 @@ export const FindSamplesByInputValueDocument = gql`
             edges {
               node {
                 smilePatientId
-                patientAliasesIsAlias {
-                  namespace
-                  value
-                }
               }
             }
           }

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -701,7 +701,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -717,7 +717,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -13324,7 +13324,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -13340,7 +13340,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -32670,7 +32670,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -32686,7 +32686,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -88740,7 +88740,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -88756,7 +88756,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -100845,13 +100845,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -100861,13 +100857,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -100877,13 +100869,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -101672,7 +101660,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -101688,7 +101676,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -101959,13 +101947,9 @@
             "name": "billed",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -101975,13 +101959,9 @@
             "name": "billedBy",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -101991,13 +101971,9 @@
             "name": "costCenter",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -109192,13 +109168,9 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "defaultValue": null,
@@ -109248,13 +109220,9 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "defaultValue": null,
@@ -109340,13 +109308,9 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "defaultValue": null,
@@ -109396,13 +109360,9 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "defaultValue": null,

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -14,38 +14,6 @@ query RequestsList(
   }
 }
 
-# query PatientsList(
-#   $options: PatientAliasOptions
-#   $where: PatientAliasWhere
-#   $patientAliasesConnectionWhere2: PatientAliasWhere
-# ) {
-#   patientAliasesConnection(where: $patientAliasesConnectionWhere2) {
-#     totalCount
-#   }
-#   patientAliases(where: $where, options: $options) {
-#     namespace
-#     value
-#     isAliasPatients {
-#       smilePatientId
-#       hasSampleSamples {
-#         smileSampleId
-#         hasMetadataSampleMetadata {
-#           primaryId
-#           cmoSampleName
-#           additionalProperties
-#         }
-#       }
-#       hasSampleSamplesConnection {
-#         totalCount
-#       }
-#       patientAliasesIsAlias {
-#         namespace
-#         value
-#       }
-#     }
-#   }
-# }
-
 query PatientsList(
   $options: PatientOptions
   $where: PatientWhere

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -14,34 +14,62 @@ query RequestsList(
   }
 }
 
+# query PatientsList(
+#   $options: PatientAliasOptions
+#   $where: PatientAliasWhere
+#   $patientAliasesConnectionWhere2: PatientAliasWhere
+# ) {
+#   patientAliasesConnection(where: $patientAliasesConnectionWhere2) {
+#     totalCount
+#   }
+#   patientAliases(where: $where, options: $options) {
+#     namespace
+#     value
+#     isAliasPatients {
+#       smilePatientId
+#       hasSampleSamples {
+#         smileSampleId
+#         hasMetadataSampleMetadata {
+#           primaryId
+#           cmoSampleName
+#           additionalProperties
+#         }
+#       }
+#       hasSampleSamplesConnection {
+#         totalCount
+#       }
+#       patientAliasesIsAlias {
+#         namespace
+#         value
+#       }
+#     }
+#   }
+# }
+
 query PatientsList(
-  $options: PatientAliasOptions
-  $where: PatientAliasWhere
-  $patientAliasesConnectionWhere2: PatientAliasWhere
+  $options: PatientOptions
+  $where: PatientWhere
+  $patientsConnectionWhere2: PatientWhere
 ) {
-  patientAliasesConnection(where: $patientAliasesConnectionWhere2) {
+  patientsConnection(where: $patientsConnectionWhere2) {
     totalCount
   }
-  patientAliases(where: $where, options: $options) {
-    namespace
-    value
-    isAliasPatients {
-      smilePatientId
-      hasSampleSamples {
-        smileSampleId
-        hasMetadataSampleMetadata {
-          primaryId
-          cmoSampleName
-          additionalProperties
-        }
+  patients(where: $where, options: $options) {
+    smilePatientId
+    hasSampleSamples {
+      smileSampleId
+      hasMetadataSampleMetadata {
+        primaryId
+        cmoSampleName
+        additionalProperties
       }
-      hasSampleSamplesConnection {
-        totalCount
-      }
-      patientAliasesIsAlias {
-        namespace
-        value
-      }
+    }
+    hasSampleSamplesConnection {
+      totalCount
+    }
+    patientAliasesIsAlias {
+      namespace
+      value
     }
   }
 }

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -104,10 +104,6 @@ query FindSamplesByInputValue(
           edges {
             node {
               smilePatientId
-              patientAliasesIsAlias {
-                namespace
-                value
-              }
             }
           }
         }


### PR DESCRIPTION
This PR modifies the GraphQL query used on Patients page to fetch for `Patient` nodes instead of `PatientAlias`, which was what led to the duplicative rows.