### PR TITLE
Enable searching for `endUsers` and `pmUsers` fields on Cohorts page

### DIFF
--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -416,6 +416,8 @@ export type CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSel
   {
     __typename?: "CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSelection";
     date: StringAggregateSelectionNonNullable;
+    endUsers: StringAggregateSelectionNonNullable;
+    pmUsers: StringAggregateSelectionNonNullable;
     projectSubtitle: StringAggregateSelectionNonNullable;
     projectTitle: StringAggregateSelectionNonNullable;
     status: StringAggregateSelectionNonNullable;
@@ -428,8 +430,8 @@ export type CohortComplete = {
   cohortsHasCohortCompleteAggregate?: Maybe<CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection>;
   cohortsHasCohortCompleteConnection: CohortCompleteCohortsHasCohortCompleteConnection;
   date: Scalars["String"];
-  endUsers: Array<Maybe<Scalars["String"]>>;
-  pmUsers: Array<Maybe<Scalars["String"]>>;
+  endUsers: Scalars["String"];
+  pmUsers: Scalars["String"];
   projectSubtitle: Scalars["String"];
   projectTitle: Scalars["String"];
   status: Scalars["String"];
@@ -461,6 +463,8 @@ export type CohortCompleteAggregateSelection = {
   __typename?: "CohortCompleteAggregateSelection";
   count: Scalars["Int"];
   date: StringAggregateSelectionNonNullable;
+  endUsers: StringAggregateSelectionNonNullable;
+  pmUsers: StringAggregateSelectionNonNullable;
   projectSubtitle: StringAggregateSelectionNonNullable;
   projectTitle: StringAggregateSelectionNonNullable;
   status: StringAggregateSelectionNonNullable;
@@ -607,8 +611,8 @@ export type CohortCompleteConnectWhere = {
 export type CohortCompleteCreateInput = {
   cohortsHasCohortComplete?: InputMaybe<CohortCompleteCohortsHasCohortCompleteFieldInput>;
   date: Scalars["String"];
-  endUsers: Array<InputMaybe<Scalars["String"]>>;
-  pmUsers: Array<InputMaybe<Scalars["String"]>>;
+  endUsers: Scalars["String"];
+  pmUsers: Scalars["String"];
   projectSubtitle: Scalars["String"];
   projectTitle: Scalars["String"];
   status: Scalars["String"];
@@ -649,6 +653,8 @@ export type CohortCompleteRelationInput = {
 /** Fields to sort CohortCompletes by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortCompleteSort object. */
 export type CohortCompleteSort = {
   date?: InputMaybe<SortDirection>;
+  endUsers?: InputMaybe<SortDirection>;
+  pmUsers?: InputMaybe<SortDirection>;
   projectSubtitle?: InputMaybe<SortDirection>;
   projectTitle?: InputMaybe<SortDirection>;
   status?: InputMaybe<SortDirection>;
@@ -660,12 +666,8 @@ export type CohortCompleteUpdateInput = {
     Array<CohortCompleteCohortsHasCohortCompleteUpdateFieldInput>
   >;
   date?: InputMaybe<Scalars["String"]>;
-  endUsers?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  endUsers_POP?: InputMaybe<Scalars["Int"]>;
-  endUsers_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pmUsers?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pmUsers_POP?: InputMaybe<Scalars["Int"]>;
-  pmUsers_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  endUsers?: InputMaybe<Scalars["String"]>;
+  pmUsers?: InputMaybe<Scalars["String"]>;
   projectSubtitle?: InputMaybe<Scalars["String"]>;
   projectTitle?: InputMaybe<Scalars["String"]>;
   status?: InputMaybe<Scalars["String"]>;
@@ -698,14 +700,26 @@ export type CohortCompleteWhere = {
   date_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   date_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  endUsers?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  endUsers_INCLUDES?: InputMaybe<Scalars["String"]>;
-  endUsers_NOT?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  endUsers_NOT_INCLUDES?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pmUsers_INCLUDES?: InputMaybe<Scalars["String"]>;
-  pmUsers_NOT?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pmUsers_NOT_INCLUDES?: InputMaybe<Scalars["String"]>;
+  endUsers?: InputMaybe<Scalars["String"]>;
+  endUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
+  endUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers_IN?: InputMaybe<Array<Scalars["String"]>>;
+  endUsers_NOT?: InputMaybe<Scalars["String"]>;
+  endUsers_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  endUsers_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  endUsers_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers?: InputMaybe<Scalars["String"]>;
+  pmUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
+  pmUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers_IN?: InputMaybe<Array<Scalars["String"]>>;
+  pmUsers_NOT?: InputMaybe<Scalars["String"]>;
+  pmUsers_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  pmUsers_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  pmUsers_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   projectSubtitle?: InputMaybe<Scalars["String"]>;
   projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]>;
   projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
@@ -884,6 +898,46 @@ export type CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput = {
   date_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   date_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   date_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  endUsers_EQUAL?: InputMaybe<Scalars["String"]>;
+  endUsers_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  pmUsers_EQUAL?: InputMaybe<Scalars["String"]>;
+  pmUsers_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   projectSubtitle_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   projectSubtitle_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   projectSubtitle_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -11566,8 +11620,8 @@ export type CohortsListQuery = {
     hasCohortCompleteCohortCompletes: Array<{
       __typename?: "CohortComplete";
       type: string;
-      endUsers: Array<string | null>;
-      pmUsers: Array<string | null>;
+      endUsers: string;
+      pmUsers: string;
       projectTitle: string;
       projectSubtitle: string;
       status: string;

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -1,6 +1,5 @@
 import {
   CohortCompleteOptions,
-  CohortCompleteWhere,
   CohortWhere,
   SampleWhere,
   SortDirection,
@@ -73,7 +72,9 @@ function cohortFilterWhereVariables(parsedSearchVals: string[]): CohortWhere[] {
     });
 
     return whereVariables;
-  } else {
+  }
+
+  if (parsedSearchVals.length === 1) {
     return [
       { cohortId_CONTAINS: parsedSearchVals[0] },
       {
@@ -120,6 +121,8 @@ function cohortFilterWhereVariables(parsedSearchVals: string[]): CohortWhere[] {
       },
     ];
   }
+
+  return [];
 }
 
 interface ICohortsPageProps {

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -1,5 +1,6 @@
 import {
   CohortCompleteOptions,
+  CohortCompleteWhere,
   CohortWhere,
   SampleWhere,
   SortDirection,
@@ -20,21 +21,11 @@ import { PageHeader } from "../../shared/components/PageHeader";
 
 function cohortFilterWhereVariables(parsedSearchVals: string[]): CohortWhere[] {
   if (parsedSearchVals.length > 1) {
-    return [
+    const whereVariables: CohortWhere[] = [
       { cohortId_IN: parsedSearchVals },
       {
         hasCohortCompleteCohortCompletes_SOME: {
           type_IN: parsedSearchVals,
-        },
-      },
-      {
-        hasCohortCompleteCohortCompletes_SOME: {
-          endUsers_INCLUDES: parsedSearchVals[0],
-        },
-      },
-      {
-        hasCohortCompleteCohortCompletes_SOME: {
-          pmUsers_INCLUDES: parsedSearchVals[0],
         },
       },
       {
@@ -65,6 +56,23 @@ function cohortFilterWhereVariables(parsedSearchVals: string[]): CohortWhere[] {
         },
       },
     ];
+
+    // Enable fuzzy search for these fields instead of exact match
+    // because their value type in the DB is a string
+    parsedSearchVals.forEach((val) => {
+      whereVariables.push({
+        hasCohortCompleteCohortCompletes_SOME: {
+          endUsers_CONTAINS: val,
+        },
+      });
+      whereVariables.push({
+        hasCohortCompleteCohortCompletes_SOME: {
+          pmUsers_CONTAINS: val,
+        },
+      });
+    });
+
+    return whereVariables;
   } else {
     return [
       { cohortId_CONTAINS: parsedSearchVals[0] },
@@ -75,12 +83,12 @@ function cohortFilterWhereVariables(parsedSearchVals: string[]): CohortWhere[] {
       },
       {
         hasCohortCompleteCohortCompletes_SOME: {
-          endUsers_INCLUDES: parsedSearchVals[0],
+          endUsers_CONTAINS: parsedSearchVals[0],
         },
       },
       {
         hasCohortCompleteCohortCompletes_SOME: {
-          pmUsers_INCLUDES: parsedSearchVals[0],
+          pmUsers_CONTAINS: parsedSearchVals[0],
         },
       },
       {

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -47,7 +47,9 @@ function patientFilterWhereVariables(
         },
       },
     ];
-  } else {
+  }
+
+  if (parsedSearchVals.length === 1) {
     return [
       {
         patientAliasesIsAlias_SOME: {
@@ -63,6 +65,8 @@ function patientFilterWhereVariables(
       },
     ];
   }
+
+  return [];
 }
 
 function addCDashToCMOId(cmoId: string): string {

--- a/frontend/src/pages/requests/RequestsPage.tsx
+++ b/frontend/src/pages/requests/RequestsPage.tsx
@@ -35,7 +35,9 @@ function requestFilterWhereVariables(
       { dataAccessEmails_IN: parsedSearchVals },
       { otherContactEmails_IN: parsedSearchVals },
     ];
-  } else {
+  }
+
+  if (parsedSearchVals.length === 1) {
     return [
       { igoProjectId_CONTAINS: parsedSearchVals[0] },
       { igoRequestId_CONTAINS: parsedSearchVals[0] },
@@ -53,6 +55,8 @@ function requestFilterWhereVariables(
       { otherContactEmails_CONTAINS: parsedSearchVals[0] },
     ];
   }
+
+  return [];
 }
 
 export default function RequestsPage() {

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -857,7 +857,9 @@ export function sampleFilterWhereVariables(
       { species_IN: parsedSearchVals },
       { genePanel_IN: parsedSearchVals },
     ];
-  } else {
+  }
+
+  if (parsedSearchVals.length === 1) {
     return [
       { cmoSampleName_CONTAINS: parsedSearchVals[0] },
       { importDate_CONTAINS: parsedSearchVals[0] },
@@ -880,6 +882,8 @@ export function sampleFilterWhereVariables(
       { genePanel_CONTAINS: parsedSearchVals[0] },
     ];
   }
+
+  return [];
 }
 
 export function cohortSampleFilterWhereVariables(

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -1045,9 +1045,13 @@ export function prepareSampleCohortDataForAgGrid(samples: Sample[]) {
       });
     });
     const deliveryDate = cohortDates?.sort()[0]; // earliest cohort date
-    let embargoDateAsDate = new Date(deliveryDate);
-    embargoDateAsDate.setMonth(embargoDateAsDate.getMonth() + 18); // embargo date is 18 months post earliest delivery date
-    const embargoDate = moment(embargoDateAsDate).format("YYYY-MM-DD");
+
+    let embargoDate;
+    if (deliveryDate !== undefined) {
+      let embargoDateAsDate = new Date(deliveryDate);
+      embargoDateAsDate.setMonth(embargoDateAsDate.getMonth() + 18);
+      embargoDate = moment(embargoDateAsDate).format("YYYY-MM-DD");
+    }
 
     const tempo = s.hasTempoTempos?.[0];
     const { billedBy, costCenter, custodianInformation, accessLevel } =

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -415,6 +415,8 @@ export type CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSel
   {
     __typename?: "CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSelection";
     date: StringAggregateSelectionNonNullable;
+    endUsers: StringAggregateSelectionNonNullable;
+    pmUsers: StringAggregateSelectionNonNullable;
     projectSubtitle: StringAggregateSelectionNonNullable;
     projectTitle: StringAggregateSelectionNonNullable;
     status: StringAggregateSelectionNonNullable;
@@ -427,8 +429,8 @@ export type CohortComplete = {
   cohortsHasCohortCompleteAggregate?: Maybe<CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection>;
   cohortsHasCohortCompleteConnection: CohortCompleteCohortsHasCohortCompleteConnection;
   date: Scalars["String"];
-  endUsers: Array<Maybe<Scalars["String"]>>;
-  pmUsers: Array<Maybe<Scalars["String"]>>;
+  endUsers: Scalars["String"];
+  pmUsers: Scalars["String"];
   projectSubtitle: Scalars["String"];
   projectTitle: Scalars["String"];
   status: Scalars["String"];
@@ -460,6 +462,8 @@ export type CohortCompleteAggregateSelection = {
   __typename?: "CohortCompleteAggregateSelection";
   count: Scalars["Int"];
   date: StringAggregateSelectionNonNullable;
+  endUsers: StringAggregateSelectionNonNullable;
+  pmUsers: StringAggregateSelectionNonNullable;
   projectSubtitle: StringAggregateSelectionNonNullable;
   projectTitle: StringAggregateSelectionNonNullable;
   status: StringAggregateSelectionNonNullable;
@@ -606,8 +610,8 @@ export type CohortCompleteConnectWhere = {
 export type CohortCompleteCreateInput = {
   cohortsHasCohortComplete?: InputMaybe<CohortCompleteCohortsHasCohortCompleteFieldInput>;
   date: Scalars["String"];
-  endUsers: Array<InputMaybe<Scalars["String"]>>;
-  pmUsers: Array<InputMaybe<Scalars["String"]>>;
+  endUsers: Scalars["String"];
+  pmUsers: Scalars["String"];
   projectSubtitle: Scalars["String"];
   projectTitle: Scalars["String"];
   status: Scalars["String"];
@@ -648,6 +652,8 @@ export type CohortCompleteRelationInput = {
 /** Fields to sort CohortCompletes by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortCompleteSort object. */
 export type CohortCompleteSort = {
   date?: InputMaybe<SortDirection>;
+  endUsers?: InputMaybe<SortDirection>;
+  pmUsers?: InputMaybe<SortDirection>;
   projectSubtitle?: InputMaybe<SortDirection>;
   projectTitle?: InputMaybe<SortDirection>;
   status?: InputMaybe<SortDirection>;
@@ -659,12 +665,8 @@ export type CohortCompleteUpdateInput = {
     Array<CohortCompleteCohortsHasCohortCompleteUpdateFieldInput>
   >;
   date?: InputMaybe<Scalars["String"]>;
-  endUsers?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  endUsers_POP?: InputMaybe<Scalars["Int"]>;
-  endUsers_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pmUsers?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pmUsers_POP?: InputMaybe<Scalars["Int"]>;
-  pmUsers_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  endUsers?: InputMaybe<Scalars["String"]>;
+  pmUsers?: InputMaybe<Scalars["String"]>;
   projectSubtitle?: InputMaybe<Scalars["String"]>;
   projectTitle?: InputMaybe<Scalars["String"]>;
   status?: InputMaybe<Scalars["String"]>;
@@ -697,14 +699,26 @@ export type CohortCompleteWhere = {
   date_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   date_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  endUsers?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  endUsers_INCLUDES?: InputMaybe<Scalars["String"]>;
-  endUsers_NOT?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  endUsers_NOT_INCLUDES?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pmUsers_INCLUDES?: InputMaybe<Scalars["String"]>;
-  pmUsers_NOT?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pmUsers_NOT_INCLUDES?: InputMaybe<Scalars["String"]>;
+  endUsers?: InputMaybe<Scalars["String"]>;
+  endUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
+  endUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers_IN?: InputMaybe<Array<Scalars["String"]>>;
+  endUsers_NOT?: InputMaybe<Scalars["String"]>;
+  endUsers_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  endUsers_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  endUsers_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers?: InputMaybe<Scalars["String"]>;
+  pmUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
+  pmUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers_IN?: InputMaybe<Array<Scalars["String"]>>;
+  pmUsers_NOT?: InputMaybe<Scalars["String"]>;
+  pmUsers_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  pmUsers_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  pmUsers_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   projectSubtitle?: InputMaybe<Scalars["String"]>;
   projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]>;
   projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
@@ -883,6 +897,46 @@ export type CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput = {
   date_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   date_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   date_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  endUsers_EQUAL?: InputMaybe<Scalars["String"]>;
+  endUsers_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  pmUsers_EQUAL?: InputMaybe<Scalars["String"]>;
+  pmUsers_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   projectSubtitle_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   projectSubtitle_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   projectSubtitle_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -11565,8 +11619,8 @@ export type CohortsListQuery = {
     hasCohortCompleteCohortCompletes: Array<{
       __typename?: "CohortComplete";
       type: string;
-      endUsers: Array<string | null>;
-      pmUsers: Array<string | null>;
+      endUsers: string;
+      pmUsers: string;
       projectTitle: string;
       projectSubtitle: string;
       status: string;

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -3733,6 +3733,38 @@
             "deprecationReason": null
           },
           {
+            "name": "endUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "projectSubtitle",
             "description": null,
             "args": [],
@@ -4014,13 +4046,9 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -4034,13 +4062,9 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -4139,6 +4163,38 @@
           },
           {
             "name": "date",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers",
             "description": null,
             "args": [],
             "type": {
@@ -5339,13 +5395,9 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "defaultValue": null,
@@ -5359,13 +5411,9 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "defaultValue": null,
@@ -5651,6 +5699,30 @@
             "deprecationReason": null
           },
           {
+            "name": "endUsers",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "projectSubtitle",
             "description": null,
             "type": {
@@ -5745,41 +5817,9 @@
             "name": "endUsers",
             "description": null,
             "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "endUsers_POP",
-            "description": null,
-            "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "String",
               "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "endUsers_PUSH",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -5789,41 +5829,9 @@
             "name": "pmUsers",
             "description": null,
             "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pmUsers_POP",
-            "description": null,
-            "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "String",
               "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pmUsers_PUSH",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -6176,20 +6184,16 @@
             "name": "endUsers",
             "description": null,
             "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "endUsers_INCLUDES",
+            "name": "endUsers_CONTAINS",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -6201,15 +6205,31 @@
             "deprecationReason": null
           },
           {
-            "name": "endUsers_NOT",
+            "name": "endUsers_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_IN",
             "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -6217,7 +6237,75 @@
             "deprecationReason": null
           },
           {
-            "name": "endUsers_NOT_INCLUDES",
+            "name": "endUsers_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_STARTS_WITH",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -6232,20 +6320,16 @@
             "name": "pmUsers",
             "description": null,
             "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "pmUsers_INCLUDES",
+            "name": "pmUsers_CONTAINS",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -6257,15 +6341,31 @@
             "deprecationReason": null
           },
           {
-            "name": "pmUsers_NOT",
+            "name": "pmUsers_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_IN",
             "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -6273,7 +6373,75 @@
             "deprecationReason": null
           },
           {
-            "name": "pmUsers_NOT_INCLUDES",
+            "name": "pmUsers_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_STARTS_WITH",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -7929,6 +8097,486 @@
           },
           {
             "name": "date_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",


### PR DESCRIPTION
This PR addresses mskcc/smile-server#1124 and mskcc/smile-server#1110:

For mskcc/smile-server#1124, this PR enables fuzzy search for `endUsers` and `pmUsers` fields for **both** single-value and bulk searches.


https://github.com/mskcc/smile-dashboard/assets/86090707/11f0591f-9352-41c4-b678-160e28e2c53f

Note that mskcc/smile-server#1110 has been unintentionally handled by a previous PR. Demo: [this page](https://smile-dev.mskcc.org:3006/cohorts/CCS_PPPQQQQ_2) doesn't break even though the sample has no Tempo events.