### PR TITLE
Surface additional fields in Cohort Samples table

### DIFF
--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -394,25 +394,23 @@ export type CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelec
 export type CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSelection =
   {
     __typename?: "CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSelection";
-    analyst: StringAggregateSelectionNullable;
     date: StringAggregateSelectionNonNullable;
-    projectSubtitle: StringAggregateSelectionNullable;
-    projectTitle: StringAggregateSelectionNullable;
+    projectSubtitle: StringAggregateSelectionNonNullable;
+    projectTitle: StringAggregateSelectionNonNullable;
     status: StringAggregateSelectionNonNullable;
     type: StringAggregateSelectionNonNullable;
   };
 
 export type CohortComplete = {
   __typename?: "CohortComplete";
-  analyst?: Maybe<Scalars["String"]>;
   cohortsHasCohortComplete: Array<Cohort>;
   cohortsHasCohortCompleteAggregate?: Maybe<CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection>;
   cohortsHasCohortCompleteConnection: CohortCompleteCohortsHasCohortCompleteConnection;
   date: Scalars["String"];
-  endUsers?: Maybe<Array<Maybe<Scalars["String"]>>>;
-  pmUsers?: Maybe<Array<Maybe<Scalars["String"]>>>;
-  projectSubtitle?: Maybe<Scalars["String"]>;
-  projectTitle?: Maybe<Scalars["String"]>;
+  endUsers: Array<Maybe<Scalars["String"]>>;
+  pmUsers: Array<Maybe<Scalars["String"]>>;
+  projectSubtitle: Scalars["String"];
+  projectTitle: Scalars["String"];
   status: Scalars["String"];
   type: Scalars["String"];
 };
@@ -440,11 +438,10 @@ export type CohortCompleteCohortsHasCohortCompleteConnectionArgs = {
 
 export type CohortCompleteAggregateSelection = {
   __typename?: "CohortCompleteAggregateSelection";
-  analyst: StringAggregateSelectionNullable;
   count: Scalars["Int"];
   date: StringAggregateSelectionNonNullable;
-  projectSubtitle: StringAggregateSelectionNullable;
-  projectTitle: StringAggregateSelectionNullable;
+  projectSubtitle: StringAggregateSelectionNonNullable;
+  projectTitle: StringAggregateSelectionNonNullable;
   status: StringAggregateSelectionNonNullable;
   type: StringAggregateSelectionNonNullable;
 };
@@ -587,13 +584,12 @@ export type CohortCompleteConnectWhere = {
 };
 
 export type CohortCompleteCreateInput = {
-  analyst?: InputMaybe<Scalars["String"]>;
   cohortsHasCohortComplete?: InputMaybe<CohortCompleteCohortsHasCohortCompleteFieldInput>;
   date: Scalars["String"];
-  endUsers?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pmUsers?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
+  endUsers: Array<InputMaybe<Scalars["String"]>>;
+  pmUsers: Array<InputMaybe<Scalars["String"]>>;
+  projectSubtitle: Scalars["String"];
+  projectTitle: Scalars["String"];
   status: Scalars["String"];
   type: Scalars["String"];
 };
@@ -631,7 +627,6 @@ export type CohortCompleteRelationInput = {
 
 /** Fields to sort CohortCompletes by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortCompleteSort object. */
 export type CohortCompleteSort = {
-  analyst?: InputMaybe<SortDirection>;
   date?: InputMaybe<SortDirection>;
   projectSubtitle?: InputMaybe<SortDirection>;
   projectTitle?: InputMaybe<SortDirection>;
@@ -640,7 +635,6 @@ export type CohortCompleteSort = {
 };
 
 export type CohortCompleteUpdateInput = {
-  analyst?: InputMaybe<Scalars["String"]>;
   cohortsHasCohortComplete?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteUpdateFieldInput>
   >;
@@ -660,16 +654,6 @@ export type CohortCompleteUpdateInput = {
 export type CohortCompleteWhere = {
   AND?: InputMaybe<Array<CohortCompleteWhere>>;
   OR?: InputMaybe<Array<CohortCompleteWhere>>;
-  analyst?: InputMaybe<Scalars["String"]>;
-  analyst_CONTAINS?: InputMaybe<Scalars["String"]>;
-  analyst_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  analyst_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  analyst_NOT?: InputMaybe<Scalars["String"]>;
-  analyst_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
-  analyst_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  analyst_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  analyst_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  analyst_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   cohortsHasCohortCompleteAggregate?: InputMaybe<CohortCompleteCohortsHasCohortCompleteAggregateInput>;
   cohortsHasCohortCompleteConnection_ALL?: InputMaybe<CohortCompleteCohortsHasCohortCompleteConnectionWhere>;
   cohortsHasCohortCompleteConnection_NONE?: InputMaybe<CohortCompleteCohortsHasCohortCompleteConnectionWhere>;
@@ -704,21 +688,21 @@ export type CohortCompleteWhere = {
   projectSubtitle?: InputMaybe<Scalars["String"]>;
   projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]>;
   projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectSubtitle_IN?: InputMaybe<Array<Scalars["String"]>>;
   projectSubtitle_NOT?: InputMaybe<Scalars["String"]>;
   projectSubtitle_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
   projectSubtitle_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectSubtitle_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   projectSubtitle_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   projectSubtitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   projectTitle?: InputMaybe<Scalars["String"]>;
   projectTitle_CONTAINS?: InputMaybe<Scalars["String"]>;
   projectTitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectTitle_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectTitle_IN?: InputMaybe<Array<Scalars["String"]>>;
   projectTitle_NOT?: InputMaybe<Scalars["String"]>;
   projectTitle_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
   projectTitle_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectTitle_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectTitle_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   projectTitle_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   projectTitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   status?: InputMaybe<Scalars["String"]>;
@@ -859,26 +843,6 @@ export type CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput>
   >;
-  analyst_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  analyst_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  analyst_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  analyst_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  analyst_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  analyst_EQUAL?: InputMaybe<Scalars["String"]>;
-  analyst_GT?: InputMaybe<Scalars["Int"]>;
-  analyst_GTE?: InputMaybe<Scalars["Int"]>;
-  analyst_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  analyst_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  analyst_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  analyst_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  analyst_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  analyst_LT?: InputMaybe<Scalars["Int"]>;
-  analyst_LTE?: InputMaybe<Scalars["Int"]>;
-  analyst_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  analyst_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  analyst_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  analyst_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  analyst_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   date_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   date_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   date_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -11257,6 +11221,8 @@ export type FindSamplesByInputValueQuery = {
           billed?: boolean | null;
           billedBy?: string | null;
           costCenter?: string | null;
+          custodianInformation: string;
+          accessLevel: string;
           hasEventBamCompletes: Array<{
             __typename?: "BamComplete";
             date: string;
@@ -11472,10 +11438,10 @@ export type CohortsListQuery = {
     hasCohortCompleteCohortCompletes: Array<{
       __typename?: "CohortComplete";
       type: string;
-      endUsers?: Array<string | null> | null;
-      pmUsers?: Array<string | null> | null;
-      projectTitle?: string | null;
-      projectSubtitle?: string | null;
+      endUsers: Array<string | null>;
+      pmUsers: Array<string | null>;
+      projectTitle: string;
+      projectSubtitle: string;
       status: string;
       date: string;
     }>;
@@ -11754,6 +11720,8 @@ export const FindSamplesByInputValueDocument = gql`
             billed
             billedBy
             costCenter
+            custodianInformation
+            accessLevel
             hasEventBamCompletes(options: $bamCompletesOptions) {
               date
               status

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -722,13 +722,20 @@ export const CohortSampleDetailsColumns: ColDef[] = [
   {
     field: "costCenter",
     headerName: "Cost Center/Fund Number",
-    editable: true,
   },
   {
     field: "billedBy",
     headerName: "Edited By",
     headerTooltip: 'User who last updated the "Billed" status',
     headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
+  },
+  {
+    field: "custodianInformation",
+    headerName: "Data Custodian",
+  },
+  {
+    field: "accessLevel",
+    headerName: "Access Level",
   },
   {
     field: "bamCompleteDate",
@@ -792,6 +799,8 @@ const editableSampleFields = [
   "sex",
   "billed",
   "costCenter",
+  "custodianInformation",
+  "accessLevel",
 ];
 
 export function sampleFilterWhereVariables(
@@ -1009,6 +1018,8 @@ export function prepareSampleCohortDataForAgGrid(samples: Sample[]) {
 
     const tempo = s.hasTempoTempos?.[0];
     const { billed, billedBy, costCenter } = tempo ?? {};
+    const custodianInformation = tempo?.custodianInformation;
+    const accessLevel = tempo?.accessLevel;
 
     const bamComplete = tempo?.hasEventBamCompletes?.[0];
     const { date: bamCompleteDate, status: bamCompleteStatus } =
@@ -1037,6 +1048,8 @@ export function prepareSampleCohortDataForAgGrid(samples: Sample[]) {
       billed,
       billedBy,
       costCenter,
+      custodianInformation,
+      accessLevel,
       bamCompleteDate: formatCohortRelatedDate(bamCompleteDate),
       bamCompleteStatus,
       mafCompleteDate: formatCohortRelatedDate(mafCompleteDate),

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -393,25 +393,23 @@ export type CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelec
 export type CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSelection =
   {
     __typename?: "CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSelection";
-    analyst: StringAggregateSelectionNullable;
     date: StringAggregateSelectionNonNullable;
-    projectSubtitle: StringAggregateSelectionNullable;
-    projectTitle: StringAggregateSelectionNullable;
+    projectSubtitle: StringAggregateSelectionNonNullable;
+    projectTitle: StringAggregateSelectionNonNullable;
     status: StringAggregateSelectionNonNullable;
     type: StringAggregateSelectionNonNullable;
   };
 
 export type CohortComplete = {
   __typename?: "CohortComplete";
-  analyst?: Maybe<Scalars["String"]>;
   cohortsHasCohortComplete: Array<Cohort>;
   cohortsHasCohortCompleteAggregate?: Maybe<CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection>;
   cohortsHasCohortCompleteConnection: CohortCompleteCohortsHasCohortCompleteConnection;
   date: Scalars["String"];
-  endUsers?: Maybe<Array<Maybe<Scalars["String"]>>>;
-  pmUsers?: Maybe<Array<Maybe<Scalars["String"]>>>;
-  projectSubtitle?: Maybe<Scalars["String"]>;
-  projectTitle?: Maybe<Scalars["String"]>;
+  endUsers: Array<Maybe<Scalars["String"]>>;
+  pmUsers: Array<Maybe<Scalars["String"]>>;
+  projectSubtitle: Scalars["String"];
+  projectTitle: Scalars["String"];
   status: Scalars["String"];
   type: Scalars["String"];
 };
@@ -439,11 +437,10 @@ export type CohortCompleteCohortsHasCohortCompleteConnectionArgs = {
 
 export type CohortCompleteAggregateSelection = {
   __typename?: "CohortCompleteAggregateSelection";
-  analyst: StringAggregateSelectionNullable;
   count: Scalars["Int"];
   date: StringAggregateSelectionNonNullable;
-  projectSubtitle: StringAggregateSelectionNullable;
-  projectTitle: StringAggregateSelectionNullable;
+  projectSubtitle: StringAggregateSelectionNonNullable;
+  projectTitle: StringAggregateSelectionNonNullable;
   status: StringAggregateSelectionNonNullable;
   type: StringAggregateSelectionNonNullable;
 };
@@ -586,13 +583,12 @@ export type CohortCompleteConnectWhere = {
 };
 
 export type CohortCompleteCreateInput = {
-  analyst?: InputMaybe<Scalars["String"]>;
   cohortsHasCohortComplete?: InputMaybe<CohortCompleteCohortsHasCohortCompleteFieldInput>;
   date: Scalars["String"];
-  endUsers?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pmUsers?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
+  endUsers: Array<InputMaybe<Scalars["String"]>>;
+  pmUsers: Array<InputMaybe<Scalars["String"]>>;
+  projectSubtitle: Scalars["String"];
+  projectTitle: Scalars["String"];
   status: Scalars["String"];
   type: Scalars["String"];
 };
@@ -630,7 +626,6 @@ export type CohortCompleteRelationInput = {
 
 /** Fields to sort CohortCompletes by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortCompleteSort object. */
 export type CohortCompleteSort = {
-  analyst?: InputMaybe<SortDirection>;
   date?: InputMaybe<SortDirection>;
   projectSubtitle?: InputMaybe<SortDirection>;
   projectTitle?: InputMaybe<SortDirection>;
@@ -639,7 +634,6 @@ export type CohortCompleteSort = {
 };
 
 export type CohortCompleteUpdateInput = {
-  analyst?: InputMaybe<Scalars["String"]>;
   cohortsHasCohortComplete?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteUpdateFieldInput>
   >;
@@ -659,16 +653,6 @@ export type CohortCompleteUpdateInput = {
 export type CohortCompleteWhere = {
   AND?: InputMaybe<Array<CohortCompleteWhere>>;
   OR?: InputMaybe<Array<CohortCompleteWhere>>;
-  analyst?: InputMaybe<Scalars["String"]>;
-  analyst_CONTAINS?: InputMaybe<Scalars["String"]>;
-  analyst_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  analyst_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  analyst_NOT?: InputMaybe<Scalars["String"]>;
-  analyst_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
-  analyst_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  analyst_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  analyst_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  analyst_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   cohortsHasCohortCompleteAggregate?: InputMaybe<CohortCompleteCohortsHasCohortCompleteAggregateInput>;
   cohortsHasCohortCompleteConnection_ALL?: InputMaybe<CohortCompleteCohortsHasCohortCompleteConnectionWhere>;
   cohortsHasCohortCompleteConnection_NONE?: InputMaybe<CohortCompleteCohortsHasCohortCompleteConnectionWhere>;
@@ -703,21 +687,21 @@ export type CohortCompleteWhere = {
   projectSubtitle?: InputMaybe<Scalars["String"]>;
   projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]>;
   projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectSubtitle_IN?: InputMaybe<Array<Scalars["String"]>>;
   projectSubtitle_NOT?: InputMaybe<Scalars["String"]>;
   projectSubtitle_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
   projectSubtitle_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectSubtitle_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   projectSubtitle_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   projectSubtitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   projectTitle?: InputMaybe<Scalars["String"]>;
   projectTitle_CONTAINS?: InputMaybe<Scalars["String"]>;
   projectTitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectTitle_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectTitle_IN?: InputMaybe<Array<Scalars["String"]>>;
   projectTitle_NOT?: InputMaybe<Scalars["String"]>;
   projectTitle_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
   projectTitle_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectTitle_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectTitle_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   projectTitle_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   projectTitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   status?: InputMaybe<Scalars["String"]>;
@@ -858,26 +842,6 @@ export type CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput>
   >;
-  analyst_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  analyst_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  analyst_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  analyst_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  analyst_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  analyst_EQUAL?: InputMaybe<Scalars["String"]>;
-  analyst_GT?: InputMaybe<Scalars["Int"]>;
-  analyst_GTE?: InputMaybe<Scalars["Int"]>;
-  analyst_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  analyst_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  analyst_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  analyst_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  analyst_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  analyst_LT?: InputMaybe<Scalars["Int"]>;
-  analyst_LTE?: InputMaybe<Scalars["Int"]>;
-  analyst_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  analyst_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  analyst_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  analyst_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  analyst_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   date_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   date_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   date_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -11256,6 +11220,8 @@ export type FindSamplesByInputValueQuery = {
           billed?: boolean | null;
           billedBy?: string | null;
           costCenter?: string | null;
+          custodianInformation: string;
+          accessLevel: string;
           hasEventBamCompletes: Array<{
             __typename?: "BamComplete";
             date: string;
@@ -11471,10 +11437,10 @@ export type CohortsListQuery = {
     hasCohortCompleteCohortCompletes: Array<{
       __typename?: "CohortComplete";
       type: string;
-      endUsers?: Array<string | null> | null;
-      pmUsers?: Array<string | null> | null;
-      projectTitle?: string | null;
-      projectSubtitle?: string | null;
+      endUsers: Array<string | null>;
+      pmUsers: Array<string | null>;
+      projectTitle: string;
+      projectSubtitle: string;
       status: string;
       date: string;
     }>;
@@ -11655,6 +11621,8 @@ export const FindSamplesByInputValueDocument = gql`
             billed
             billedBy
             costCenter
+            custodianInformation
+            accessLevel
             hasEventBamCompletes(options: $bamCompletesOptions) {
               date
               status

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -3461,22 +3461,6 @@
         "description": null,
         "fields": [
           {
-            "name": "analyst",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "date",
             "description": null,
             "args": [],
@@ -3501,7 +3485,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNullable",
+                "name": "StringAggregateSelectionNonNullable",
                 "ofType": null
               }
             },
@@ -3517,7 +3501,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNullable",
+                "name": "StringAggregateSelectionNonNullable",
                 "ofType": null
               }
             },
@@ -3567,18 +3551,6 @@
         "name": "CohortComplete",
         "description": null,
         "fields": [
-          {
-            "name": "analyst",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
           {
             "name": "cohortsHasCohortComplete",
             "description": null,
@@ -3783,12 +3755,16 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             "isDeprecated": false,
@@ -3799,7 +3775,27 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
@@ -3811,25 +3807,17 @@
             "deprecationReason": null
           },
           {
-            "name": "projectSubtitle",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "projectTitle",
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3878,22 +3866,6 @@
         "description": null,
         "fields": [
           {
-            "name": "analyst",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "count",
             "description": null,
             "args": [],
@@ -3934,7 +3906,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNullable",
+                "name": "StringAggregateSelectionNonNullable",
                 "ofType": null
               }
             },
@@ -3950,7 +3922,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNullable",
+                "name": "StringAggregateSelectionNonNullable",
                 "ofType": null
               }
             },
@@ -5077,18 +5049,6 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "analyst",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "cohortsHasCohortComplete",
             "description": null,
             "type": {
@@ -5120,12 +5080,16 @@
             "name": "endUsers",
             "description": null,
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -5136,7 +5100,27 @@
             "name": "pmUsers",
             "description": null,
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
@@ -5149,24 +5133,16 @@
             "deprecationReason": null
           },
           {
-            "name": "projectSubtitle",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "projectTitle",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -5407,18 +5383,6 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "analyst",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortDirection",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "date",
             "description": null,
             "type": {
@@ -5489,18 +5453,6 @@
         "description": null,
         "fields": null,
         "inputFields": [
-          {
-            "name": "analyst",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
           {
             "name": "cohortsHasCohortComplete",
             "description": null,
@@ -5715,134 +5667,6 @@
                   "ofType": null
                 }
               }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_CONTAINS",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_ENDS_WITH",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_IN",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_NOT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_NOT_CONTAINS",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_NOT_ENDS_WITH",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_NOT_IN",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_NOT_STARTS_WITH",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_STARTS_WITH",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -6247,9 +6071,13 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -6299,9 +6127,13 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -6375,9 +6207,13 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -6427,9 +6263,13 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -7598,246 +7438,6 @@
                   "ofType": null
                 }
               }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "analyst_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -89,6 +89,8 @@ query FindSamplesByInputValue(
           billed
           billedBy
           costCenter
+          custodianInformation
+          accessLevel
           hasEventBamCompletes(options: $bamCompletesOptions) {
             date
             status


### PR DESCRIPTION
These changes surface additional fields in the Cohort Samples table.

Fields surfaced:
- custodianInformation (as Data Custodian)
- accessLevel (as Access Level)

These changes also included related updates to the graphql data schema 

![image](https://github.com/mskcc/smile-dashboard/assets/15623749/0d552999-599b-4116-ab52-92d082e6422a)
