### PR TITLE
Filter SampleMetadata and Tempo fields on Samples page via tabs

### DIFF
--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -276,7 +276,7 @@ export default function RecordsList({
               })`
         }`}
         handleDownload={handleDownload}
-        customUI={customToolbarUI}
+        customUIRight={customToolbarUI}
       />
 
       <AutoSizer>

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -39,7 +39,6 @@ const costCenterAlertContent =
 
 interface ISampleListProps {
   columnDefs: ColDef[];
-  setColumnDefs?: Dispatch<SetStateAction<ColDef[]>>;
   prepareDataForAgGrid: (samples: Sample[]) => any[];
   setUnsavedChanges?: (unsavedChanges: boolean) => void;
   parentWhereVariables?: SampleWhere;
@@ -48,11 +47,11 @@ interface ISampleListProps {
   sampleKeyForUpdate?: keyof Sample;
   userEmail?: string | null;
   setUserEmail?: Dispatch<SetStateAction<string | null>>;
+  customToolbarUI?: JSX.Element;
 }
 
 export default function SamplesList({
   columnDefs,
-  setColumnDefs,
   prepareDataForAgGrid,
   parentWhereVariables,
   refetchWhereVariables,
@@ -61,6 +60,7 @@ export default function SamplesList({
   sampleKeyForUpdate = "hasMetadataSampleMetadata",
   userEmail,
   setUserEmail,
+  customToolbarUI,
 }: ISampleListProps) {
   const { loading, error, data, startPolling, stopPolling, refetch } =
     useFindSamplesByInputValueQuery({
@@ -292,20 +292,18 @@ export default function SamplesList({
             : `${rowCount} matching samples`
         }
         handleDownload={() => setShowDownloadModal(true)}
-        customUI={
+        customUILeft={customToolbarUI}
+        customUIRight={
           changes.length > 0 ? (
             <>
-              <Col className={"text-end"}>
+              <Col md="auto">
                 <Button
                   className={"btn btn-secondary"}
                   onClick={handleDiscardChanges}
                   size={"sm"}
                 >
                   Discard Changes
-                </Button>
-              </Col>
-
-              <Col className={"text-start"}>
+                </Button>{" "}
                 <Button
                   className={"btn btn-success"}
                   disabled={alertContent === costCenterAlertContent}
@@ -320,7 +318,6 @@ export default function SamplesList({
             </>
           ) : undefined
         }
-        setColumnDefs={setColumnDefs}
       />
 
       <AutoSizer>

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -39,6 +39,7 @@ const costCenterAlertContent =
 
 interface ISampleListProps {
   columnDefs: ColDef[];
+  setColumnDefs?: Dispatch<SetStateAction<ColDef[]>>;
   prepareDataForAgGrid: (samples: Sample[]) => any[];
   setUnsavedChanges?: (unsavedChanges: boolean) => void;
   parentWhereVariables?: SampleWhere;
@@ -51,6 +52,7 @@ interface ISampleListProps {
 
 export default function SamplesList({
   columnDefs,
+  setColumnDefs,
   prepareDataForAgGrid,
   parentWhereVariables,
   refetchWhereVariables,
@@ -318,6 +320,7 @@ export default function SamplesList({
             </>
           ) : undefined
         }
+        setColumnDefs={setColumnDefs}
       />
 
       <AutoSizer>

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -1,6 +1,8 @@
 import { PageHeader } from "../../shared/components/PageHeader";
 import SamplesList from "../../components/SamplesList";
 import {
+  ReadOnlyCohortSampleDetailsColumns,
+  SampleMetadataDetailsColumns,
   cohortSampleFilterWhereVariables,
   combinedSampleDetailsColumns,
   prepareCombinedSampleDataForAgGrid,
@@ -8,6 +10,7 @@ import {
 } from "../../shared/helpers";
 import { SampleWhere } from "../../generated/graphql";
 import { useState } from "react";
+import { Button } from "react-bootstrap";
 
 export default function SamplesPage() {
   const [columnDefs, setColumnDefs] = useState(combinedSampleDetailsColumns);
@@ -18,7 +21,6 @@ export default function SamplesPage() {
 
       <SamplesList
         columnDefs={columnDefs}
-        setColumnDefs={setColumnDefs}
         prepareDataForAgGrid={prepareCombinedSampleDataForAgGrid}
         refetchWhereVariables={(parsedSearchVals) => {
           return {
@@ -29,6 +31,37 @@ export default function SamplesPage() {
             }),
           } as SampleWhere;
         }}
+        customToolbarUI={
+          <>
+            <Button
+              onClick={() => {
+                setColumnDefs(SampleMetadataDetailsColumns);
+              }}
+              size="sm"
+              variant="outline-secondary"
+            >
+              View SampleMetadata
+            </Button>{" "}
+            <Button
+              onClick={() => {
+                setColumnDefs(ReadOnlyCohortSampleDetailsColumns);
+              }}
+              size="sm"
+              variant="outline-secondary"
+            >
+              View Tempo
+            </Button>{" "}
+            <Button
+              onClick={() => {
+                setColumnDefs(combinedSampleDetailsColumns);
+              }}
+              size="sm"
+              variant="outline-secondary"
+            >
+              View all
+            </Button>
+          </>
+        }
       />
     </>
   );

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -11,6 +11,7 @@ import {
 import { SampleWhere } from "../../generated/graphql";
 import { useState } from "react";
 import { Button } from "react-bootstrap";
+import _ from "lodash";
 
 export default function SamplesPage() {
   const [columnDefs, setColumnDefs] = useState(combinedSampleDetailsColumns);
@@ -39,6 +40,7 @@ export default function SamplesPage() {
               }}
               size="sm"
               variant="outline-secondary"
+              active={_.isEqual(columnDefs, SampleMetadataDetailsColumns)}
             >
               View SampleMetadata
             </Button>{" "}
@@ -48,6 +50,7 @@ export default function SamplesPage() {
               }}
               size="sm"
               variant="outline-secondary"
+              active={_.isEqual(columnDefs, ReadOnlyCohortSampleDetailsColumns)}
             >
               View Tempo
             </Button>{" "}
@@ -57,6 +60,7 @@ export default function SamplesPage() {
               }}
               size="sm"
               variant="outline-secondary"
+              active={_.isEqual(columnDefs, combinedSampleDetailsColumns)}
             >
               View all
             </Button>

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -7,14 +7,18 @@ import {
   sampleFilterWhereVariables,
 } from "../../shared/helpers";
 import { SampleWhere } from "../../generated/graphql";
+import { useState } from "react";
 
 export default function SamplesPage() {
+  const [columnDefs, setColumnDefs] = useState(combinedSampleDetailsColumns);
+
   return (
     <>
       <PageHeader dataName={"samples"} />
 
       <SamplesList
-        columnDefs={combinedSampleDetailsColumns}
+        columnDefs={columnDefs}
+        setColumnDefs={setColumnDefs}
         prepareDataForAgGrid={prepareCombinedSampleDataForAgGrid}
         refetchWhereVariables={(parsedSearchVals) => {
           return {

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -2,7 +2,6 @@ import { PageHeader } from "../../shared/components/PageHeader";
 import SamplesList from "../../components/SamplesList";
 import {
   ReadOnlyCohortSampleDetailsColumns,
-  SampleMetadataDetailsColumns,
   cohortSampleFilterWhereVariables,
   combinedSampleDetailsColumns,
   prepareCombinedSampleDataForAgGrid,
@@ -12,6 +11,7 @@ import { SampleWhere } from "../../generated/graphql";
 import { useState } from "react";
 import { Button } from "react-bootstrap";
 import _ from "lodash";
+import { InfoToolTip } from "../../shared/components/InfoToolTip";
 
 export default function SamplesPage() {
   const [columnDefs, setColumnDefs] = useState(combinedSampleDetailsColumns);
@@ -34,26 +34,11 @@ export default function SamplesPage() {
         }}
         customToolbarUI={
           <>
-            <Button
-              onClick={() => {
-                setColumnDefs(SampleMetadataDetailsColumns);
-              }}
-              size="sm"
-              variant="outline-secondary"
-              active={_.isEqual(columnDefs, SampleMetadataDetailsColumns)}
-            >
-              View SampleMetadata
-            </Button>{" "}
-            <Button
-              onClick={() => {
-                setColumnDefs(ReadOnlyCohortSampleDetailsColumns);
-              }}
-              size="sm"
-              variant="outline-secondary"
-              active={_.isEqual(columnDefs, ReadOnlyCohortSampleDetailsColumns)}
-            >
-              View Tempo
-            </Button>{" "}
+            <InfoToolTip>
+              These tabs change the fields displayed in the table below. "View
+              All" shows all fields, including both SampleMetadata and Tempo
+              fields.
+            </InfoToolTip>{" "}
             <Button
               onClick={() => {
                 setColumnDefs(combinedSampleDetailsColumns);
@@ -63,6 +48,16 @@ export default function SamplesPage() {
               active={_.isEqual(columnDefs, combinedSampleDetailsColumns)}
             >
               View all
+            </Button>{" "}
+            <Button
+              onClick={() => {
+                setColumnDefs(ReadOnlyCohortSampleDetailsColumns);
+              }}
+              size="sm"
+              variant="outline-secondary"
+              active={_.isEqual(columnDefs, ReadOnlyCohortSampleDetailsColumns)}
+            >
+              Tempo fields
             </Button>
           </>
         }

--- a/frontend/src/shared/components/InfoToolTip.tsx
+++ b/frontend/src/shared/components/InfoToolTip.tsx
@@ -1,0 +1,10 @@
+import { Tooltip } from "@material-ui/core";
+import InfoIcon from "@material-ui/icons/InfoOutlined";
+
+export function InfoToolTip({ children }: { children: React.ReactNode }) {
+  return (
+    <Tooltip title={<span style={{ fontSize: 12 }}>{children}</span>}>
+      <InfoIcon style={{ fontSize: 18, color: "grey" }} />
+    </Tooltip>
+  );
+}

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -806,10 +806,28 @@ export const ReadOnlyCohortSampleDetailsColumns = _.cloneDeep(
 setupEditableSampleFields(SampleMetadataDetailsColumns);
 setupEditableSampleFields(CohortSampleDetailsColumns);
 
-export const combinedSampleDetailsColumns = _.uniqBy(
-  [...SampleMetadataDetailsColumns, ...ReadOnlyCohortSampleDetailsColumns],
-  "field"
-);
+export const combinedSampleDetailsColumns = [
+  {
+    marryChildren: true,
+    children: SampleMetadataDetailsColumns.filter((col) => {
+      return col.field === "primaryId" || col.field === "revisable";
+    }),
+  },
+  {
+    headerName: "SampleMetadata",
+    marryChildren: true,
+    children: SampleMetadataDetailsColumns.filter(
+      (col) => col.field !== "primaryId" && col.field !== "revisable"
+    ),
+  },
+  {
+    headerName: "Tempo",
+    marryChildren: true,
+    children: ReadOnlyCohortSampleDetailsColumns.filter(
+      (col) => col.field !== "primaryId" && col.field !== "cmoSampleName"
+    ),
+  },
+];
 
 export const defaultColDef: ColDef = {
   sortable: true,

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -806,28 +806,10 @@ export const ReadOnlyCohortSampleDetailsColumns = _.cloneDeep(
 setupEditableSampleFields(SampleMetadataDetailsColumns);
 setupEditableSampleFields(CohortSampleDetailsColumns);
 
-export const combinedSampleDetailsColumns = [
-  {
-    marryChildren: true,
-    children: SampleMetadataDetailsColumns.filter((col) => {
-      return col.field === "primaryId" || col.field === "revisable";
-    }),
-  },
-  {
-    headerName: "SampleMetadata",
-    marryChildren: true,
-    children: SampleMetadataDetailsColumns.filter(
-      (col) => col.field !== "primaryId" && col.field !== "revisable"
-    ),
-  },
-  {
-    headerName: "Tempo",
-    marryChildren: true,
-    children: ReadOnlyCohortSampleDetailsColumns.filter(
-      (col) => col.field !== "primaryId" && col.field !== "cmoSampleName"
-    ),
-  },
-];
+export const combinedSampleDetailsColumns = _.uniqBy(
+  [...SampleMetadataDetailsColumns, ...ReadOnlyCohortSampleDetailsColumns],
+  "field"
+);
 
 export const defaultColDef: ColDef = {
   sortable: true,

--- a/frontend/src/shared/tableElements.tsx
+++ b/frontend/src/shared/tableElements.tsx
@@ -5,13 +5,7 @@ import Spinner from "react-spinkit";
 import InfoIcon from "@material-ui/icons/InfoOutlined";
 import { Tooltip } from "@material-ui/core";
 import { DataName } from "./types";
-import { Dispatch, RefObject, SetStateAction } from "react";
-import { AgGridReact } from "ag-grid-react";
-import {
-  CohortSampleDetailsColumns,
-  SampleMetadataDetailsColumns,
-  combinedSampleDetailsColumns,
-} from "./helpers";
+import { Dispatch, SetStateAction } from "react";
 
 export function LoadingSpinner() {
   return (
@@ -37,8 +31,8 @@ interface IToolbarProps {
   clearUserSearchVal: () => void;
   matchingResultsCount: string;
   handleDownload: () => void;
-  customUI?: JSX.Element;
-  setColumnDefs?: Dispatch<SetStateAction<any[]>>;
+  customUILeft?: JSX.Element;
+  customUIRight?: JSX.Element;
 }
 
 export function Toolbar({
@@ -49,46 +43,12 @@ export function Toolbar({
   clearUserSearchVal,
   matchingResultsCount,
   handleDownload,
-  customUI,
-  setColumnDefs,
+  customUILeft,
+  customUIRight,
 }: IToolbarProps) {
   return (
     <Row className={classNames("d-flex align-items-center tableControlsRow")}>
-      <Col>
-        <Button
-          onClick={() => {
-            if (setColumnDefs) {
-              setColumnDefs(SampleMetadataDetailsColumns);
-            }
-          }}
-          size="sm"
-          variant="outline-secondary"
-        >
-          View SampleMetadata
-        </Button>{" "}
-        <Button
-          onClick={() => {
-            if (setColumnDefs) {
-              setColumnDefs(CohortSampleDetailsColumns);
-            }
-          }}
-          size="sm"
-          variant="outline-secondary"
-        >
-          View Tempo
-        </Button>{" "}
-        <Button
-          onClick={() => {
-            if (setColumnDefs) {
-              setColumnDefs(combinedSampleDetailsColumns);
-            }
-          }}
-          size="sm"
-          variant="outline-secondary"
-        >
-          View all
-        </Button>
-      </Col>
+      <Col>{customUILeft}</Col>
 
       <Col md="auto">
         <Form.Control
@@ -140,7 +100,7 @@ export function Toolbar({
 
       <Col md="auto">{matchingResultsCount}</Col>
 
-      {customUI}
+      {customUIRight}
 
       <Col className={"text-end"}>
         <Button onClick={handleDownload} size={"sm"}>

--- a/frontend/src/shared/tableElements.tsx
+++ b/frontend/src/shared/tableElements.tsx
@@ -5,7 +5,13 @@ import Spinner from "react-spinkit";
 import InfoIcon from "@material-ui/icons/InfoOutlined";
 import { Tooltip } from "@material-ui/core";
 import { DataName } from "./types";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, RefObject, SetStateAction } from "react";
+import { AgGridReact } from "ag-grid-react";
+import {
+  CohortSampleDetailsColumns,
+  SampleMetadataDetailsColumns,
+  combinedSampleDetailsColumns,
+} from "./helpers";
 
 export function LoadingSpinner() {
   return (
@@ -23,6 +29,18 @@ export function ErrorMessage({ error }: { error: ApolloError }) {
   );
 }
 
+interface IToolbarProps {
+  dataName: DataName;
+  userSearchVal: string;
+  setUserSearchVal: Dispatch<SetStateAction<string>>;
+  handleSearch: () => void;
+  clearUserSearchVal: () => void;
+  matchingResultsCount: string;
+  handleDownload: () => void;
+  customUI?: JSX.Element;
+  setColumnDefs?: Dispatch<SetStateAction<any[]>>;
+}
+
 export function Toolbar({
   dataName,
   userSearchVal,
@@ -32,23 +50,45 @@ export function Toolbar({
   matchingResultsCount,
   handleDownload,
   customUI,
-}: {
-  dataName: DataName;
-  userSearchVal: string;
-  setUserSearchVal: Dispatch<SetStateAction<string>>;
-  handleSearch: () => void;
-  clearUserSearchVal: () => void;
-  matchingResultsCount: string;
-  handleDownload: () => void;
-  customUI?: JSX.Element;
-}) {
+  setColumnDefs,
+}: IToolbarProps) {
   return (
-    <Row
-      className={classNames(
-        "d-flex justify-content-between align-items-center tableControlsRow"
-      )}
-    >
-      <Col></Col>
+    <Row className={classNames("d-flex align-items-center tableControlsRow")}>
+      <Col>
+        <Button
+          onClick={() => {
+            if (setColumnDefs) {
+              setColumnDefs(SampleMetadataDetailsColumns);
+            }
+          }}
+          size="sm"
+          variant="outline-secondary"
+        >
+          View SampleMetadata
+        </Button>{" "}
+        <Button
+          onClick={() => {
+            if (setColumnDefs) {
+              setColumnDefs(CohortSampleDetailsColumns);
+            }
+          }}
+          size="sm"
+          variant="outline-secondary"
+        >
+          View Tempo
+        </Button>{" "}
+        <Button
+          onClick={() => {
+            if (setColumnDefs) {
+              setColumnDefs(combinedSampleDetailsColumns);
+            }
+          }}
+          size="sm"
+          variant="outline-secondary"
+        >
+          View all
+        </Button>
+      </Col>
 
       <Col md="auto">
         <Form.Control

--- a/frontend/src/shared/tableElements.tsx
+++ b/frontend/src/shared/tableElements.tsx
@@ -2,10 +2,9 @@ import { ApolloError } from "@apollo/client";
 import classNames from "classnames";
 import { Button, Col, Form, Row } from "react-bootstrap";
 import Spinner from "react-spinkit";
-import InfoIcon from "@material-ui/icons/InfoOutlined";
-import { Tooltip } from "@material-ui/core";
 import { DataName } from "./types";
 import { Dispatch, SetStateAction } from "react";
+import { InfoToolTip } from "./components/InfoToolTip";
 
 export function LoadingSpinner() {
   return (
@@ -74,18 +73,11 @@ export function Toolbar({
       </Col>
 
       <Col md="auto" style={{ marginLeft: -15 }}>
-        <Tooltip
-          title={
-            <span style={{ fontSize: 12 }}>
-              After inputting your search query, click on &quot;Search&quot; or
-              press &quot;Enter&quot; to get your results. To bulk search, input
-              a list of values separated by spaces or commas (e.g. &quot;value1
-              value2 value3&quot;)
-            </span>
-          }
-        >
-          <InfoIcon style={{ fontSize: 18, color: "grey" }} />
-        </Tooltip>
+        <InfoToolTip>
+          After inputting your search query, click on "Search" or press "Enter"
+          to get your results. To bulk search, input a list of values separated
+          by spaces or commas (e.g. "value1 value2 value3")
+        </InfoToolTip>
       </Col>
 
       <Col md="auto" style={{ marginLeft: -15 }}>
@@ -104,7 +96,7 @@ export function Toolbar({
 
       <Col className={"text-end"}>
         <Button onClick={handleDownload} size={"sm"}>
-          Generate Report
+          Generate report
         </Button>
       </Col>
     </Row>


### PR DESCRIPTION
This PR adds tabs to the general Samples page that filter columns by SampleMetadata vs. Tempo, making it easier to navigate these fields.

These tabs work in tandem with the following:
- search bar
- column-level filter (e.g. of the "Billed" column)
- exporting file

https://github.com/mskcc/smile-dashboard/assets/86090707/3694249d-0371-4708-9b45-8fdeb7fb7b28

