### PR TITLE
Add Tempo fields to the Samples page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,9 +27,11 @@ export default function App() {
           <Route path="/" element={<RequestsPage />}>
             <Route path=":igoRequestId" />
           </Route>
+
           <Route path="/requests/" element={<RequestsPage />}>
             <Route path=":igoRequestId" />
           </Route>
+
           <Route
             path="/patients/"
             element={
@@ -38,7 +40,14 @@ export default function App() {
           >
             <Route path=":smilePatientId" />
           </Route>
-          <Route path="/samples" element={<SamplesPage />} />
+
+          <Route
+            path="/samples"
+            element={
+              <SamplesPage userEmail={userEmail} setUserEmail={setUserEmail} />
+            }
+          />
+
           <Route
             path="/cohorts/"
             element={
@@ -47,6 +56,7 @@ export default function App() {
           >
             <Route path=":cohortId" />
           </Route>
+
           <Route path="/auth/login-success" element={<LoginSuccessPage />} />
         </>
       </Routes>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,11 +27,9 @@ export default function App() {
           <Route path="/" element={<RequestsPage />}>
             <Route path=":igoRequestId" />
           </Route>
-
           <Route path="/requests/" element={<RequestsPage />}>
             <Route path=":igoRequestId" />
           </Route>
-
           <Route
             path="/patients/"
             element={
@@ -40,14 +38,7 @@ export default function App() {
           >
             <Route path=":smilePatientId" />
           </Route>
-
-          <Route
-            path="/samples"
-            element={
-              <SamplesPage userEmail={userEmail} setUserEmail={setUserEmail} />
-            }
-          />
-
+          <Route path="/samples" element={<SamplesPage />} />
           <Route
             path="/cohorts/"
             element={
@@ -56,7 +47,6 @@ export default function App() {
           >
             <Route path=":cohortId" />
           </Route>
-
           <Route path="/auth/login-success" element={<LoginSuccessPage />} />
         </>
       </Routes>

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -15,7 +15,7 @@ import InfoIcon from "@material-ui/icons/InfoOutlined";
 import { parseUserSearchVal } from "../../utils/parseSearchQueries";
 import {
   PatientsListColumns,
-  SampleDetailsColumns,
+  SampleMetadataDetailsColumns,
   preparePatientDataForAgGrid,
   sampleFilterWhereVariables,
 } from "../../shared/helpers";
@@ -269,7 +269,7 @@ export default function PatientsPage({
           });
           setShowDownloadModal(true);
         }}
-        samplesColDefs={SampleDetailsColumns}
+        samplesColDefs={SampleMetadataDetailsColumns}
         samplesQueryParam={sampleQueryParamValue && "Patient's Samples"}
         samplesParentWhereVariables={
           {

--- a/frontend/src/pages/requests/RequestsPage.tsx
+++ b/frontend/src/pages/requests/RequestsPage.tsx
@@ -6,7 +6,7 @@ import {
 import { useState } from "react";
 import {
   RequestsListColumns,
-  SampleDetailsColumns,
+  SampleMetadataDetailsColumns,
   prepareSampleMetadataForAgGrid,
   handleSearch,
   sampleFilterWhereVariables,
@@ -87,7 +87,7 @@ export default function RequestsPage() {
         showDownloadModal={showDownloadModal}
         setShowDownloadModal={setShowDownloadModal}
         handleDownload={() => setShowDownloadModal(true)}
-        samplesColDefs={SampleDetailsColumns}
+        samplesColDefs={SampleMetadataDetailsColumns}
         samplesQueryParam={
           sampleQueryParamValue &&
           `${sampleQueryParamHeaderName} "${sampleQueryParamValue}"`

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -1,8 +1,8 @@
 import { PageHeader } from "../../shared/components/PageHeader";
 import SamplesList from "../../components/SamplesList";
 import {
-  SampleDetailsColumns,
-  prepareSampleMetadataForAgGrid,
+  combinedSampleDetailsColumns,
+  prepareCombinedSampleDataForAgGrid,
   sampleFilterWhereVariables,
 } from "../../shared/helpers";
 import { SampleWhere } from "../../generated/graphql";
@@ -13,8 +13,8 @@ export default function SamplesPage() {
       <PageHeader dataName={"samples"} />
 
       <SamplesList
-        columnDefs={SampleDetailsColumns}
-        prepareDataForAgGrid={prepareSampleMetadataForAgGrid}
+        columnDefs={combinedSampleDetailsColumns}
+        prepareDataForAgGrid={prepareCombinedSampleDataForAgGrid}
         refetchWhereVariables={(parsedSearchVals) => {
           return {
             hasMetadataSampleMetadata_SOME: {

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -1,4 +1,3 @@
-import { Dispatch, SetStateAction } from "react";
 import { PageHeader } from "../../shared/components/PageHeader";
 import SamplesList from "../../components/SamplesList";
 import {
@@ -9,15 +8,7 @@ import {
 } from "../../shared/helpers";
 import { SampleWhere } from "../../generated/graphql";
 
-interface ISamplesPageProps {
-  userEmail: string | null;
-  setUserEmail: Dispatch<SetStateAction<string | null>>;
-}
-
-export default function SamplesPage({
-  userEmail,
-  setUserEmail,
-}: ISamplesPageProps) {
+export default function SamplesPage() {
   return (
     <>
       <PageHeader dataName={"samples"} />
@@ -34,8 +25,6 @@ export default function SamplesPage({
             }),
           } as SampleWhere;
         }}
-        userEmail={userEmail}
-        setUserEmail={setUserEmail}
       />
     </>
   );

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -1,13 +1,23 @@
+import { Dispatch, SetStateAction } from "react";
 import { PageHeader } from "../../shared/components/PageHeader";
 import SamplesList from "../../components/SamplesList";
 import {
+  cohortSampleFilterWhereVariables,
   combinedSampleDetailsColumns,
   prepareCombinedSampleDataForAgGrid,
   sampleFilterWhereVariables,
 } from "../../shared/helpers";
 import { SampleWhere } from "../../generated/graphql";
 
-export default function SamplesPage() {
+interface ISamplesPageProps {
+  userEmail: string | null;
+  setUserEmail: Dispatch<SetStateAction<string | null>>;
+}
+
+export default function SamplesPage({
+  userEmail,
+  setUserEmail,
+}: ISamplesPageProps) {
   return (
     <>
       <PageHeader dataName={"samples"} />
@@ -17,11 +27,15 @@ export default function SamplesPage() {
         prepareDataForAgGrid={prepareCombinedSampleDataForAgGrid}
         refetchWhereVariables={(parsedSearchVals) => {
           return {
-            hasMetadataSampleMetadata_SOME: {
-              OR: sampleFilterWhereVariables(parsedSearchVals),
-            },
+            OR: cohortSampleFilterWhereVariables(parsedSearchVals).concat({
+              hasMetadataSampleMetadata_SOME: {
+                OR: sampleFilterWhereVariables(parsedSearchVals),
+              },
+            }),
           } as SampleWhere;
         }}
+        userEmail={userEmail}
+        setUserEmail={setUserEmail}
       />
     </>
   );

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -911,6 +911,12 @@ export function cohortSampleFilterWhereVariables(
         costCenter_IN: parsedSearchVals,
       },
       {
+        custodianInformation_IN: parsedSearchVals,
+      },
+      {
+        accessLevel_IN: parsedSearchVals,
+      },
+      {
         hasEventBamCompletes_SOME: {
           date_IN: parsedSearchVals,
         },
@@ -963,6 +969,12 @@ export function cohortSampleFilterWhereVariables(
       },
       {
         costCenter_CONTAINS: parsedSearchVals[0],
+      },
+      {
+        custodianInformation_CONTAINS: parsedSearchVals[0],
+      },
+      {
+        accessLevel_CONTAINS: parsedSearchVals[0],
       },
       {
         hasEventBamCompletes_SOME: {

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -271,7 +271,7 @@ function LoadingIcon() {
   );
 }
 
-export const SampleDetailsColumns: ColDef<SampleMetadataExtended>[] = [
+export const SampleMetadataDetailsColumns: ColDef<SampleMetadataExtended>[] = [
   {
     field: "primaryId",
     headerName: "Primary ID",
@@ -804,8 +804,20 @@ export const CohortSampleDetailsColumns: ColDef[] = [
   },
 ];
 
-setupEditableSampleFields(SampleDetailsColumns);
+setupEditableSampleFields(SampleMetadataDetailsColumns);
 setupEditableSampleFields(CohortSampleDetailsColumns);
+
+const seenColumns = new Set();
+export const combinedSampleDetailsColumns = [
+  ...SampleMetadataDetailsColumns,
+  ...CohortSampleDetailsColumns,
+].filter((col) => {
+  if (seenColumns.has(col.field)) {
+    return false;
+  }
+  seenColumns.add(col.field);
+  return true;
+});
 
 export const defaultColDef: ColDef = {
   sortable: true,
@@ -1046,6 +1058,19 @@ export function prepareSampleCohortDataForAgGrid(samples: Sample[]) {
       cmoSampleName: sampleMetadata.cmoSampleName,
       hasStatusStatuses: sampleMetadata.hasStatusStatuses,
       revisable: s.revisable,
+      ...tempoData,
+    };
+  });
+}
+
+export function prepareCombinedSampleDataForAgGrid(samples: Sample[]) {
+  return samples.map((s) => {
+    const sampleMetadata = s.hasMetadataSampleMetadata[0];
+    const tempoData = extractTempoFromSample(s);
+
+    return {
+      revisable: s.revisable,
+      ...sampleMetadata,
       ...tempoData,
     };
   });

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -193,8 +193,6 @@ async function publishNatsMessageForSampleBillingUpdates(
     custodianInformation,
   };
 
-  console.log("dataForTempoBillingUpdate: ", dataForTempoBillingUpdate);
-
   publishNatsMessage(
     props.pub_tempo_sample_billing,
     JSON.stringify(dataForTempoBillingUpdate)


### PR DESCRIPTION
This PR adds additional Tempo-related fields to the table on Samples page. Note that while these Tempo fields are editable on the Cohort Sample view, these fields are read-only on the Samples page.

https://github.com/mskcc/smile-dashboard/assets/86090707/12306735-c104-4113-bcfb-54255c059b0a

