### PR TITLE
Flatten data queried to SSRM AG Grid tables

### DIFF
--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -32,7 +32,7 @@ interface IRecordsListProps {
   enableInfiniteScroll?: boolean;
   lazyRecordsQuery: typeof useHookLazyGeneric;
   lazyRecordsQueryAddlVariables?: Record<string, any>;
-  prepareDataForAgGrid: (
+  prepareDataForAgGrid?: (
     data: any,
     filterModel: IServerSideGetRowsRequest["filterModel"]
   ) => any;
@@ -135,7 +135,10 @@ export default function RecordsList({
               });
 
         return thisFetch.then((d) => {
-          const agGridData = prepareDataForAgGrid(d.data, filterModel);
+          let agGridData = d.data;
+          if (prepareDataForAgGrid) {
+            agGridData = prepareDataForAgGrid(d.data, filterModel);
+          }
 
           if ("uniqueSampleCount" in agGridData) {
             setUniqueSampleCount(agGridData.uniqueSampleCount);
@@ -180,7 +183,10 @@ export default function RecordsList({
                 },
               },
             }).then(({ data }) => {
-              const agGridData = prepareDataForAgGrid(data, filterModel);
+              let agGridData = data;
+              if (prepareDataForAgGrid) {
+                agGridData = prepareDataForAgGrid(data, filterModel);
+              }
               return buildTsvString(agGridData[dataName], colDefs);
             });
           }}

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -116,9 +116,6 @@ export default function RecordsList({
           where: {
             OR: queryFilterWhereVariables(parsedSearchVals),
           },
-          [`${dataName}ConnectionWhere2`]: {
-            OR: queryFilterWhereVariables(parsedSearchVals),
-          },
           options: {
             offset: params.request.startRow,
             limit: params.request.endRow,

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -350,7 +350,9 @@ export type BamCompletesConnection = {
 
 export type Cohort = {
   __typename?: "Cohort";
+  billed?: Maybe<Scalars["String"]>;
   cohortId: Scalars["String"];
+  endUsers?: Maybe<Scalars["String"]>;
   hasCohortCompleteCohortCompletes: Array<CohortComplete>;
   hasCohortCompleteCohortCompletesAggregate?: Maybe<CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection>;
   hasCohortCompleteCohortCompletesConnection: CohortHasCohortCompleteCohortCompletesConnection;
@@ -358,6 +360,13 @@ export type Cohort = {
   hasCohortSampleSamplesAggregate?: Maybe<CohortSampleHasCohortSampleSamplesAggregationSelection>;
   hasCohortSampleSamplesConnection: CohortHasCohortSampleSamplesConnection;
   initialCohortDeliveryDate?: Maybe<Scalars["String"]>;
+  pmUsers?: Maybe<Scalars["String"]>;
+  projectSubtitle?: Maybe<Scalars["String"]>;
+  projectTitle?: Maybe<Scalars["String"]>;
+  smileSampleIds?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  status?: Maybe<Scalars["String"]>;
+  totalSampleCount?: Maybe<Scalars["Int"]>;
+  type?: Maybe<Scalars["String"]>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesArgs = {
@@ -402,9 +411,17 @@ export type CohortHasCohortSampleSamplesConnectionArgs = {
 
 export type CohortAggregateSelection = {
   __typename?: "CohortAggregateSelection";
+  billed: StringAggregateSelectionNullable;
   cohortId: StringAggregateSelectionNonNullable;
   count: Scalars["Int"];
+  endUsers: StringAggregateSelectionNullable;
   initialCohortDeliveryDate: StringAggregateSelectionNullable;
+  pmUsers: StringAggregateSelectionNullable;
+  projectSubtitle: StringAggregateSelectionNullable;
+  projectTitle: StringAggregateSelectionNullable;
+  status: StringAggregateSelectionNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
+  type: StringAggregateSelectionNullable;
 };
 
 export type CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection =
@@ -482,8 +499,16 @@ export type CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection = {
 export type CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection =
   {
     __typename?: "CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection";
+    billed: StringAggregateSelectionNullable;
     cohortId: StringAggregateSelectionNonNullable;
+    endUsers: StringAggregateSelectionNullable;
     initialCohortDeliveryDate: StringAggregateSelectionNullable;
+    pmUsers: StringAggregateSelectionNullable;
+    projectSubtitle: StringAggregateSelectionNullable;
+    projectTitle: StringAggregateSelectionNullable;
+    status: StringAggregateSelectionNullable;
+    totalSampleCount: IntAggregateSelectionNullable;
+    type: StringAggregateSelectionNullable;
   };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateInput = {
@@ -552,6 +577,26 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput>
   >;
+  billed_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  billed_EQUAL?: InputMaybe<Scalars["String"]>;
+  billed_GT?: InputMaybe<Scalars["Int"]>;
+  billed_GTE?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billed_LT?: InputMaybe<Scalars["Int"]>;
+  billed_LTE?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   cohortId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   cohortId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   cohortId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -572,6 +617,26 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   cohortId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  endUsers_EQUAL?: InputMaybe<Scalars["String"]>;
+  endUsers_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   initialCohortDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   initialCohortDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   initialCohortDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -592,6 +657,131 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   initialCohortDeliveryDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   initialCohortDeliveryDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   initialCohortDeliveryDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  pmUsers_EQUAL?: InputMaybe<Scalars["String"]>;
+  pmUsers_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_EQUAL?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_GT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_GTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  projectTitle_EQUAL?: InputMaybe<Scalars["String"]>;
+  projectTitle_GT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_GTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  status_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  status_EQUAL?: InputMaybe<Scalars["String"]>;
+  status_GT?: InputMaybe<Scalars["Int"]>;
+  status_GTE?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  status_LT?: InputMaybe<Scalars["Int"]>;
+  status_LTE?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
+  type_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  type_EQUAL?: InputMaybe<Scalars["String"]>;
+  type_GT?: InputMaybe<Scalars["Int"]>;
+  type_GTE?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  type_LT?: InputMaybe<Scalars["Int"]>;
+  type_LTE?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteRelationship = {
@@ -806,10 +996,19 @@ export type CohortConnectWhere = {
 };
 
 export type CohortCreateInput = {
+  billed?: InputMaybe<Scalars["String"]>;
   cohortId: Scalars["String"];
+  endUsers?: InputMaybe<Scalars["String"]>;
   hasCohortCompleteCohortCompletes?: InputMaybe<CohortHasCohortCompleteCohortCompletesFieldInput>;
   hasCohortSampleSamples?: InputMaybe<CohortHasCohortSampleSamplesFieldInput>;
   initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
+  pmUsers?: InputMaybe<Scalars["String"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]>;
+  projectTitle?: InputMaybe<Scalars["String"]>;
+  smileSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  status?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  type?: InputMaybe<Scalars["String"]>;
 };
 
 export type CohortDeleteInput = {
@@ -1264,12 +1463,22 @@ export type CohortSampleHasCohortSampleSamplesNodeAggregateSelection = {
 
 /** Fields to sort Cohorts by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortSort object. */
 export type CohortSort = {
+  billed?: InputMaybe<SortDirection>;
   cohortId?: InputMaybe<SortDirection>;
+  endUsers?: InputMaybe<SortDirection>;
   initialCohortDeliveryDate?: InputMaybe<SortDirection>;
+  pmUsers?: InputMaybe<SortDirection>;
+  projectSubtitle?: InputMaybe<SortDirection>;
+  projectTitle?: InputMaybe<SortDirection>;
+  status?: InputMaybe<SortDirection>;
+  totalSampleCount?: InputMaybe<SortDirection>;
+  type?: InputMaybe<SortDirection>;
 };
 
 export type CohortUpdateInput = {
+  billed?: InputMaybe<Scalars["String"]>;
   cohortId?: InputMaybe<Scalars["String"]>;
+  endUsers?: InputMaybe<Scalars["String"]>;
   hasCohortCompleteCohortCompletes?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesUpdateFieldInput>
   >;
@@ -1277,11 +1486,32 @@ export type CohortUpdateInput = {
     Array<CohortHasCohortSampleSamplesUpdateFieldInput>
   >;
   initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
+  pmUsers?: InputMaybe<Scalars["String"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]>;
+  projectTitle?: InputMaybe<Scalars["String"]>;
+  smileSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  smileSampleIds_POP?: InputMaybe<Scalars["Int"]>;
+  smileSampleIds_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  status?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_DECREMENT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_INCREMENT?: InputMaybe<Scalars["Int"]>;
+  type?: InputMaybe<Scalars["String"]>;
 };
 
 export type CohortWhere = {
   AND?: InputMaybe<Array<CohortWhere>>;
   OR?: InputMaybe<Array<CohortWhere>>;
+  billed?: InputMaybe<Scalars["String"]>;
+  billed_CONTAINS?: InputMaybe<Scalars["String"]>;
+  billed_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  billed_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  billed_NOT?: InputMaybe<Scalars["String"]>;
+  billed_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  billed_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  billed_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  billed_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  billed_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   cohortId?: InputMaybe<Scalars["String"]>;
   cohortId_CONTAINS?: InputMaybe<Scalars["String"]>;
   cohortId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
@@ -1292,6 +1522,16 @@ export type CohortWhere = {
   cohortId_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   cohortId_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   cohortId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers?: InputMaybe<Scalars["String"]>;
+  endUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
+  endUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  endUsers_NOT?: InputMaybe<Scalars["String"]>;
+  endUsers_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  endUsers_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  endUsers_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   hasCohortCompleteCohortCompletesAggregate?: InputMaybe<CohortHasCohortCompleteCohortCompletesAggregateInput>;
   hasCohortCompleteCohortCompletesConnection_ALL?: InputMaybe<CohortHasCohortCompleteCohortCompletesConnectionWhere>;
   hasCohortCompleteCohortCompletesConnection_NONE?: InputMaybe<CohortHasCohortCompleteCohortCompletesConnectionWhere>;
@@ -1332,6 +1572,68 @@ export type CohortWhere = {
   >;
   initialCohortDeliveryDate_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   initialCohortDeliveryDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers?: InputMaybe<Scalars["String"]>;
+  pmUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
+  pmUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  pmUsers_NOT?: InputMaybe<Scalars["String"]>;
+  pmUsers_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  pmUsers_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  pmUsers_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectSubtitle_NOT?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectSubtitle_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  projectTitle?: InputMaybe<Scalars["String"]>;
+  projectTitle_CONTAINS?: InputMaybe<Scalars["String"]>;
+  projectTitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  projectTitle_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectTitle_NOT?: InputMaybe<Scalars["String"]>;
+  projectTitle_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  projectTitle_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  projectTitle_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectTitle_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  projectTitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smileSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  smileSampleIds_INCLUDES?: InputMaybe<Scalars["String"]>;
+  smileSampleIds_NOT?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  smileSampleIds_NOT_INCLUDES?: InputMaybe<Scalars["String"]>;
+  status?: InputMaybe<Scalars["String"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  status_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  status_NOT?: InputMaybe<Scalars["String"]>;
+  status_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  status_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  status_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  status_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_IN?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_NOT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
+  type?: InputMaybe<Scalars["String"]>;
+  type_CONTAINS?: InputMaybe<Scalars["String"]>;
+  type_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  type_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  type_NOT?: InputMaybe<Scalars["String"]>;
+  type_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  type_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  type_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  type_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  type_STARTS_WITH?: InputMaybe<Scalars["String"]>;
 };
 
 export type CohortsConnection = {
@@ -5867,8 +6169,16 @@ export type SampleCohortCohortsHasCohortSampleAggregationSelection = {
 
 export type SampleCohortCohortsHasCohortSampleNodeAggregateSelection = {
   __typename?: "SampleCohortCohortsHasCohortSampleNodeAggregateSelection";
+  billed: StringAggregateSelectionNullable;
   cohortId: StringAggregateSelectionNonNullable;
+  endUsers: StringAggregateSelectionNullable;
   initialCohortDeliveryDate: StringAggregateSelectionNullable;
+  pmUsers: StringAggregateSelectionNullable;
+  projectSubtitle: StringAggregateSelectionNullable;
+  projectTitle: StringAggregateSelectionNullable;
+  status: StringAggregateSelectionNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
+  type: StringAggregateSelectionNullable;
 };
 
 export type SampleCohortsHasCohortSampleAggregateInput = {
@@ -5929,6 +6239,26 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
     Array<SampleCohortsHasCohortSampleNodeAggregationWhereInput>
   >;
   OR?: InputMaybe<Array<SampleCohortsHasCohortSampleNodeAggregationWhereInput>>;
+  billed_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  billed_EQUAL?: InputMaybe<Scalars["String"]>;
+  billed_GT?: InputMaybe<Scalars["Int"]>;
+  billed_GTE?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billed_LT?: InputMaybe<Scalars["Int"]>;
+  billed_LTE?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   cohortId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   cohortId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   cohortId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -5949,6 +6279,26 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
   cohortId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  endUsers_EQUAL?: InputMaybe<Scalars["String"]>;
+  endUsers_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   initialCohortDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   initialCohortDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   initialCohortDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -5969,6 +6319,131 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
   initialCohortDeliveryDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   initialCohortDeliveryDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   initialCohortDeliveryDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  pmUsers_EQUAL?: InputMaybe<Scalars["String"]>;
+  pmUsers_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_EQUAL?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_GT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_GTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  projectTitle_EQUAL?: InputMaybe<Scalars["String"]>;
+  projectTitle_GT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_GTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  status_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  status_EQUAL?: InputMaybe<Scalars["String"]>;
+  status_GT?: InputMaybe<Scalars["Int"]>;
+  status_GTE?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  status_LT?: InputMaybe<Scalars["Int"]>;
+  status_LTE?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
+  type_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  type_EQUAL?: InputMaybe<Scalars["String"]>;
+  type_GT?: InputMaybe<Scalars["Int"]>;
+  type_GTE?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  type_LT?: InputMaybe<Scalars["Int"]>;
+  type_LTE?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type SampleCohortsHasCohortSampleRelationship = {
@@ -11299,16 +11774,25 @@ export type CohortsListQuery = {
   cohorts: Array<{
     __typename?: "Cohort";
     cohortId: string;
+    smileSampleIds?: Array<string | null> | null;
+    totalSampleCount?: number | null;
+    billed?: string | null;
     initialCohortDeliveryDate?: string | null;
+    endUsers?: string | null;
+    pmUsers?: string | null;
+    projectTitle?: string | null;
+    projectSubtitle?: string | null;
+    status?: string | null;
+    type?: string | null;
     hasCohortCompleteCohortCompletes: Array<{
       __typename?: "CohortComplete";
-      type: string;
+      date: string;
       endUsers: string;
       pmUsers: string;
       projectTitle: string;
       projectSubtitle: string;
       status: string;
-      date: string;
+      type: string;
     }>;
     hasCohortSampleSamplesConnection: {
       __typename?: "CohortHasCohortSampleSamplesConnection";
@@ -11885,17 +12369,26 @@ export const CohortsListDocument = gql`
     }
     cohorts(where: $where, options: $options) {
       cohortId
+      smileSampleIds
+      totalSampleCount
+      billed
       initialCohortDeliveryDate
+      endUsers
+      pmUsers
+      projectTitle
+      projectSubtitle
+      status
+      type
       hasCohortCompleteCohortCompletes(
         options: $hasCohortCompleteCohortCompletesOptions2
       ) {
-        type
+        date
         endUsers
         pmUsers
         projectTitle
         projectSubtitle
         status
-        date
+        type
       }
       hasCohortSampleSamplesConnection {
         totalCount

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -2125,6 +2125,11 @@ export type PageInfo = {
 
 export type Patient = {
   __typename?: "Patient";
+  cmoPatientId?: Maybe<Scalars["String"]>;
+  cmoSampleIds?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  consentPartA?: Maybe<Scalars["String"]>;
+  consentPartC?: Maybe<Scalars["String"]>;
+  dmpPatientId?: Maybe<Scalars["String"]>;
   hasSampleSamples: Array<Sample>;
   hasSampleSamplesAggregate?: Maybe<PatientSampleHasSampleSamplesAggregationSelection>;
   hasSampleSamplesConnection: PatientHasSampleSamplesConnection;
@@ -2132,6 +2137,7 @@ export type Patient = {
   patientAliasesIsAliasAggregate?: Maybe<PatientPatientAliasPatientAliasesIsAliasAggregationSelection>;
   patientAliasesIsAliasConnection: PatientPatientAliasesIsAliasConnection;
   smilePatientId: Scalars["String"];
+  totalSampleCount?: Maybe<Scalars["Int"]>;
 };
 
 export type PatientHasSampleSamplesArgs = {
@@ -2174,8 +2180,13 @@ export type PatientPatientAliasesIsAliasConnectionArgs = {
 
 export type PatientAggregateSelection = {
   __typename?: "PatientAggregateSelection";
+  cmoPatientId: StringAggregateSelectionNullable;
+  consentPartA: StringAggregateSelectionNullable;
+  consentPartC: StringAggregateSelectionNullable;
   count: Scalars["Int"];
+  dmpPatientId: StringAggregateSelectionNullable;
   smilePatientId: StringAggregateSelectionNonNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
 };
 
 export type PatientAlias = {
@@ -2303,6 +2314,86 @@ export type PatientAliasIsAliasPatientsFieldInput = {
 export type PatientAliasIsAliasPatientsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<PatientAliasIsAliasPatientsNodeAggregationWhereInput>>;
   OR?: InputMaybe<Array<PatientAliasIsAliasPatientsNodeAggregationWhereInput>>;
+  cmoPatientId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_EQUAL?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_GT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  consentPartA_EQUAL?: InputMaybe<Scalars["String"]>;
+  consentPartA_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  consentPartC_EQUAL?: InputMaybe<Scalars["String"]>;
+  consentPartC_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_EQUAL?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_GT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_GTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   smilePatientId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   smilePatientId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   smilePatientId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -2323,6 +2414,31 @@ export type PatientAliasIsAliasPatientsNodeAggregationWhereInput = {
   smilePatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   smilePatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   smilePatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type PatientAliasIsAliasPatientsRelationship = {
@@ -2361,7 +2477,12 @@ export type PatientAliasPatientIsAliasPatientsAggregationSelection = {
 
 export type PatientAliasPatientIsAliasPatientsNodeAggregateSelection = {
   __typename?: "PatientAliasPatientIsAliasPatientsNodeAggregateSelection";
+  cmoPatientId: StringAggregateSelectionNullable;
+  consentPartA: StringAggregateSelectionNullable;
+  consentPartC: StringAggregateSelectionNullable;
+  dmpPatientId: StringAggregateSelectionNullable;
   smilePatientId: StringAggregateSelectionNonNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
 };
 
 export type PatientAliasRelationInput = {
@@ -2443,9 +2564,15 @@ export type PatientConnectWhere = {
 };
 
 export type PatientCreateInput = {
+  cmoPatientId?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  consentPartA?: InputMaybe<Scalars["String"]>;
+  consentPartC?: InputMaybe<Scalars["String"]>;
+  dmpPatientId?: InputMaybe<Scalars["String"]>;
   hasSampleSamples?: InputMaybe<PatientHasSampleSamplesFieldInput>;
   patientAliasesIsAlias?: InputMaybe<PatientPatientAliasesIsAliasFieldInput>;
   smilePatientId: Scalars["String"];
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
 };
 
 export type PatientDeleteInput = {
@@ -2797,20 +2924,79 @@ export type PatientSampleHasSampleSamplesNodeAggregateSelection = {
 
 /** Fields to sort Patients by. The order in which sorts are applied is not guaranteed when specifying many fields in one PatientSort object. */
 export type PatientSort = {
+  cmoPatientId?: InputMaybe<SortDirection>;
+  consentPartA?: InputMaybe<SortDirection>;
+  consentPartC?: InputMaybe<SortDirection>;
+  dmpPatientId?: InputMaybe<SortDirection>;
   smilePatientId?: InputMaybe<SortDirection>;
+  totalSampleCount?: InputMaybe<SortDirection>;
 };
 
 export type PatientUpdateInput = {
+  cmoPatientId?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds_POP?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  consentPartA?: InputMaybe<Scalars["String"]>;
+  consentPartC?: InputMaybe<Scalars["String"]>;
+  dmpPatientId?: InputMaybe<Scalars["String"]>;
   hasSampleSamples?: InputMaybe<Array<PatientHasSampleSamplesUpdateFieldInput>>;
   patientAliasesIsAlias?: InputMaybe<
     Array<PatientPatientAliasesIsAliasUpdateFieldInput>
   >;
   smilePatientId?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_DECREMENT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_INCREMENT?: InputMaybe<Scalars["Int"]>;
 };
 
 export type PatientWhere = {
   AND?: InputMaybe<Array<PatientWhere>>;
   OR?: InputMaybe<Array<PatientWhere>>;
+  cmoPatientId?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoPatientId_NOT?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoPatientId_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds_INCLUDES?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_NOT?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds_NOT_INCLUDES?: InputMaybe<Scalars["String"]>;
+  consentPartA?: InputMaybe<Scalars["String"]>;
+  consentPartA_CONTAINS?: InputMaybe<Scalars["String"]>;
+  consentPartA_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartA_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  consentPartA_NOT?: InputMaybe<Scalars["String"]>;
+  consentPartA_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  consentPartA_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartA_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  consentPartA_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartA_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartC?: InputMaybe<Scalars["String"]>;
+  consentPartC_CONTAINS?: InputMaybe<Scalars["String"]>;
+  consentPartC_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartC_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  consentPartC_NOT?: InputMaybe<Scalars["String"]>;
+  consentPartC_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  consentPartC_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartC_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  consentPartC_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartC_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  dmpPatientId?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_CONTAINS?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  dmpPatientId_NOT?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  dmpPatientId_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   hasSampleSamplesAggregate?: InputMaybe<PatientHasSampleSamplesAggregateInput>;
   hasSampleSamplesConnection_ALL?: InputMaybe<PatientHasSampleSamplesConnectionWhere>;
   hasSampleSamplesConnection_NONE?: InputMaybe<PatientHasSampleSamplesConnectionWhere>;
@@ -2847,6 +3033,14 @@ export type PatientWhere = {
   smilePatientId_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   smilePatientId_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   smilePatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_IN?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_NOT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
 };
 
 export type PatientsConnection = {
@@ -7529,7 +7723,12 @@ export type SamplePatientPatientsHasSampleAggregationSelection = {
 
 export type SamplePatientPatientsHasSampleNodeAggregateSelection = {
   __typename?: "SamplePatientPatientsHasSampleNodeAggregateSelection";
+  cmoPatientId: StringAggregateSelectionNullable;
+  consentPartA: StringAggregateSelectionNullable;
+  consentPartC: StringAggregateSelectionNullable;
+  dmpPatientId: StringAggregateSelectionNullable;
   smilePatientId: StringAggregateSelectionNonNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
 };
 
 export type SamplePatientsHasSampleAggregateInput = {
@@ -7588,6 +7787,86 @@ export type SamplePatientsHasSampleFieldInput = {
 export type SamplePatientsHasSampleNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SamplePatientsHasSampleNodeAggregationWhereInput>>;
   OR?: InputMaybe<Array<SamplePatientsHasSampleNodeAggregationWhereInput>>;
+  cmoPatientId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_EQUAL?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_GT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  consentPartA_EQUAL?: InputMaybe<Scalars["String"]>;
+  consentPartA_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  consentPartC_EQUAL?: InputMaybe<Scalars["String"]>;
+  consentPartC_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_EQUAL?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_GT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_GTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   smilePatientId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   smilePatientId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   smilePatientId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -7608,6 +7887,31 @@ export type SamplePatientsHasSampleNodeAggregationWhereInput = {
   smilePatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   smilePatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   smilePatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type SamplePatientsHasSampleRelationship = {
@@ -10613,6 +10917,12 @@ export type PatientsListQuery = {
   patients: Array<{
     __typename?: "Patient";
     smilePatientId: string;
+    cmoPatientId?: string | null;
+    dmpPatientId?: string | null;
+    totalSampleCount?: number | null;
+    cmoSampleIds?: Array<string | null> | null;
+    consentPartA?: string | null;
+    consentPartC?: string | null;
     hasSampleSamples: Array<{
       __typename?: "Sample";
       smileSampleId: string;
@@ -11162,6 +11472,12 @@ export const PatientsListDocument = gql`
     }
     patients(where: $where, options: $options) {
       smilePatientId
+      cmoPatientId
+      dmpPatientId
+      totalSampleCount
+      cmoSampleIds
+      consentPartA
+      consentPartC
       hasSampleSamples {
         smileSampleId
         hasMetadataSampleMetadata {

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1445,6 +1445,14 @@ export type DeleteInfo = {
   relationshipsDeleted: Scalars["Int"];
 };
 
+export type IntAggregateSelectionNullable = {
+  __typename?: "IntAggregateSelectionNullable";
+  average?: Maybe<Scalars["Float"]>;
+  max?: Maybe<Scalars["Int"]>;
+  min?: Maybe<Scalars["Int"]>;
+  sum?: Maybe<Scalars["Int"]>;
+};
+
 export type MafComplete = {
   __typename?: "MafComplete";
   date: Scalars["String"];
@@ -3353,6 +3361,31 @@ export type ProjectHasRequestRequestsNodeAggregationWhereInput = {
   strand_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   strand_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   strand_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type ProjectHasRequestRequestsRelationship = {
@@ -3414,6 +3447,7 @@ export type ProjectRequestHasRequestRequestsNodeAggregateSelection = {
   requestJson: StringAggregateSelectionNonNullable;
   smileRequestId: StringAggregateSelectionNonNullable;
   strand: StringAggregateSelectionNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
 };
 
 /** Fields to sort Projects by. The order in which sorts are applied is not guaranteed when specifying many fields in one ProjectSort object. */
@@ -4154,6 +4188,7 @@ export type Request = {
   requestJson: Scalars["String"];
   smileRequestId: Scalars["String"];
   strand?: Maybe<Scalars["String"]>;
+  totalSampleCount?: Maybe<Scalars["Int"]>;
 };
 
 export type RequestHasSampleSamplesArgs = {
@@ -4216,6 +4251,7 @@ export type RequestAggregateSelection = {
   requestJson: StringAggregateSelectionNonNullable;
   smileRequestId: StringAggregateSelectionNonNullable;
   strand: StringAggregateSelectionNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
 };
 
 export type RequestConnectInput = {
@@ -4256,6 +4292,7 @@ export type RequestCreateInput = {
   requestJson: Scalars["String"];
   smileRequestId: Scalars["String"];
   strand?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
 };
 
 export type RequestDeleteInput = {
@@ -4891,6 +4928,7 @@ export type RequestSort = {
   requestJson?: InputMaybe<SortDirection>;
   smileRequestId?: InputMaybe<SortDirection>;
   strand?: InputMaybe<SortDirection>;
+  totalSampleCount?: InputMaybe<SortDirection>;
 };
 
 export type RequestUpdateInput = {
@@ -4922,6 +4960,9 @@ export type RequestUpdateInput = {
   requestJson?: InputMaybe<Scalars["String"]>;
   smileRequestId?: InputMaybe<Scalars["String"]>;
   strand?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_DECREMENT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_INCREMENT?: InputMaybe<Scalars["Int"]>;
 };
 
 export type RequestWhere = {
@@ -5151,6 +5192,14 @@ export type RequestWhere = {
   strand_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   strand_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   strand_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_IN?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_NOT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
 };
 
 export type RequestsConnection = {
@@ -7626,6 +7675,7 @@ export type SampleRequestRequestsHasSampleNodeAggregateSelection = {
   requestJson: StringAggregateSelectionNonNullable;
   smileRequestId: StringAggregateSelectionNonNullable;
   strand: StringAggregateSelectionNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
 };
 
 export type SampleRequestsHasSampleAggregateInput = {
@@ -8064,6 +8114,31 @@ export type SampleRequestsHasSampleNodeAggregationWhereInput = {
   strand_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   strand_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   strand_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type SampleRequestsHasSampleRelationship = {
@@ -10503,6 +10578,7 @@ export type RequestsListQuery = {
     __typename?: "Request";
     igoRequestId: string;
     igoProjectId: string;
+    totalSampleCount?: number | null;
     genePanel: string;
     dataAnalystName: string;
     dataAnalystEmail: string;
@@ -10624,6 +10700,7 @@ export type FindSamplesByInputValueQuery = {
               __typename?: "Request";
               igoRequestId: string;
               igoProjectId: string;
+              totalSampleCount?: number | null;
               genePanel: string;
               dataAnalystName: string;
               dataAnalystEmail: string;
@@ -10700,6 +10777,7 @@ export type RequestPartsFragment = {
   __typename?: "Request";
   igoRequestId: string;
   igoProjectId: string;
+  totalSampleCount?: number | null;
   genePanel: string;
   dataAnalystName: string;
   dataAnalystEmail: string;
@@ -10942,6 +11020,7 @@ export const RequestPartsFragmentDoc = gql`
   fragment RequestParts on Request {
     igoRequestId
     igoProjectId
+    totalSampleCount
     genePanel
     dataAnalystName
     dataAnalystEmail

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -10494,7 +10494,6 @@ export type UpdateTemposMutationResponse = {
 export type RequestsListQueryVariables = Exact<{
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
-  requestsConnectionWhere2?: InputMaybe<RequestWhere>;
 }>;
 
 export type RequestsListQuery = {
@@ -10530,7 +10529,6 @@ export type RequestsListQuery = {
 export type PatientsListQueryVariables = Exact<{
   options?: InputMaybe<PatientOptions>;
   where?: InputMaybe<PatientWhere>;
-  patientsConnectionWhere2?: InputMaybe<PatientWhere>;
 }>;
 
 export type PatientsListQuery = {
@@ -10904,7 +10902,6 @@ export type GetPatientIdsTripletsQuery = {
 export type CohortsListQueryVariables = Exact<{
   where?: InputMaybe<CohortWhere>;
   options?: InputMaybe<CohortOptions>;
-  cohortsConnectionWhere2?: InputMaybe<CohortWhere>;
   hasCohortCompleteCohortCompletesOptions2?: InputMaybe<CohortCompleteOptions>;
 }>;
 
@@ -11014,12 +11011,8 @@ export const TempoPartsFragmentDoc = gql`
   }
 `;
 export const RequestsListDocument = gql`
-  query RequestsList(
-    $options: RequestOptions
-    $where: RequestWhere
-    $requestsConnectionWhere2: RequestWhere
-  ) {
-    requestsConnection(where: $requestsConnectionWhere2) {
+  query RequestsList($options: RequestOptions, $where: RequestWhere) {
+    requestsConnection(where: $where) {
       totalCount
     }
     requests(where: $where, options: $options) {
@@ -11046,7 +11039,6 @@ export const RequestsListDocument = gql`
  *   variables: {
  *      options: // value for 'options'
  *      where: // value for 'where'
- *      requestsConnectionWhere2: // value for 'requestsConnectionWhere2'
  *   },
  * });
  */
@@ -11085,12 +11077,8 @@ export type RequestsListQueryResult = Apollo.QueryResult<
   RequestsListQueryVariables
 >;
 export const PatientsListDocument = gql`
-  query PatientsList(
-    $options: PatientOptions
-    $where: PatientWhere
-    $patientsConnectionWhere2: PatientWhere
-  ) {
-    patientsConnection(where: $patientsConnectionWhere2) {
+  query PatientsList($options: PatientOptions, $where: PatientWhere) {
+    patientsConnection(where: $where) {
       totalCount
     }
     patients(where: $where, options: $options) {
@@ -11128,7 +11116,6 @@ export const PatientsListDocument = gql`
  *   variables: {
  *      options: // value for 'options'
  *      where: // value for 'where'
- *      patientsConnectionWhere2: // value for 'patientsConnectionWhere2'
  *   },
  * });
  */
@@ -11496,10 +11483,9 @@ export const CohortsListDocument = gql`
   query CohortsList(
     $where: CohortWhere
     $options: CohortOptions
-    $cohortsConnectionWhere2: CohortWhere
     $hasCohortCompleteCohortCompletesOptions2: CohortCompleteOptions
   ) {
-    cohortsConnection(where: $cohortsConnectionWhere2) {
+    cohortsConnection(where: $where) {
       totalCount
     }
     cohorts(where: $where, options: $options) {
@@ -11544,7 +11530,6 @@ export const CohortsListDocument = gql`
  *   variables: {
  *      where: // value for 'where'
  *      options: // value for 'options'
- *      cohortsConnectionWhere2: // value for 'cohortsConnectionWhere2'
  *      hasCohortCompleteCohortCompletesOptions2: // value for 'hasCohortCompleteCohortCompletesOptions2'
  *   },
  * });

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -113,10 +113,10 @@ export type BamCompleteTempoTemposHasEventAggregationSelection = {
 
 export type BamCompleteTempoTemposHasEventNodeAggregateSelection = {
   __typename?: "BamCompleteTempoTemposHasEventNodeAggregateSelection";
-  accessLevel: StringAggregateSelectionNonNullable;
+  accessLevel: StringAggregateSelectionNullable;
   billedBy: StringAggregateSelectionNullable;
   costCenter: StringAggregateSelectionNullable;
-  custodianInformation: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNullable;
   smileTempoId: StringAggregateSelectionNonNullable;
 };
 
@@ -357,6 +357,7 @@ export type Cohort = {
   hasCohortSampleSamples: Array<Sample>;
   hasCohortSampleSamplesAggregate?: Maybe<CohortSampleHasCohortSampleSamplesAggregationSelection>;
   hasCohortSampleSamplesConnection: CohortHasCohortSampleSamplesConnection;
+  initialCohortDeliveryDate?: Maybe<Scalars["String"]>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesArgs = {
@@ -403,6 +404,7 @@ export type CohortAggregateSelection = {
   __typename?: "CohortAggregateSelection";
   cohortId: StringAggregateSelectionNonNullable;
   count: Scalars["Int"];
+  initialCohortDeliveryDate: StringAggregateSelectionNullable;
 };
 
 export type CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection =
@@ -481,6 +483,7 @@ export type CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection =
   {
     __typename?: "CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection";
     cohortId: StringAggregateSelectionNonNullable;
+    initialCohortDeliveryDate: StringAggregateSelectionNullable;
   };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateInput = {
@@ -569,6 +572,26 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   cohortId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_EQUAL?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_GT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_GTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteRelationship = {
@@ -786,6 +809,7 @@ export type CohortCreateInput = {
   cohortId: Scalars["String"];
   hasCohortCompleteCohortCompletes?: InputMaybe<CohortHasCohortCompleteCohortCompletesFieldInput>;
   hasCohortSampleSamples?: InputMaybe<CohortHasCohortSampleSamplesFieldInput>;
+  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
 };
 
 export type CohortDeleteInput = {
@@ -1241,6 +1265,7 @@ export type CohortSampleHasCohortSampleSamplesNodeAggregateSelection = {
 /** Fields to sort Cohorts by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortSort object. */
 export type CohortSort = {
   cohortId?: InputMaybe<SortDirection>;
+  initialCohortDeliveryDate?: InputMaybe<SortDirection>;
 };
 
 export type CohortUpdateInput = {
@@ -1251,6 +1276,7 @@ export type CohortUpdateInput = {
   hasCohortSampleSamples?: InputMaybe<
     Array<CohortHasCohortSampleSamplesUpdateFieldInput>
   >;
+  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
 };
 
 export type CohortWhere = {
@@ -1292,6 +1318,20 @@ export type CohortWhere = {
   hasCohortSampleSamples_SINGLE?: InputMaybe<SampleWhere>;
   /** Return Cohorts where some of the related Samples match this filter */
   hasCohortSampleSamples_SOME?: InputMaybe<SampleWhere>;
+  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_CONTAINS?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]>>
+  >;
+  initialCohortDeliveryDate_NOT?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_NOT_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]>>
+  >;
+  initialCohortDeliveryDate_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
 };
 
 export type CohortsConnection = {
@@ -1501,10 +1541,10 @@ export type MafCompleteTempoTemposHasEventAggregationSelection = {
 
 export type MafCompleteTempoTemposHasEventNodeAggregateSelection = {
   __typename?: "MafCompleteTempoTemposHasEventNodeAggregateSelection";
-  accessLevel: StringAggregateSelectionNonNullable;
+  accessLevel: StringAggregateSelectionNullable;
   billedBy: StringAggregateSelectionNullable;
   costCenter: StringAggregateSelectionNullable;
-  custodianInformation: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNullable;
   smileTempoId: StringAggregateSelectionNonNullable;
 };
 
@@ -3533,10 +3573,10 @@ export type QcCompleteTempoTemposHasEventAggregationSelection = {
 
 export type QcCompleteTempoTemposHasEventNodeAggregateSelection = {
   __typename?: "QcCompleteTempoTemposHasEventNodeAggregateSelection";
-  accessLevel: StringAggregateSelectionNonNullable;
+  accessLevel: StringAggregateSelectionNullable;
   billedBy: StringAggregateSelectionNullable;
   costCenter: StringAggregateSelectionNullable;
-  custodianInformation: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNullable;
   smileTempoId: StringAggregateSelectionNonNullable;
 };
 
@@ -4091,9 +4131,6 @@ export type Request = {
   dataAnalystEmail: Scalars["String"];
   dataAnalystName: Scalars["String"];
   genePanel: Scalars["String"];
-  hasMetadataRequestMetadata: Array<RequestMetadata>;
-  hasMetadataRequestMetadataAggregate?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection>;
-  hasMetadataRequestMetadataConnection: RequestHasMetadataRequestMetadataConnection;
   hasSampleSamples: Array<Sample>;
   hasSampleSamplesAggregate?: Maybe<RequestSampleHasSampleSamplesAggregationSelection>;
   hasSampleSamplesConnection: RequestHasSampleSamplesConnection;
@@ -4117,25 +4154,6 @@ export type Request = {
   requestJson: Scalars["String"];
   smileRequestId: Scalars["String"];
   strand?: Maybe<Scalars["String"]>;
-};
-
-export type RequestHasMetadataRequestMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  options?: InputMaybe<RequestMetadataOptions>;
-  where?: InputMaybe<RequestMetadataWhere>;
-};
-
-export type RequestHasMetadataRequestMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  where?: InputMaybe<RequestMetadataWhere>;
-};
-
-export type RequestHasMetadataRequestMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
-  sort?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionSort>>;
-  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
 };
 
 export type RequestHasSampleSamplesArgs = {
@@ -4201,9 +4219,6 @@ export type RequestAggregateSelection = {
 };
 
 export type RequestConnectInput = {
-  hasMetadataRequestMetadata?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataConnectFieldInput>
-  >;
   hasSampleSamples?: InputMaybe<
     Array<RequestHasSampleSamplesConnectFieldInput>
   >;
@@ -4222,7 +4237,6 @@ export type RequestCreateInput = {
   dataAnalystEmail: Scalars["String"];
   dataAnalystName: Scalars["String"];
   genePanel: Scalars["String"];
-  hasMetadataRequestMetadata?: InputMaybe<RequestHasMetadataRequestMetadataFieldInput>;
   hasSampleSamples?: InputMaybe<RequestHasSampleSamplesFieldInput>;
   igoProjectId: Scalars["String"];
   igoRequestId: Scalars["String"];
@@ -4245,9 +4259,6 @@ export type RequestCreateInput = {
 };
 
 export type RequestDeleteInput = {
-  hasMetadataRequestMetadata?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataDeleteFieldInput>
-  >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesDeleteFieldInput>>;
   projectsHasRequest?: InputMaybe<
     Array<RequestProjectsHasRequestDeleteFieldInput>
@@ -4255,9 +4266,6 @@ export type RequestDeleteInput = {
 };
 
 export type RequestDisconnectInput = {
-  hasMetadataRequestMetadata?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataDisconnectFieldInput>
-  >;
   hasSampleSamples?: InputMaybe<
     Array<RequestHasSampleSamplesDisconnectFieldInput>
   >;
@@ -4270,153 +4278,6 @@ export type RequestEdge = {
   __typename?: "RequestEdge";
   cursor: Scalars["String"];
   node: Request;
-};
-
-export type RequestHasMetadataRequestMetadataAggregateInput = {
-  AND?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
-  OR?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
-  node?: InputMaybe<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>;
-};
-
-export type RequestHasMetadataRequestMetadataConnectFieldInput = {
-  connect?: InputMaybe<Array<RequestMetadataConnectInput>>;
-  where?: InputMaybe<RequestMetadataConnectWhere>;
-};
-
-export type RequestHasMetadataRequestMetadataConnection = {
-  __typename?: "RequestHasMetadataRequestMetadataConnection";
-  edges: Array<RequestHasMetadataRequestMetadataRelationship>;
-  pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
-};
-
-export type RequestHasMetadataRequestMetadataConnectionSort = {
-  node?: InputMaybe<RequestMetadataSort>;
-};
-
-export type RequestHasMetadataRequestMetadataConnectionWhere = {
-  AND?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionWhere>>;
-  OR?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionWhere>>;
-  node?: InputMaybe<RequestMetadataWhere>;
-  node_NOT?: InputMaybe<RequestMetadataWhere>;
-};
-
-export type RequestHasMetadataRequestMetadataCreateFieldInput = {
-  node: RequestMetadataCreateInput;
-};
-
-export type RequestHasMetadataRequestMetadataDeleteFieldInput = {
-  delete?: InputMaybe<RequestMetadataDeleteInput>;
-  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
-};
-
-export type RequestHasMetadataRequestMetadataDisconnectFieldInput = {
-  disconnect?: InputMaybe<RequestMetadataDisconnectInput>;
-  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
-};
-
-export type RequestHasMetadataRequestMetadataFieldInput = {
-  connect?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataConnectFieldInput>
-  >;
-  create?: InputMaybe<Array<RequestHasMetadataRequestMetadataCreateFieldInput>>;
-};
-
-export type RequestHasMetadataRequestMetadataNodeAggregationWhereInput = {
-  AND?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>
-  >;
-  OR?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>
-  >;
-  igoRequestId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_EQUAL?: InputMaybe<Scalars["String"]>;
-  igoRequestId_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  importDate_EQUAL?: InputMaybe<Scalars["String"]>;
-  importDate_GT?: InputMaybe<Scalars["Int"]>;
-  importDate_GTE?: InputMaybe<Scalars["Int"]>;
-  importDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  importDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  importDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  importDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  importDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_LT?: InputMaybe<Scalars["Int"]>;
-  importDate_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  importDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  importDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  importDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  importDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_EQUAL?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-};
-
-export type RequestHasMetadataRequestMetadataRelationship = {
-  __typename?: "RequestHasMetadataRequestMetadataRelationship";
-  cursor: Scalars["String"];
-  node: RequestMetadata;
-};
-
-export type RequestHasMetadataRequestMetadataUpdateConnectionInput = {
-  node?: InputMaybe<RequestMetadataUpdateInput>;
-};
-
-export type RequestHasMetadataRequestMetadataUpdateFieldInput = {
-  connect?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataConnectFieldInput>
-  >;
-  create?: InputMaybe<Array<RequestHasMetadataRequestMetadataCreateFieldInput>>;
-  delete?: InputMaybe<Array<RequestHasMetadataRequestMetadataDeleteFieldInput>>;
-  disconnect?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataDisconnectFieldInput>
-  >;
-  update?: InputMaybe<RequestHasMetadataRequestMetadataUpdateConnectionInput>;
-  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
 };
 
 export type RequestHasSampleSamplesAggregateInput = {
@@ -4584,9 +4445,6 @@ export type RequestMetadata = {
   igoRequestId: Scalars["String"];
   importDate: Scalars["String"];
   requestMetadataJson: Scalars["String"];
-  requestsHasMetadata: Array<Request>;
-  requestsHasMetadataAggregate?: Maybe<RequestMetadataRequestRequestsHasMetadataAggregationSelection>;
-  requestsHasMetadataConnection: RequestMetadataRequestsHasMetadataConnection;
 };
 
 export type RequestMetadataHasStatusStatusesArgs = {
@@ -4608,25 +4466,6 @@ export type RequestMetadataHasStatusStatusesConnectionArgs = {
   where?: InputMaybe<RequestMetadataHasStatusStatusesConnectionWhere>;
 };
 
-export type RequestMetadataRequestsHasMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  options?: InputMaybe<RequestOptions>;
-  where?: InputMaybe<RequestWhere>;
-};
-
-export type RequestMetadataRequestsHasMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  where?: InputMaybe<RequestWhere>;
-};
-
-export type RequestMetadataRequestsHasMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
-  sort?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionSort>>;
-  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-};
-
 export type RequestMetadataAggregateSelection = {
   __typename?: "RequestMetadataAggregateSelection";
   count: Scalars["Int"];
@@ -4638,9 +4477,6 @@ export type RequestMetadataAggregateSelection = {
 export type RequestMetadataConnectInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesConnectFieldInput>
-  >;
-  requestsHasMetadata?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataConnectFieldInput>
   >;
 };
 
@@ -4660,24 +4496,17 @@ export type RequestMetadataCreateInput = {
   igoRequestId: Scalars["String"];
   importDate: Scalars["String"];
   requestMetadataJson: Scalars["String"];
-  requestsHasMetadata?: InputMaybe<RequestMetadataRequestsHasMetadataFieldInput>;
 };
 
 export type RequestMetadataDeleteInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesDeleteFieldInput>
   >;
-  requestsHasMetadata?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataDeleteFieldInput>
-  >;
 };
 
 export type RequestMetadataDisconnectInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesDisconnectFieldInput>
-  >;
-  requestsHasMetadata?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataDisconnectFieldInput>
   >;
 };
 
@@ -4805,511 +4634,6 @@ export type RequestMetadataRelationInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesCreateFieldInput>
   >;
-  requestsHasMetadata?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataCreateFieldInput>
-  >;
-};
-
-export type RequestMetadataRequestRequestsHasMetadataAggregationSelection = {
-  __typename?: "RequestMetadataRequestRequestsHasMetadataAggregationSelection";
-  count: Scalars["Int"];
-  node?: Maybe<RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection>;
-};
-
-export type RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection = {
-  __typename?: "RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection";
-  dataAccessEmails: StringAggregateSelectionNonNullable;
-  dataAnalystEmail: StringAggregateSelectionNonNullable;
-  dataAnalystName: StringAggregateSelectionNonNullable;
-  genePanel: StringAggregateSelectionNonNullable;
-  igoProjectId: StringAggregateSelectionNonNullable;
-  igoRequestId: StringAggregateSelectionNonNullable;
-  investigatorEmail: StringAggregateSelectionNonNullable;
-  investigatorName: StringAggregateSelectionNonNullable;
-  labHeadEmail: StringAggregateSelectionNonNullable;
-  labHeadName: StringAggregateSelectionNonNullable;
-  libraryType: StringAggregateSelectionNullable;
-  namespace: StringAggregateSelectionNonNullable;
-  otherContactEmails: StringAggregateSelectionNonNullable;
-  piEmail: StringAggregateSelectionNonNullable;
-  projectManagerName: StringAggregateSelectionNonNullable;
-  qcAccessEmails: StringAggregateSelectionNonNullable;
-  requestJson: StringAggregateSelectionNonNullable;
-  smileRequestId: StringAggregateSelectionNonNullable;
-  strand: StringAggregateSelectionNullable;
-};
-
-export type RequestMetadataRequestsHasMetadataAggregateInput = {
-  AND?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
-  OR?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
-  node?: InputMaybe<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>;
-};
-
-export type RequestMetadataRequestsHasMetadataConnectFieldInput = {
-  connect?: InputMaybe<Array<RequestConnectInput>>;
-  where?: InputMaybe<RequestConnectWhere>;
-};
-
-export type RequestMetadataRequestsHasMetadataConnection = {
-  __typename?: "RequestMetadataRequestsHasMetadataConnection";
-  edges: Array<RequestMetadataRequestsHasMetadataRelationship>;
-  pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
-};
-
-export type RequestMetadataRequestsHasMetadataConnectionSort = {
-  node?: InputMaybe<RequestSort>;
-};
-
-export type RequestMetadataRequestsHasMetadataConnectionWhere = {
-  AND?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionWhere>>;
-  OR?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionWhere>>;
-  node?: InputMaybe<RequestWhere>;
-  node_NOT?: InputMaybe<RequestWhere>;
-};
-
-export type RequestMetadataRequestsHasMetadataCreateFieldInput = {
-  node: RequestCreateInput;
-};
-
-export type RequestMetadataRequestsHasMetadataDeleteFieldInput = {
-  delete?: InputMaybe<RequestDeleteInput>;
-  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-};
-
-export type RequestMetadataRequestsHasMetadataDisconnectFieldInput = {
-  disconnect?: InputMaybe<RequestDisconnectInput>;
-  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-};
-
-export type RequestMetadataRequestsHasMetadataFieldInput = {
-  connect?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataConnectFieldInput>
-  >;
-  create?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataCreateFieldInput>
-  >;
-};
-
-export type RequestMetadataRequestsHasMetadataNodeAggregationWhereInput = {
-  AND?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>
-  >;
-  OR?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>
-  >;
-  dataAccessEmails_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_EQUAL?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_EQUAL?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_EQUAL?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_EQUAL?: InputMaybe<Scalars["String"]>;
-  genePanel_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_EQUAL?: InputMaybe<Scalars["String"]>;
-  igoProjectId_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_EQUAL?: InputMaybe<Scalars["String"]>;
-  igoRequestId_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_EQUAL?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_EQUAL?: InputMaybe<Scalars["String"]>;
-  investigatorName_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_EQUAL?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_EQUAL?: InputMaybe<Scalars["String"]>;
-  labHeadName_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_EQUAL?: InputMaybe<Scalars["String"]>;
-  libraryType_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_EQUAL?: InputMaybe<Scalars["String"]>;
-  namespace_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_EQUAL?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_EQUAL?: InputMaybe<Scalars["String"]>;
-  piEmail_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_EQUAL?: InputMaybe<Scalars["String"]>;
-  projectManagerName_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_EQUAL?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_EQUAL?: InputMaybe<Scalars["String"]>;
-  requestJson_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_EQUAL?: InputMaybe<Scalars["String"]>;
-  smileRequestId_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_EQUAL?: InputMaybe<Scalars["String"]>;
-  strand_GT?: InputMaybe<Scalars["Int"]>;
-  strand_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-};
-
-export type RequestMetadataRequestsHasMetadataRelationship = {
-  __typename?: "RequestMetadataRequestsHasMetadataRelationship";
-  cursor: Scalars["String"];
-  node: Request;
-};
-
-export type RequestMetadataRequestsHasMetadataUpdateConnectionInput = {
-  node?: InputMaybe<RequestUpdateInput>;
-};
-
-export type RequestMetadataRequestsHasMetadataUpdateFieldInput = {
-  connect?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataConnectFieldInput>
-  >;
-  create?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataCreateFieldInput>
-  >;
-  delete?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataDeleteFieldInput>
-  >;
-  disconnect?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataDisconnectFieldInput>
-  >;
-  update?: InputMaybe<RequestMetadataRequestsHasMetadataUpdateConnectionInput>;
-  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
 };
 
 /** Fields to sort RequestMetadata by. The order in which sorts are applied is not guaranteed when specifying many fields in one RequestMetadataSort object. */
@@ -5337,9 +4661,6 @@ export type RequestMetadataUpdateInput = {
   igoRequestId?: InputMaybe<Scalars["String"]>;
   importDate?: InputMaybe<Scalars["String"]>;
   requestMetadataJson?: InputMaybe<Scalars["String"]>;
-  requestsHasMetadata?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataUpdateFieldInput>
-  >;
 };
 
 export type RequestMetadataWhere = {
@@ -5388,19 +4709,6 @@ export type RequestMetadataWhere = {
   requestMetadataJson_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   requestMetadataJson_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   requestMetadataJson_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  requestsHasMetadataAggregate?: InputMaybe<RequestMetadataRequestsHasMetadataAggregateInput>;
-  requestsHasMetadataConnection_ALL?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-  requestsHasMetadataConnection_NONE?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-  requestsHasMetadataConnection_SINGLE?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-  requestsHasMetadataConnection_SOME?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-  /** Return RequestMetadata where all of the related Requests match this filter */
-  requestsHasMetadata_ALL?: InputMaybe<RequestWhere>;
-  /** Return RequestMetadata where none of the related Requests match this filter */
-  requestsHasMetadata_NONE?: InputMaybe<RequestWhere>;
-  /** Return RequestMetadata where one of the related Requests match this filter */
-  requestsHasMetadata_SINGLE?: InputMaybe<RequestWhere>;
-  /** Return RequestMetadata where some of the related Requests match this filter */
-  requestsHasMetadata_SOME?: InputMaybe<RequestWhere>;
 };
 
 export type RequestOptions = {
@@ -5540,29 +4848,11 @@ export type RequestProjectsHasRequestUpdateFieldInput = {
 };
 
 export type RequestRelationInput = {
-  hasMetadataRequestMetadata?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataCreateFieldInput>
-  >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesCreateFieldInput>>;
   projectsHasRequest?: InputMaybe<
     Array<RequestProjectsHasRequestCreateFieldInput>
   >;
 };
-
-export type RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection =
-  {
-    __typename?: "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection";
-    count: Scalars["Int"];
-    node?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection>;
-  };
-
-export type RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection =
-  {
-    __typename?: "RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection";
-    igoRequestId: StringAggregateSelectionNonNullable;
-    importDate: StringAggregateSelectionNonNullable;
-    requestMetadataJson: StringAggregateSelectionNonNullable;
-  };
 
 export type RequestSampleHasSampleSamplesAggregationSelection = {
   __typename?: "RequestSampleHasSampleSamplesAggregationSelection";
@@ -5609,9 +4899,6 @@ export type RequestUpdateInput = {
   dataAnalystEmail?: InputMaybe<Scalars["String"]>;
   dataAnalystName?: InputMaybe<Scalars["String"]>;
   genePanel?: InputMaybe<Scalars["String"]>;
-  hasMetadataRequestMetadata?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataUpdateFieldInput>
-  >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesUpdateFieldInput>>;
   igoProjectId?: InputMaybe<Scalars["String"]>;
   igoRequestId?: InputMaybe<Scalars["String"]>;
@@ -5682,19 +4969,6 @@ export type RequestWhere = {
   genePanel_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   genePanel_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  hasMetadataRequestMetadataAggregate?: InputMaybe<RequestHasMetadataRequestMetadataAggregateInput>;
-  hasMetadataRequestMetadataConnection_ALL?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
-  hasMetadataRequestMetadataConnection_NONE?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
-  hasMetadataRequestMetadataConnection_SINGLE?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
-  hasMetadataRequestMetadataConnection_SOME?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
-  /** Return Requests where all of the related RequestMetadata match this filter */
-  hasMetadataRequestMetadata_ALL?: InputMaybe<RequestMetadataWhere>;
-  /** Return Requests where none of the related RequestMetadata match this filter */
-  hasMetadataRequestMetadata_NONE?: InputMaybe<RequestMetadataWhere>;
-  /** Return Requests where one of the related RequestMetadata match this filter */
-  hasMetadataRequestMetadata_SINGLE?: InputMaybe<RequestMetadataWhere>;
-  /** Return Requests where some of the related RequestMetadata match this filter */
-  hasMetadataRequestMetadata_SOME?: InputMaybe<RequestMetadataWhere>;
   hasSampleSamplesAggregate?: InputMaybe<RequestHasSampleSamplesAggregateInput>;
   hasSampleSamplesConnection_ALL?: InputMaybe<RequestHasSampleSamplesConnectionWhere>;
   hasSampleSamplesConnection_NONE?: InputMaybe<RequestHasSampleSamplesConnectionWhere>;
@@ -6351,6 +5625,7 @@ export type SampleCohortCohortsHasCohortSampleAggregationSelection = {
 export type SampleCohortCohortsHasCohortSampleNodeAggregateSelection = {
   __typename?: "SampleCohortCohortsHasCohortSampleNodeAggregateSelection";
   cohortId: StringAggregateSelectionNonNullable;
+  initialCohortDeliveryDate: StringAggregateSelectionNullable;
 };
 
 export type SampleCohortsHasCohortSampleAggregateInput = {
@@ -6431,6 +5706,26 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
   cohortId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_EQUAL?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_GT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_GTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type SampleCohortsHasCohortSampleRelationship = {
@@ -8976,10 +8271,10 @@ export type SampleTempoHasTempoTemposAggregationSelection = {
 
 export type SampleTempoHasTempoTemposNodeAggregateSelection = {
   __typename?: "SampleTempoHasTempoTemposNodeAggregateSelection";
-  accessLevel: StringAggregateSelectionNonNullable;
+  accessLevel: StringAggregateSelectionNullable;
   billedBy: StringAggregateSelectionNullable;
   costCenter: StringAggregateSelectionNullable;
-  custodianInformation: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNullable;
   smileTempoId: StringAggregateSelectionNonNullable;
 };
 
@@ -10141,11 +9436,11 @@ export type StringAggregateSelectionNullable = {
 
 export type Tempo = {
   __typename?: "Tempo";
-  accessLevel: Scalars["String"];
-  billed: Scalars["Boolean"];
+  accessLevel?: Maybe<Scalars["String"]>;
+  billed?: Maybe<Scalars["Boolean"]>;
   billedBy?: Maybe<Scalars["String"]>;
   costCenter?: Maybe<Scalars["String"]>;
-  custodianInformation: Scalars["String"];
+  custodianInformation?: Maybe<Scalars["String"]>;
   hasEventBamCompletes: Array<BamComplete>;
   hasEventBamCompletesAggregate?: Maybe<TempoBamCompleteHasEventBamCompletesAggregationSelection>;
   hasEventBamCompletesConnection: TempoHasEventBamCompletesConnection;
@@ -10239,11 +9534,11 @@ export type TempoSamplesHasTempoConnectionArgs = {
 
 export type TempoAggregateSelection = {
   __typename?: "TempoAggregateSelection";
-  accessLevel: StringAggregateSelectionNonNullable;
+  accessLevel: StringAggregateSelectionNullable;
   billedBy: StringAggregateSelectionNullable;
   costCenter: StringAggregateSelectionNullable;
   count: Scalars["Int"];
-  custodianInformation: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNullable;
   smileTempoId: StringAggregateSelectionNonNullable;
 };
 
@@ -10277,11 +9572,11 @@ export type TempoConnectWhere = {
 };
 
 export type TempoCreateInput = {
-  accessLevel: Scalars["String"];
-  billed: Scalars["Boolean"];
+  accessLevel?: InputMaybe<Scalars["String"]>;
+  billed?: InputMaybe<Scalars["Boolean"]>;
   billedBy?: InputMaybe<Scalars["String"]>;
   costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation: Scalars["String"];
+  custodianInformation?: InputMaybe<Scalars["String"]>;
   hasEventBamCompletes?: InputMaybe<TempoHasEventBamCompletesFieldInput>;
   hasEventMafCompletes?: InputMaybe<TempoHasEventMafCompletesFieldInput>;
   hasEventQcCompletes?: InputMaybe<TempoHasEventQcCompletesFieldInput>;
@@ -10985,11 +10280,11 @@ export type TempoWhere = {
   accessLevel?: InputMaybe<Scalars["String"]>;
   accessLevel_CONTAINS?: InputMaybe<Scalars["String"]>;
   accessLevel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  accessLevel_IN?: InputMaybe<Array<Scalars["String"]>>;
+  accessLevel_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   accessLevel_NOT?: InputMaybe<Scalars["String"]>;
   accessLevel_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
   accessLevel_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  accessLevel_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  accessLevel_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   accessLevel_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   accessLevel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   billed?: InputMaybe<Scalars["Boolean"]>;
@@ -11017,11 +10312,13 @@ export type TempoWhere = {
   custodianInformation?: InputMaybe<Scalars["String"]>;
   custodianInformation_CONTAINS?: InputMaybe<Scalars["String"]>;
   custodianInformation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  custodianInformation_IN?: InputMaybe<Array<Scalars["String"]>>;
+  custodianInformation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   custodianInformation_NOT?: InputMaybe<Scalars["String"]>;
   custodianInformation_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
   custodianInformation_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  custodianInformation_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  custodianInformation_NOT_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]>>
+  >;
   custodianInformation_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   custodianInformation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   hasEventBamCompletesAggregate?: InputMaybe<TempoHasEventBamCompletesAggregateInput>;
@@ -11372,11 +10669,11 @@ export type FindSamplesByInputValueQuery = {
         hasTempoTempos: Array<{
           __typename?: "Tempo";
           smileTempoId: string;
-          billed: boolean;
+          billed?: boolean | null;
           billedBy?: string | null;
           costCenter?: string | null;
-          custodianInformation: string;
-          accessLevel: string;
+          custodianInformation?: string | null;
+          accessLevel?: string | null;
           hasEventBamCompletes: Array<{
             __typename?: "BamComplete";
             date: string;
@@ -11466,11 +10763,11 @@ export type SampleMetadataPartsFragment = {
 export type TempoPartsFragment = {
   __typename?: "Tempo";
   smileTempoId: string;
-  billed: boolean;
+  billed?: boolean | null;
   billedBy?: string | null;
   costCenter?: string | null;
-  custodianInformation: string;
-  accessLevel: string;
+  custodianInformation?: string | null;
+  accessLevel?: string | null;
 };
 
 export type SamplesQueryVariables = Exact<{
@@ -11521,11 +10818,11 @@ export type SamplesQuery = {
     hasTempoTempos: Array<{
       __typename?: "Tempo";
       smileTempoId: string;
-      billed: boolean;
+      billed?: boolean | null;
       billedBy?: string | null;
       costCenter?: string | null;
-      custodianInformation: string;
-      accessLevel: string;
+      custodianInformation?: string | null;
+      accessLevel?: string | null;
     }>;
   }>;
 };
@@ -11580,11 +10877,11 @@ export type UpdateSamplesMutation = {
       hasTempoTempos: Array<{
         __typename?: "Tempo";
         smileTempoId: string;
-        billed: boolean;
+        billed?: boolean | null;
         billedBy?: string | null;
         costCenter?: string | null;
-        custodianInformation: string;
-        accessLevel: string;
+        custodianInformation?: string | null;
+        accessLevel?: string | null;
       }>;
     }>;
   };
@@ -11617,6 +10914,7 @@ export type CohortsListQuery = {
   cohorts: Array<{
     __typename?: "Cohort";
     cohortId: string;
+    initialCohortDeliveryDate?: string | null;
     hasCohortCompleteCohortCompletes: Array<{
       __typename?: "CohortComplete";
       type: string;
@@ -11637,7 +10935,7 @@ export type CohortsListQuery = {
       hasTempoTempos: Array<{
         __typename?: "Tempo";
         smileTempoId: string;
-        billed: boolean;
+        billed?: boolean | null;
       }>;
     }>;
   }>;
@@ -12206,6 +11504,7 @@ export const CohortsListDocument = gql`
     }
     cohorts(where: $where, options: $options) {
       cohortId
+      initialCohortDeliveryDate
       hasCohortCompleteCohortCompletes(
         options: $hasCohortCompleteCohortCompletesOptions2
       ) {

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -1,5 +1,6 @@
 import {
   PatientWhere,
+  PatientsListQuery,
   SampleWhere,
   useGetPatientIdsTripletsLazyQuery,
   usePatientsListLazyQuery,
@@ -16,7 +17,6 @@ import { parseUserSearchVal } from "../../utils/parseSearchQueries";
 import {
   PatientsListColumns,
   SampleMetadataDetailsColumns,
-  preparePatientDataForAgGrid,
   sampleFilterWhereVariables,
 } from "../../shared/helpers";
 import { getUserEmail } from "../../utils/getUserEmail";
@@ -218,9 +218,7 @@ export default function PatientsPage({
           valueGetter: ({
             data,
           }: {
-            data: ReturnType<
-              typeof preparePatientDataForAgGrid
-            >["patients"][number];
+            data: PatientsListQuery["patients"][number];
           }) => {
             const cmoId = data.cmoPatientId;
 
@@ -253,7 +251,6 @@ export default function PatientsPage({
         colDefs={ActivePatientsListColumns}
         dataName={dataName}
         lazyRecordsQuery={usePatientsListLazyQuery}
-        prepareDataForAgGrid={preparePatientDataForAgGrid}
         queryFilterWhereVariables={patientFilterWhereVariables}
         userSearchVal={userSearchVal}
         setUserSearchVal={setUserSearchVal}

--- a/frontend/src/pages/requests/RequestsPage.tsx
+++ b/frontend/src/pages/requests/RequestsPage.tsx
@@ -10,7 +10,6 @@ import {
   prepareSampleMetadataForAgGrid,
   handleSearch,
   sampleFilterWhereVariables,
-  prepareRequestDataForAgGrid,
 } from "../../shared/helpers";
 import RecordsList from "../../components/RecordsList";
 import { useParams } from "react-router-dom";
@@ -79,7 +78,6 @@ export default function RequestsPage() {
         colDefs={RequestsListColumns}
         dataName={dataName}
         lazyRecordsQuery={useRequestsListLazyQuery}
-        prepareDataForAgGrid={prepareRequestDataForAgGrid}
         queryFilterWhereVariables={requestFilterWhereVariables}
         userSearchVal={userSearchVal}
         setUserSearchVal={setUserSearchVal}

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -47,7 +47,7 @@ export default function SamplesPage() {
               variant="outline-secondary"
               active={_.isEqual(columnDefs, combinedSampleDetailsColumns)}
             >
-              View all
+              View all columns
             </Button>{" "}
             <Button
               onClick={() => {
@@ -57,7 +57,7 @@ export default function SamplesPage() {
               variant="outline-secondary"
               active={_.isEqual(columnDefs, ReadOnlyCohortSampleDetailsColumns)}
             >
-              Tempo fields
+              View TEMPO columns
             </Button>
           </>
         }

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -552,9 +552,7 @@ export function prepareCohortDataForAgGrid(
       totalSamples: cohort.hasCohortSampleSamplesConnection.totalCount,
       smileSampleIds: samples.map((s) => s.smileSampleId),
       billed: allSamplesBilled === true ? "Yes" : "No",
-      initialCohortDeliveryDate: formatDate(
-        cohortCompletes?.slice(-1)[0]?.date
-      ),
+      initialCohortDeliveryDate: formatDate(cohort.initialCohortDeliveryDate),
       completeDate: formatDate(latestCohortDeliveryDate?.date),
       endUsers: latestCohortDeliveryDate?.endUsers,
       pmUsers: latestCohortDeliveryDate?.pmUsers,

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -13,7 +13,6 @@ import "ag-grid-enterprise";
 import {
   CohortsListQuery,
   PatientsListQuery,
-  RequestsListQuery,
   Sample,
   SampleMetadata,
   SampleMetadataWhere,
@@ -77,7 +76,7 @@ export const RequestsListColumns: ColDef[] = [
     headerName: "IGO Project ID",
   },
   {
-    field: "totalSamples",
+    field: "totalSampleCount",
     headerName: "# Samples",
     cellClass: (params) => {
       if (params.data.revisable === false) {
@@ -144,22 +143,6 @@ export const RequestsListColumns: ColDef[] = [
     headerName: "Other Contact Emails",
   },
 ];
-
-export function prepareRequestDataForAgGrid(
-  requestsListQueryResult: RequestsListQuery
-) {
-  const newRequests = requestsListQueryResult.requests.map((request) => {
-    return {
-      totalSamples: request.hasSampleSamplesConnection?.totalCount,
-      ...request,
-    };
-  });
-
-  return {
-    requestsConnection: requestsListQueryResult.requestsConnection,
-    requests: newRequests,
-  };
-}
 
 export function preparePatientDataForAgGrid(
   patientsListQueryResult: PatientsListQuery

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -546,7 +546,7 @@ export const CohortsListColumns: ColDef[] = [
     headerName: "Cohort ID",
   },
   {
-    field: "totalSamples",
+    field: "totalSampleCount",
     headerName: "# Samples",
     sortable: false,
   },

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -475,34 +475,7 @@ export function prepareCohortDataForAgGrid(
   cohortsListQueryResult: CohortsListQuery,
   filterModel: IServerSideGetRowsRequest["filterModel"]
 ) {
-  let newCohorts = cohortsListQueryResult.cohorts.map((cohort) => {
-    const samples = cohort.hasCohortSampleSamples;
-    const cohortCompletes = cohort.hasCohortCompleteCohortCompletes;
-
-    const allSamplesBilled =
-      samples.length > 0 &&
-      samples?.every((sample) => {
-        return sample.hasTempoTempos?.[0].billed === true;
-      });
-
-    const latestCohortDeliveryDate = cohortCompletes?.[0];
-
-    return {
-      cohortId: cohort.cohortId,
-      totalSamples: cohort.hasCohortSampleSamplesConnection.totalCount,
-      smileSampleIds: samples.map((s) => s.smileSampleId),
-      billed: allSamplesBilled === true ? "Yes" : "No",
-      initialCohortDeliveryDate: formatDate(cohort.initialCohortDeliveryDate),
-      completeDate: formatDate(latestCohortDeliveryDate?.date),
-      endUsers: latestCohortDeliveryDate?.endUsers,
-      pmUsers: latestCohortDeliveryDate?.pmUsers,
-      projectTitle: latestCohortDeliveryDate?.projectTitle,
-      projectSubtitle: latestCohortDeliveryDate?.projectSubtitle,
-      status: latestCohortDeliveryDate?.status,
-      type: latestCohortDeliveryDate?.type,
-    };
-  });
-
+  let newCohorts = [...cohortsListQueryResult.cohorts];
   let newCohortsConnection = { ...cohortsListQueryResult.cohortsConnection };
 
   if ("initialCohortDeliveryDate" in filterModel) {
@@ -534,8 +507,8 @@ export function prepareCohortDataForAgGrid(
 
   const uniqueSmileSampleIds: Set<string> = new Set();
   newCohorts.forEach((cohort) => {
-    cohort.smileSampleIds.forEach((id) => {
-      uniqueSmileSampleIds.add(id);
+    cohort.smileSampleIds?.forEach((id) => {
+      uniqueSmileSampleIds.add(id!);
     });
   });
 
@@ -599,6 +572,7 @@ export const CohortsListColumns: ColDef[] = [
       minValidYear: 2016,
       maxValidYear: new Date().getFullYear(),
     },
+    valueFormatter: (params) => params.value && formatDate(params.value),
   },
   {
     field: "completeDate",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -12,7 +12,6 @@ import { Button } from "react-bootstrap";
 import "ag-grid-enterprise";
 import {
   CohortsListQuery,
-  PatientsListQuery,
   Sample,
   SampleMetadata,
   SampleMetadataWhere,
@@ -144,48 +143,6 @@ export const RequestsListColumns: ColDef[] = [
   },
 ];
 
-export function preparePatientDataForAgGrid(
-  patientsListQueryResult: PatientsListQuery
-) {
-  const newPatients = patientsListQueryResult.patients.map((patient) => {
-    const samples = patient.hasSampleSamples;
-    const patientAliases = patient.patientAliasesIsAlias;
-
-    const cmoPatientId = patientAliases?.find(
-      (pa) => pa.namespace === "cmoId"
-    )?.value;
-    const dmpPatientId = patientAliases?.find(
-      (pa) => pa.namespace === "dmpId"
-    )?.value;
-
-    const cmoSampleIds = samples?.map((s) => {
-      const sampleMetadata = s.hasMetadataSampleMetadata[0];
-      return sampleMetadata?.cmoSampleName || sampleMetadata?.primaryId;
-    });
-
-    const additionalProperties =
-      samples[0]?.hasMetadataSampleMetadata[0]?.additionalProperties;
-    const additionalPropertiesJson = additionalProperties
-      ? JSON.parse(additionalProperties)
-      : {};
-
-    return {
-      cmoPatientId,
-      dmpPatientId,
-      cmoSampleIds,
-      smilePatientId: patient.smilePatientId,
-      totalSamples: patient.hasSampleSamplesConnection?.totalCount,
-      consentPartA: additionalPropertiesJson["consent-parta"],
-      consentPartC: additionalPropertiesJson["consent-partc"],
-    };
-  });
-
-  return {
-    patientsConnection: patientsListQueryResult.patientsConnection,
-    patients: newPatients,
-  };
-}
-
 export const PatientsListColumns: ColDef[] = [
   {
     headerName: "View Samples",
@@ -224,7 +181,7 @@ export const PatientsListColumns: ColDef[] = [
     sortable: false,
   },
   {
-    field: "totalSamples",
+    field: "totalSampleCount",
     headerName: "# Samples",
     sortable: false,
   },

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1444,6 +1444,14 @@ export type DeleteInfo = {
   relationshipsDeleted: Scalars["Int"];
 };
 
+export type IntAggregateSelectionNullable = {
+  __typename?: "IntAggregateSelectionNullable";
+  average?: Maybe<Scalars["Float"]>;
+  max?: Maybe<Scalars["Int"]>;
+  min?: Maybe<Scalars["Int"]>;
+  sum?: Maybe<Scalars["Int"]>;
+};
+
 export type MafComplete = {
   __typename?: "MafComplete";
   date: Scalars["String"];
@@ -3352,6 +3360,31 @@ export type ProjectHasRequestRequestsNodeAggregationWhereInput = {
   strand_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   strand_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   strand_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type ProjectHasRequestRequestsRelationship = {
@@ -3413,6 +3446,7 @@ export type ProjectRequestHasRequestRequestsNodeAggregateSelection = {
   requestJson: StringAggregateSelectionNonNullable;
   smileRequestId: StringAggregateSelectionNonNullable;
   strand: StringAggregateSelectionNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
 };
 
 /** Fields to sort Projects by. The order in which sorts are applied is not guaranteed when specifying many fields in one ProjectSort object. */
@@ -4153,6 +4187,7 @@ export type Request = {
   requestJson: Scalars["String"];
   smileRequestId: Scalars["String"];
   strand?: Maybe<Scalars["String"]>;
+  totalSampleCount?: Maybe<Scalars["Int"]>;
 };
 
 export type RequestHasSampleSamplesArgs = {
@@ -4215,6 +4250,7 @@ export type RequestAggregateSelection = {
   requestJson: StringAggregateSelectionNonNullable;
   smileRequestId: StringAggregateSelectionNonNullable;
   strand: StringAggregateSelectionNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
 };
 
 export type RequestConnectInput = {
@@ -4255,6 +4291,7 @@ export type RequestCreateInput = {
   requestJson: Scalars["String"];
   smileRequestId: Scalars["String"];
   strand?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
 };
 
 export type RequestDeleteInput = {
@@ -4890,6 +4927,7 @@ export type RequestSort = {
   requestJson?: InputMaybe<SortDirection>;
   smileRequestId?: InputMaybe<SortDirection>;
   strand?: InputMaybe<SortDirection>;
+  totalSampleCount?: InputMaybe<SortDirection>;
 };
 
 export type RequestUpdateInput = {
@@ -4921,6 +4959,9 @@ export type RequestUpdateInput = {
   requestJson?: InputMaybe<Scalars["String"]>;
   smileRequestId?: InputMaybe<Scalars["String"]>;
   strand?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_DECREMENT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_INCREMENT?: InputMaybe<Scalars["Int"]>;
 };
 
 export type RequestWhere = {
@@ -5150,6 +5191,14 @@ export type RequestWhere = {
   strand_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   strand_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   strand_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_IN?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_NOT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
 };
 
 export type RequestsConnection = {
@@ -7625,6 +7674,7 @@ export type SampleRequestRequestsHasSampleNodeAggregateSelection = {
   requestJson: StringAggregateSelectionNonNullable;
   smileRequestId: StringAggregateSelectionNonNullable;
   strand: StringAggregateSelectionNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
 };
 
 export type SampleRequestsHasSampleAggregateInput = {
@@ -8063,6 +8113,31 @@ export type SampleRequestsHasSampleNodeAggregationWhereInput = {
   strand_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   strand_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   strand_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type SampleRequestsHasSampleRelationship = {
@@ -10502,6 +10577,7 @@ export type RequestsListQuery = {
     __typename?: "Request";
     igoRequestId: string;
     igoProjectId: string;
+    totalSampleCount?: number | null;
     genePanel: string;
     dataAnalystName: string;
     dataAnalystEmail: string;
@@ -10623,6 +10699,7 @@ export type FindSamplesByInputValueQuery = {
               __typename?: "Request";
               igoRequestId: string;
               igoProjectId: string;
+              totalSampleCount?: number | null;
               genePanel: string;
               dataAnalystName: string;
               dataAnalystEmail: string;
@@ -10699,6 +10776,7 @@ export type RequestPartsFragment = {
   __typename?: "Request";
   igoRequestId: string;
   igoProjectId: string;
+  totalSampleCount?: number | null;
   genePanel: string;
   dataAnalystName: string;
   dataAnalystEmail: string;
@@ -10941,6 +11019,7 @@ export const RequestPartsFragmentDoc = gql`
   fragment RequestParts on Request {
     igoRequestId
     igoProjectId
+    totalSampleCount
     genePanel
     dataAnalystName
     dataAnalystEmail

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -2124,6 +2124,11 @@ export type PageInfo = {
 
 export type Patient = {
   __typename?: "Patient";
+  cmoPatientId?: Maybe<Scalars["String"]>;
+  cmoSampleIds?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  consentPartA?: Maybe<Scalars["String"]>;
+  consentPartC?: Maybe<Scalars["String"]>;
+  dmpPatientId?: Maybe<Scalars["String"]>;
   hasSampleSamples: Array<Sample>;
   hasSampleSamplesAggregate?: Maybe<PatientSampleHasSampleSamplesAggregationSelection>;
   hasSampleSamplesConnection: PatientHasSampleSamplesConnection;
@@ -2131,6 +2136,7 @@ export type Patient = {
   patientAliasesIsAliasAggregate?: Maybe<PatientPatientAliasPatientAliasesIsAliasAggregationSelection>;
   patientAliasesIsAliasConnection: PatientPatientAliasesIsAliasConnection;
   smilePatientId: Scalars["String"];
+  totalSampleCount?: Maybe<Scalars["Int"]>;
 };
 
 export type PatientHasSampleSamplesArgs = {
@@ -2173,8 +2179,13 @@ export type PatientPatientAliasesIsAliasConnectionArgs = {
 
 export type PatientAggregateSelection = {
   __typename?: "PatientAggregateSelection";
+  cmoPatientId: StringAggregateSelectionNullable;
+  consentPartA: StringAggregateSelectionNullable;
+  consentPartC: StringAggregateSelectionNullable;
   count: Scalars["Int"];
+  dmpPatientId: StringAggregateSelectionNullable;
   smilePatientId: StringAggregateSelectionNonNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
 };
 
 export type PatientAlias = {
@@ -2302,6 +2313,86 @@ export type PatientAliasIsAliasPatientsFieldInput = {
 export type PatientAliasIsAliasPatientsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<PatientAliasIsAliasPatientsNodeAggregationWhereInput>>;
   OR?: InputMaybe<Array<PatientAliasIsAliasPatientsNodeAggregationWhereInput>>;
+  cmoPatientId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_EQUAL?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_GT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  consentPartA_EQUAL?: InputMaybe<Scalars["String"]>;
+  consentPartA_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  consentPartC_EQUAL?: InputMaybe<Scalars["String"]>;
+  consentPartC_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_EQUAL?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_GT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_GTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   smilePatientId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   smilePatientId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   smilePatientId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -2322,6 +2413,31 @@ export type PatientAliasIsAliasPatientsNodeAggregationWhereInput = {
   smilePatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   smilePatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   smilePatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type PatientAliasIsAliasPatientsRelationship = {
@@ -2360,7 +2476,12 @@ export type PatientAliasPatientIsAliasPatientsAggregationSelection = {
 
 export type PatientAliasPatientIsAliasPatientsNodeAggregateSelection = {
   __typename?: "PatientAliasPatientIsAliasPatientsNodeAggregateSelection";
+  cmoPatientId: StringAggregateSelectionNullable;
+  consentPartA: StringAggregateSelectionNullable;
+  consentPartC: StringAggregateSelectionNullable;
+  dmpPatientId: StringAggregateSelectionNullable;
   smilePatientId: StringAggregateSelectionNonNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
 };
 
 export type PatientAliasRelationInput = {
@@ -2442,9 +2563,15 @@ export type PatientConnectWhere = {
 };
 
 export type PatientCreateInput = {
+  cmoPatientId?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  consentPartA?: InputMaybe<Scalars["String"]>;
+  consentPartC?: InputMaybe<Scalars["String"]>;
+  dmpPatientId?: InputMaybe<Scalars["String"]>;
   hasSampleSamples?: InputMaybe<PatientHasSampleSamplesFieldInput>;
   patientAliasesIsAlias?: InputMaybe<PatientPatientAliasesIsAliasFieldInput>;
   smilePatientId: Scalars["String"];
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
 };
 
 export type PatientDeleteInput = {
@@ -2796,20 +2923,79 @@ export type PatientSampleHasSampleSamplesNodeAggregateSelection = {
 
 /** Fields to sort Patients by. The order in which sorts are applied is not guaranteed when specifying many fields in one PatientSort object. */
 export type PatientSort = {
+  cmoPatientId?: InputMaybe<SortDirection>;
+  consentPartA?: InputMaybe<SortDirection>;
+  consentPartC?: InputMaybe<SortDirection>;
+  dmpPatientId?: InputMaybe<SortDirection>;
   smilePatientId?: InputMaybe<SortDirection>;
+  totalSampleCount?: InputMaybe<SortDirection>;
 };
 
 export type PatientUpdateInput = {
+  cmoPatientId?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds_POP?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  consentPartA?: InputMaybe<Scalars["String"]>;
+  consentPartC?: InputMaybe<Scalars["String"]>;
+  dmpPatientId?: InputMaybe<Scalars["String"]>;
   hasSampleSamples?: InputMaybe<Array<PatientHasSampleSamplesUpdateFieldInput>>;
   patientAliasesIsAlias?: InputMaybe<
     Array<PatientPatientAliasesIsAliasUpdateFieldInput>
   >;
   smilePatientId?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_DECREMENT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_INCREMENT?: InputMaybe<Scalars["Int"]>;
 };
 
 export type PatientWhere = {
   AND?: InputMaybe<Array<PatientWhere>>;
   OR?: InputMaybe<Array<PatientWhere>>;
+  cmoPatientId?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoPatientId_NOT?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoPatientId_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds_INCLUDES?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_NOT?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds_NOT_INCLUDES?: InputMaybe<Scalars["String"]>;
+  consentPartA?: InputMaybe<Scalars["String"]>;
+  consentPartA_CONTAINS?: InputMaybe<Scalars["String"]>;
+  consentPartA_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartA_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  consentPartA_NOT?: InputMaybe<Scalars["String"]>;
+  consentPartA_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  consentPartA_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartA_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  consentPartA_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartA_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartC?: InputMaybe<Scalars["String"]>;
+  consentPartC_CONTAINS?: InputMaybe<Scalars["String"]>;
+  consentPartC_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartC_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  consentPartC_NOT?: InputMaybe<Scalars["String"]>;
+  consentPartC_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  consentPartC_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartC_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  consentPartC_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  consentPartC_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  dmpPatientId?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_CONTAINS?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  dmpPatientId_NOT?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  dmpPatientId_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   hasSampleSamplesAggregate?: InputMaybe<PatientHasSampleSamplesAggregateInput>;
   hasSampleSamplesConnection_ALL?: InputMaybe<PatientHasSampleSamplesConnectionWhere>;
   hasSampleSamplesConnection_NONE?: InputMaybe<PatientHasSampleSamplesConnectionWhere>;
@@ -2846,6 +3032,14 @@ export type PatientWhere = {
   smilePatientId_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   smilePatientId_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   smilePatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_IN?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_NOT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
 };
 
 export type PatientsConnection = {
@@ -7528,7 +7722,12 @@ export type SamplePatientPatientsHasSampleAggregationSelection = {
 
 export type SamplePatientPatientsHasSampleNodeAggregateSelection = {
   __typename?: "SamplePatientPatientsHasSampleNodeAggregateSelection";
+  cmoPatientId: StringAggregateSelectionNullable;
+  consentPartA: StringAggregateSelectionNullable;
+  consentPartC: StringAggregateSelectionNullable;
+  dmpPatientId: StringAggregateSelectionNullable;
   smilePatientId: StringAggregateSelectionNonNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
 };
 
 export type SamplePatientsHasSampleAggregateInput = {
@@ -7587,6 +7786,86 @@ export type SamplePatientsHasSampleFieldInput = {
 export type SamplePatientsHasSampleNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SamplePatientsHasSampleNodeAggregationWhereInput>>;
   OR?: InputMaybe<Array<SamplePatientsHasSampleNodeAggregationWhereInput>>;
+  cmoPatientId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cmoPatientId_EQUAL?: InputMaybe<Scalars["String"]>;
+  cmoPatientId_GT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoPatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  consentPartA_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  consentPartA_EQUAL?: InputMaybe<Scalars["String"]>;
+  consentPartA_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartA_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  consentPartC_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  consentPartC_EQUAL?: InputMaybe<Scalars["String"]>;
+  consentPartC_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_LTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  consentPartC_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  dmpPatientId_EQUAL?: InputMaybe<Scalars["String"]>;
+  dmpPatientId_GT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_GTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_LTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  dmpPatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   smilePatientId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   smilePatientId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   smilePatientId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -7607,6 +7886,31 @@ export type SamplePatientsHasSampleNodeAggregationWhereInput = {
   smilePatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   smilePatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   smilePatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type SamplePatientsHasSampleRelationship = {
@@ -10612,6 +10916,12 @@ export type PatientsListQuery = {
   patients: Array<{
     __typename?: "Patient";
     smilePatientId: string;
+    cmoPatientId?: string | null;
+    dmpPatientId?: string | null;
+    totalSampleCount?: number | null;
+    cmoSampleIds?: Array<string | null> | null;
+    consentPartA?: string | null;
+    consentPartC?: string | null;
     hasSampleSamples: Array<{
       __typename?: "Sample";
       smileSampleId: string;
@@ -11113,6 +11423,12 @@ export const PatientsListDocument = gql`
     }
     patients(where: $where, options: $options) {
       smilePatientId
+      cmoPatientId
+      dmpPatientId
+      totalSampleCount
+      cmoSampleIds
+      consentPartA
+      consentPartC
       hasSampleSamples {
         smileSampleId
         hasMetadataSampleMetadata {

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -112,10 +112,10 @@ export type BamCompleteTempoTemposHasEventAggregationSelection = {
 
 export type BamCompleteTempoTemposHasEventNodeAggregateSelection = {
   __typename?: "BamCompleteTempoTemposHasEventNodeAggregateSelection";
-  accessLevel: StringAggregateSelectionNonNullable;
+  accessLevel: StringAggregateSelectionNullable;
   billedBy: StringAggregateSelectionNullable;
   costCenter: StringAggregateSelectionNullable;
-  custodianInformation: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNullable;
   smileTempoId: StringAggregateSelectionNonNullable;
 };
 
@@ -356,6 +356,7 @@ export type Cohort = {
   hasCohortSampleSamples: Array<Sample>;
   hasCohortSampleSamplesAggregate?: Maybe<CohortSampleHasCohortSampleSamplesAggregationSelection>;
   hasCohortSampleSamplesConnection: CohortHasCohortSampleSamplesConnection;
+  initialCohortDeliveryDate?: Maybe<Scalars["String"]>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesArgs = {
@@ -402,6 +403,7 @@ export type CohortAggregateSelection = {
   __typename?: "CohortAggregateSelection";
   cohortId: StringAggregateSelectionNonNullable;
   count: Scalars["Int"];
+  initialCohortDeliveryDate: StringAggregateSelectionNullable;
 };
 
 export type CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection =
@@ -480,6 +482,7 @@ export type CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection =
   {
     __typename?: "CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection";
     cohortId: StringAggregateSelectionNonNullable;
+    initialCohortDeliveryDate: StringAggregateSelectionNullable;
   };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateInput = {
@@ -568,6 +571,26 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   cohortId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_EQUAL?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_GT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_GTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteRelationship = {
@@ -785,6 +808,7 @@ export type CohortCreateInput = {
   cohortId: Scalars["String"];
   hasCohortCompleteCohortCompletes?: InputMaybe<CohortHasCohortCompleteCohortCompletesFieldInput>;
   hasCohortSampleSamples?: InputMaybe<CohortHasCohortSampleSamplesFieldInput>;
+  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
 };
 
 export type CohortDeleteInput = {
@@ -1240,6 +1264,7 @@ export type CohortSampleHasCohortSampleSamplesNodeAggregateSelection = {
 /** Fields to sort Cohorts by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortSort object. */
 export type CohortSort = {
   cohortId?: InputMaybe<SortDirection>;
+  initialCohortDeliveryDate?: InputMaybe<SortDirection>;
 };
 
 export type CohortUpdateInput = {
@@ -1250,6 +1275,7 @@ export type CohortUpdateInput = {
   hasCohortSampleSamples?: InputMaybe<
     Array<CohortHasCohortSampleSamplesUpdateFieldInput>
   >;
+  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
 };
 
 export type CohortWhere = {
@@ -1291,6 +1317,20 @@ export type CohortWhere = {
   hasCohortSampleSamples_SINGLE?: InputMaybe<SampleWhere>;
   /** Return Cohorts where some of the related Samples match this filter */
   hasCohortSampleSamples_SOME?: InputMaybe<SampleWhere>;
+  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_CONTAINS?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]>>
+  >;
+  initialCohortDeliveryDate_NOT?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_NOT_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]>>
+  >;
+  initialCohortDeliveryDate_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
 };
 
 export type CohortsConnection = {
@@ -1500,10 +1540,10 @@ export type MafCompleteTempoTemposHasEventAggregationSelection = {
 
 export type MafCompleteTempoTemposHasEventNodeAggregateSelection = {
   __typename?: "MafCompleteTempoTemposHasEventNodeAggregateSelection";
-  accessLevel: StringAggregateSelectionNonNullable;
+  accessLevel: StringAggregateSelectionNullable;
   billedBy: StringAggregateSelectionNullable;
   costCenter: StringAggregateSelectionNullable;
-  custodianInformation: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNullable;
   smileTempoId: StringAggregateSelectionNonNullable;
 };
 
@@ -3532,10 +3572,10 @@ export type QcCompleteTempoTemposHasEventAggregationSelection = {
 
 export type QcCompleteTempoTemposHasEventNodeAggregateSelection = {
   __typename?: "QcCompleteTempoTemposHasEventNodeAggregateSelection";
-  accessLevel: StringAggregateSelectionNonNullable;
+  accessLevel: StringAggregateSelectionNullable;
   billedBy: StringAggregateSelectionNullable;
   costCenter: StringAggregateSelectionNullable;
-  custodianInformation: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNullable;
   smileTempoId: StringAggregateSelectionNonNullable;
 };
 
@@ -4090,9 +4130,6 @@ export type Request = {
   dataAnalystEmail: Scalars["String"];
   dataAnalystName: Scalars["String"];
   genePanel: Scalars["String"];
-  hasMetadataRequestMetadata: Array<RequestMetadata>;
-  hasMetadataRequestMetadataAggregate?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection>;
-  hasMetadataRequestMetadataConnection: RequestHasMetadataRequestMetadataConnection;
   hasSampleSamples: Array<Sample>;
   hasSampleSamplesAggregate?: Maybe<RequestSampleHasSampleSamplesAggregationSelection>;
   hasSampleSamplesConnection: RequestHasSampleSamplesConnection;
@@ -4116,25 +4153,6 @@ export type Request = {
   requestJson: Scalars["String"];
   smileRequestId: Scalars["String"];
   strand?: Maybe<Scalars["String"]>;
-};
-
-export type RequestHasMetadataRequestMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  options?: InputMaybe<RequestMetadataOptions>;
-  where?: InputMaybe<RequestMetadataWhere>;
-};
-
-export type RequestHasMetadataRequestMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  where?: InputMaybe<RequestMetadataWhere>;
-};
-
-export type RequestHasMetadataRequestMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
-  sort?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionSort>>;
-  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
 };
 
 export type RequestHasSampleSamplesArgs = {
@@ -4200,9 +4218,6 @@ export type RequestAggregateSelection = {
 };
 
 export type RequestConnectInput = {
-  hasMetadataRequestMetadata?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataConnectFieldInput>
-  >;
   hasSampleSamples?: InputMaybe<
     Array<RequestHasSampleSamplesConnectFieldInput>
   >;
@@ -4221,7 +4236,6 @@ export type RequestCreateInput = {
   dataAnalystEmail: Scalars["String"];
   dataAnalystName: Scalars["String"];
   genePanel: Scalars["String"];
-  hasMetadataRequestMetadata?: InputMaybe<RequestHasMetadataRequestMetadataFieldInput>;
   hasSampleSamples?: InputMaybe<RequestHasSampleSamplesFieldInput>;
   igoProjectId: Scalars["String"];
   igoRequestId: Scalars["String"];
@@ -4244,9 +4258,6 @@ export type RequestCreateInput = {
 };
 
 export type RequestDeleteInput = {
-  hasMetadataRequestMetadata?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataDeleteFieldInput>
-  >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesDeleteFieldInput>>;
   projectsHasRequest?: InputMaybe<
     Array<RequestProjectsHasRequestDeleteFieldInput>
@@ -4254,9 +4265,6 @@ export type RequestDeleteInput = {
 };
 
 export type RequestDisconnectInput = {
-  hasMetadataRequestMetadata?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataDisconnectFieldInput>
-  >;
   hasSampleSamples?: InputMaybe<
     Array<RequestHasSampleSamplesDisconnectFieldInput>
   >;
@@ -4269,153 +4277,6 @@ export type RequestEdge = {
   __typename?: "RequestEdge";
   cursor: Scalars["String"];
   node: Request;
-};
-
-export type RequestHasMetadataRequestMetadataAggregateInput = {
-  AND?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
-  OR?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
-  node?: InputMaybe<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>;
-};
-
-export type RequestHasMetadataRequestMetadataConnectFieldInput = {
-  connect?: InputMaybe<Array<RequestMetadataConnectInput>>;
-  where?: InputMaybe<RequestMetadataConnectWhere>;
-};
-
-export type RequestHasMetadataRequestMetadataConnection = {
-  __typename?: "RequestHasMetadataRequestMetadataConnection";
-  edges: Array<RequestHasMetadataRequestMetadataRelationship>;
-  pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
-};
-
-export type RequestHasMetadataRequestMetadataConnectionSort = {
-  node?: InputMaybe<RequestMetadataSort>;
-};
-
-export type RequestHasMetadataRequestMetadataConnectionWhere = {
-  AND?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionWhere>>;
-  OR?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionWhere>>;
-  node?: InputMaybe<RequestMetadataWhere>;
-  node_NOT?: InputMaybe<RequestMetadataWhere>;
-};
-
-export type RequestHasMetadataRequestMetadataCreateFieldInput = {
-  node: RequestMetadataCreateInput;
-};
-
-export type RequestHasMetadataRequestMetadataDeleteFieldInput = {
-  delete?: InputMaybe<RequestMetadataDeleteInput>;
-  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
-};
-
-export type RequestHasMetadataRequestMetadataDisconnectFieldInput = {
-  disconnect?: InputMaybe<RequestMetadataDisconnectInput>;
-  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
-};
-
-export type RequestHasMetadataRequestMetadataFieldInput = {
-  connect?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataConnectFieldInput>
-  >;
-  create?: InputMaybe<Array<RequestHasMetadataRequestMetadataCreateFieldInput>>;
-};
-
-export type RequestHasMetadataRequestMetadataNodeAggregationWhereInput = {
-  AND?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>
-  >;
-  OR?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>
-  >;
-  igoRequestId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_EQUAL?: InputMaybe<Scalars["String"]>;
-  igoRequestId_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  importDate_EQUAL?: InputMaybe<Scalars["String"]>;
-  importDate_GT?: InputMaybe<Scalars["Int"]>;
-  importDate_GTE?: InputMaybe<Scalars["Int"]>;
-  importDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  importDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  importDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  importDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  importDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_LT?: InputMaybe<Scalars["Int"]>;
-  importDate_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  importDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  importDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  importDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  importDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_EQUAL?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-};
-
-export type RequestHasMetadataRequestMetadataRelationship = {
-  __typename?: "RequestHasMetadataRequestMetadataRelationship";
-  cursor: Scalars["String"];
-  node: RequestMetadata;
-};
-
-export type RequestHasMetadataRequestMetadataUpdateConnectionInput = {
-  node?: InputMaybe<RequestMetadataUpdateInput>;
-};
-
-export type RequestHasMetadataRequestMetadataUpdateFieldInput = {
-  connect?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataConnectFieldInput>
-  >;
-  create?: InputMaybe<Array<RequestHasMetadataRequestMetadataCreateFieldInput>>;
-  delete?: InputMaybe<Array<RequestHasMetadataRequestMetadataDeleteFieldInput>>;
-  disconnect?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataDisconnectFieldInput>
-  >;
-  update?: InputMaybe<RequestHasMetadataRequestMetadataUpdateConnectionInput>;
-  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
 };
 
 export type RequestHasSampleSamplesAggregateInput = {
@@ -4583,9 +4444,6 @@ export type RequestMetadata = {
   igoRequestId: Scalars["String"];
   importDate: Scalars["String"];
   requestMetadataJson: Scalars["String"];
-  requestsHasMetadata: Array<Request>;
-  requestsHasMetadataAggregate?: Maybe<RequestMetadataRequestRequestsHasMetadataAggregationSelection>;
-  requestsHasMetadataConnection: RequestMetadataRequestsHasMetadataConnection;
 };
 
 export type RequestMetadataHasStatusStatusesArgs = {
@@ -4607,25 +4465,6 @@ export type RequestMetadataHasStatusStatusesConnectionArgs = {
   where?: InputMaybe<RequestMetadataHasStatusStatusesConnectionWhere>;
 };
 
-export type RequestMetadataRequestsHasMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  options?: InputMaybe<RequestOptions>;
-  where?: InputMaybe<RequestWhere>;
-};
-
-export type RequestMetadataRequestsHasMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  where?: InputMaybe<RequestWhere>;
-};
-
-export type RequestMetadataRequestsHasMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
-  sort?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionSort>>;
-  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-};
-
 export type RequestMetadataAggregateSelection = {
   __typename?: "RequestMetadataAggregateSelection";
   count: Scalars["Int"];
@@ -4637,9 +4476,6 @@ export type RequestMetadataAggregateSelection = {
 export type RequestMetadataConnectInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesConnectFieldInput>
-  >;
-  requestsHasMetadata?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataConnectFieldInput>
   >;
 };
 
@@ -4659,24 +4495,17 @@ export type RequestMetadataCreateInput = {
   igoRequestId: Scalars["String"];
   importDate: Scalars["String"];
   requestMetadataJson: Scalars["String"];
-  requestsHasMetadata?: InputMaybe<RequestMetadataRequestsHasMetadataFieldInput>;
 };
 
 export type RequestMetadataDeleteInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesDeleteFieldInput>
   >;
-  requestsHasMetadata?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataDeleteFieldInput>
-  >;
 };
 
 export type RequestMetadataDisconnectInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesDisconnectFieldInput>
-  >;
-  requestsHasMetadata?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataDisconnectFieldInput>
   >;
 };
 
@@ -4804,511 +4633,6 @@ export type RequestMetadataRelationInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesCreateFieldInput>
   >;
-  requestsHasMetadata?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataCreateFieldInput>
-  >;
-};
-
-export type RequestMetadataRequestRequestsHasMetadataAggregationSelection = {
-  __typename?: "RequestMetadataRequestRequestsHasMetadataAggregationSelection";
-  count: Scalars["Int"];
-  node?: Maybe<RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection>;
-};
-
-export type RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection = {
-  __typename?: "RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection";
-  dataAccessEmails: StringAggregateSelectionNonNullable;
-  dataAnalystEmail: StringAggregateSelectionNonNullable;
-  dataAnalystName: StringAggregateSelectionNonNullable;
-  genePanel: StringAggregateSelectionNonNullable;
-  igoProjectId: StringAggregateSelectionNonNullable;
-  igoRequestId: StringAggregateSelectionNonNullable;
-  investigatorEmail: StringAggregateSelectionNonNullable;
-  investigatorName: StringAggregateSelectionNonNullable;
-  labHeadEmail: StringAggregateSelectionNonNullable;
-  labHeadName: StringAggregateSelectionNonNullable;
-  libraryType: StringAggregateSelectionNullable;
-  namespace: StringAggregateSelectionNonNullable;
-  otherContactEmails: StringAggregateSelectionNonNullable;
-  piEmail: StringAggregateSelectionNonNullable;
-  projectManagerName: StringAggregateSelectionNonNullable;
-  qcAccessEmails: StringAggregateSelectionNonNullable;
-  requestJson: StringAggregateSelectionNonNullable;
-  smileRequestId: StringAggregateSelectionNonNullable;
-  strand: StringAggregateSelectionNullable;
-};
-
-export type RequestMetadataRequestsHasMetadataAggregateInput = {
-  AND?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
-  OR?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
-  node?: InputMaybe<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>;
-};
-
-export type RequestMetadataRequestsHasMetadataConnectFieldInput = {
-  connect?: InputMaybe<Array<RequestConnectInput>>;
-  where?: InputMaybe<RequestConnectWhere>;
-};
-
-export type RequestMetadataRequestsHasMetadataConnection = {
-  __typename?: "RequestMetadataRequestsHasMetadataConnection";
-  edges: Array<RequestMetadataRequestsHasMetadataRelationship>;
-  pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
-};
-
-export type RequestMetadataRequestsHasMetadataConnectionSort = {
-  node?: InputMaybe<RequestSort>;
-};
-
-export type RequestMetadataRequestsHasMetadataConnectionWhere = {
-  AND?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionWhere>>;
-  OR?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionWhere>>;
-  node?: InputMaybe<RequestWhere>;
-  node_NOT?: InputMaybe<RequestWhere>;
-};
-
-export type RequestMetadataRequestsHasMetadataCreateFieldInput = {
-  node: RequestCreateInput;
-};
-
-export type RequestMetadataRequestsHasMetadataDeleteFieldInput = {
-  delete?: InputMaybe<RequestDeleteInput>;
-  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-};
-
-export type RequestMetadataRequestsHasMetadataDisconnectFieldInput = {
-  disconnect?: InputMaybe<RequestDisconnectInput>;
-  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-};
-
-export type RequestMetadataRequestsHasMetadataFieldInput = {
-  connect?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataConnectFieldInput>
-  >;
-  create?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataCreateFieldInput>
-  >;
-};
-
-export type RequestMetadataRequestsHasMetadataNodeAggregationWhereInput = {
-  AND?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>
-  >;
-  OR?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>
-  >;
-  dataAccessEmails_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_EQUAL?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_EQUAL?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_EQUAL?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_EQUAL?: InputMaybe<Scalars["String"]>;
-  genePanel_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_EQUAL?: InputMaybe<Scalars["String"]>;
-  igoProjectId_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_EQUAL?: InputMaybe<Scalars["String"]>;
-  igoRequestId_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_EQUAL?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_EQUAL?: InputMaybe<Scalars["String"]>;
-  investigatorName_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_EQUAL?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_EQUAL?: InputMaybe<Scalars["String"]>;
-  labHeadName_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_EQUAL?: InputMaybe<Scalars["String"]>;
-  libraryType_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_EQUAL?: InputMaybe<Scalars["String"]>;
-  namespace_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_EQUAL?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_EQUAL?: InputMaybe<Scalars["String"]>;
-  piEmail_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_EQUAL?: InputMaybe<Scalars["String"]>;
-  projectManagerName_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_EQUAL?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_EQUAL?: InputMaybe<Scalars["String"]>;
-  requestJson_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_EQUAL?: InputMaybe<Scalars["String"]>;
-  smileRequestId_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_EQUAL?: InputMaybe<Scalars["String"]>;
-  strand_GT?: InputMaybe<Scalars["Int"]>;
-  strand_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
-};
-
-export type RequestMetadataRequestsHasMetadataRelationship = {
-  __typename?: "RequestMetadataRequestsHasMetadataRelationship";
-  cursor: Scalars["String"];
-  node: Request;
-};
-
-export type RequestMetadataRequestsHasMetadataUpdateConnectionInput = {
-  node?: InputMaybe<RequestUpdateInput>;
-};
-
-export type RequestMetadataRequestsHasMetadataUpdateFieldInput = {
-  connect?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataConnectFieldInput>
-  >;
-  create?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataCreateFieldInput>
-  >;
-  delete?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataDeleteFieldInput>
-  >;
-  disconnect?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataDisconnectFieldInput>
-  >;
-  update?: InputMaybe<RequestMetadataRequestsHasMetadataUpdateConnectionInput>;
-  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
 };
 
 /** Fields to sort RequestMetadata by. The order in which sorts are applied is not guaranteed when specifying many fields in one RequestMetadataSort object. */
@@ -5336,9 +4660,6 @@ export type RequestMetadataUpdateInput = {
   igoRequestId?: InputMaybe<Scalars["String"]>;
   importDate?: InputMaybe<Scalars["String"]>;
   requestMetadataJson?: InputMaybe<Scalars["String"]>;
-  requestsHasMetadata?: InputMaybe<
-    Array<RequestMetadataRequestsHasMetadataUpdateFieldInput>
-  >;
 };
 
 export type RequestMetadataWhere = {
@@ -5387,19 +4708,6 @@ export type RequestMetadataWhere = {
   requestMetadataJson_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   requestMetadataJson_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   requestMetadataJson_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  requestsHasMetadataAggregate?: InputMaybe<RequestMetadataRequestsHasMetadataAggregateInput>;
-  requestsHasMetadataConnection_ALL?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-  requestsHasMetadataConnection_NONE?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-  requestsHasMetadataConnection_SINGLE?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-  requestsHasMetadataConnection_SOME?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
-  /** Return RequestMetadata where all of the related Requests match this filter */
-  requestsHasMetadata_ALL?: InputMaybe<RequestWhere>;
-  /** Return RequestMetadata where none of the related Requests match this filter */
-  requestsHasMetadata_NONE?: InputMaybe<RequestWhere>;
-  /** Return RequestMetadata where one of the related Requests match this filter */
-  requestsHasMetadata_SINGLE?: InputMaybe<RequestWhere>;
-  /** Return RequestMetadata where some of the related Requests match this filter */
-  requestsHasMetadata_SOME?: InputMaybe<RequestWhere>;
 };
 
 export type RequestOptions = {
@@ -5539,29 +4847,11 @@ export type RequestProjectsHasRequestUpdateFieldInput = {
 };
 
 export type RequestRelationInput = {
-  hasMetadataRequestMetadata?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataCreateFieldInput>
-  >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesCreateFieldInput>>;
   projectsHasRequest?: InputMaybe<
     Array<RequestProjectsHasRequestCreateFieldInput>
   >;
 };
-
-export type RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection =
-  {
-    __typename?: "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection";
-    count: Scalars["Int"];
-    node?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection>;
-  };
-
-export type RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection =
-  {
-    __typename?: "RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection";
-    igoRequestId: StringAggregateSelectionNonNullable;
-    importDate: StringAggregateSelectionNonNullable;
-    requestMetadataJson: StringAggregateSelectionNonNullable;
-  };
 
 export type RequestSampleHasSampleSamplesAggregationSelection = {
   __typename?: "RequestSampleHasSampleSamplesAggregationSelection";
@@ -5608,9 +4898,6 @@ export type RequestUpdateInput = {
   dataAnalystEmail?: InputMaybe<Scalars["String"]>;
   dataAnalystName?: InputMaybe<Scalars["String"]>;
   genePanel?: InputMaybe<Scalars["String"]>;
-  hasMetadataRequestMetadata?: InputMaybe<
-    Array<RequestHasMetadataRequestMetadataUpdateFieldInput>
-  >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesUpdateFieldInput>>;
   igoProjectId?: InputMaybe<Scalars["String"]>;
   igoRequestId?: InputMaybe<Scalars["String"]>;
@@ -5681,19 +4968,6 @@ export type RequestWhere = {
   genePanel_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   genePanel_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  hasMetadataRequestMetadataAggregate?: InputMaybe<RequestHasMetadataRequestMetadataAggregateInput>;
-  hasMetadataRequestMetadataConnection_ALL?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
-  hasMetadataRequestMetadataConnection_NONE?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
-  hasMetadataRequestMetadataConnection_SINGLE?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
-  hasMetadataRequestMetadataConnection_SOME?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
-  /** Return Requests where all of the related RequestMetadata match this filter */
-  hasMetadataRequestMetadata_ALL?: InputMaybe<RequestMetadataWhere>;
-  /** Return Requests where none of the related RequestMetadata match this filter */
-  hasMetadataRequestMetadata_NONE?: InputMaybe<RequestMetadataWhere>;
-  /** Return Requests where one of the related RequestMetadata match this filter */
-  hasMetadataRequestMetadata_SINGLE?: InputMaybe<RequestMetadataWhere>;
-  /** Return Requests where some of the related RequestMetadata match this filter */
-  hasMetadataRequestMetadata_SOME?: InputMaybe<RequestMetadataWhere>;
   hasSampleSamplesAggregate?: InputMaybe<RequestHasSampleSamplesAggregateInput>;
   hasSampleSamplesConnection_ALL?: InputMaybe<RequestHasSampleSamplesConnectionWhere>;
   hasSampleSamplesConnection_NONE?: InputMaybe<RequestHasSampleSamplesConnectionWhere>;
@@ -6350,6 +5624,7 @@ export type SampleCohortCohortsHasCohortSampleAggregationSelection = {
 export type SampleCohortCohortsHasCohortSampleNodeAggregateSelection = {
   __typename?: "SampleCohortCohortsHasCohortSampleNodeAggregateSelection";
   cohortId: StringAggregateSelectionNonNullable;
+  initialCohortDeliveryDate: StringAggregateSelectionNullable;
 };
 
 export type SampleCohortsHasCohortSampleAggregateInput = {
@@ -6430,6 +5705,26 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
   cohortId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  initialCohortDeliveryDate_EQUAL?: InputMaybe<Scalars["String"]>;
+  initialCohortDeliveryDate_GT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_GTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_LTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  initialCohortDeliveryDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type SampleCohortsHasCohortSampleRelationship = {
@@ -8975,10 +8270,10 @@ export type SampleTempoHasTempoTemposAggregationSelection = {
 
 export type SampleTempoHasTempoTemposNodeAggregateSelection = {
   __typename?: "SampleTempoHasTempoTemposNodeAggregateSelection";
-  accessLevel: StringAggregateSelectionNonNullable;
+  accessLevel: StringAggregateSelectionNullable;
   billedBy: StringAggregateSelectionNullable;
   costCenter: StringAggregateSelectionNullable;
-  custodianInformation: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNullable;
   smileTempoId: StringAggregateSelectionNonNullable;
 };
 
@@ -10140,11 +9435,11 @@ export type StringAggregateSelectionNullable = {
 
 export type Tempo = {
   __typename?: "Tempo";
-  accessLevel: Scalars["String"];
-  billed: Scalars["Boolean"];
+  accessLevel?: Maybe<Scalars["String"]>;
+  billed?: Maybe<Scalars["Boolean"]>;
   billedBy?: Maybe<Scalars["String"]>;
   costCenter?: Maybe<Scalars["String"]>;
-  custodianInformation: Scalars["String"];
+  custodianInformation?: Maybe<Scalars["String"]>;
   hasEventBamCompletes: Array<BamComplete>;
   hasEventBamCompletesAggregate?: Maybe<TempoBamCompleteHasEventBamCompletesAggregationSelection>;
   hasEventBamCompletesConnection: TempoHasEventBamCompletesConnection;
@@ -10238,11 +9533,11 @@ export type TempoSamplesHasTempoConnectionArgs = {
 
 export type TempoAggregateSelection = {
   __typename?: "TempoAggregateSelection";
-  accessLevel: StringAggregateSelectionNonNullable;
+  accessLevel: StringAggregateSelectionNullable;
   billedBy: StringAggregateSelectionNullable;
   costCenter: StringAggregateSelectionNullable;
   count: Scalars["Int"];
-  custodianInformation: StringAggregateSelectionNonNullable;
+  custodianInformation: StringAggregateSelectionNullable;
   smileTempoId: StringAggregateSelectionNonNullable;
 };
 
@@ -10276,11 +9571,11 @@ export type TempoConnectWhere = {
 };
 
 export type TempoCreateInput = {
-  accessLevel: Scalars["String"];
-  billed: Scalars["Boolean"];
+  accessLevel?: InputMaybe<Scalars["String"]>;
+  billed?: InputMaybe<Scalars["Boolean"]>;
   billedBy?: InputMaybe<Scalars["String"]>;
   costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation: Scalars["String"];
+  custodianInformation?: InputMaybe<Scalars["String"]>;
   hasEventBamCompletes?: InputMaybe<TempoHasEventBamCompletesFieldInput>;
   hasEventMafCompletes?: InputMaybe<TempoHasEventMafCompletesFieldInput>;
   hasEventQcCompletes?: InputMaybe<TempoHasEventQcCompletesFieldInput>;
@@ -10984,11 +10279,11 @@ export type TempoWhere = {
   accessLevel?: InputMaybe<Scalars["String"]>;
   accessLevel_CONTAINS?: InputMaybe<Scalars["String"]>;
   accessLevel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  accessLevel_IN?: InputMaybe<Array<Scalars["String"]>>;
+  accessLevel_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   accessLevel_NOT?: InputMaybe<Scalars["String"]>;
   accessLevel_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
   accessLevel_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  accessLevel_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  accessLevel_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   accessLevel_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   accessLevel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   billed?: InputMaybe<Scalars["Boolean"]>;
@@ -11016,11 +10311,13 @@ export type TempoWhere = {
   custodianInformation?: InputMaybe<Scalars["String"]>;
   custodianInformation_CONTAINS?: InputMaybe<Scalars["String"]>;
   custodianInformation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  custodianInformation_IN?: InputMaybe<Array<Scalars["String"]>>;
+  custodianInformation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   custodianInformation_NOT?: InputMaybe<Scalars["String"]>;
   custodianInformation_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
   custodianInformation_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  custodianInformation_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
+  custodianInformation_NOT_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]>>
+  >;
   custodianInformation_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   custodianInformation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   hasEventBamCompletesAggregate?: InputMaybe<TempoHasEventBamCompletesAggregateInput>;
@@ -11371,11 +10668,11 @@ export type FindSamplesByInputValueQuery = {
         hasTempoTempos: Array<{
           __typename?: "Tempo";
           smileTempoId: string;
-          billed: boolean;
+          billed?: boolean | null;
           billedBy?: string | null;
           costCenter?: string | null;
-          custodianInformation: string;
-          accessLevel: string;
+          custodianInformation?: string | null;
+          accessLevel?: string | null;
           hasEventBamCompletes: Array<{
             __typename?: "BamComplete";
             date: string;
@@ -11465,11 +10762,11 @@ export type SampleMetadataPartsFragment = {
 export type TempoPartsFragment = {
   __typename?: "Tempo";
   smileTempoId: string;
-  billed: boolean;
+  billed?: boolean | null;
   billedBy?: string | null;
   costCenter?: string | null;
-  custodianInformation: string;
-  accessLevel: string;
+  custodianInformation?: string | null;
+  accessLevel?: string | null;
 };
 
 export type SamplesQueryVariables = Exact<{
@@ -11520,11 +10817,11 @@ export type SamplesQuery = {
     hasTempoTempos: Array<{
       __typename?: "Tempo";
       smileTempoId: string;
-      billed: boolean;
+      billed?: boolean | null;
       billedBy?: string | null;
       costCenter?: string | null;
-      custodianInformation: string;
-      accessLevel: string;
+      custodianInformation?: string | null;
+      accessLevel?: string | null;
     }>;
   }>;
 };
@@ -11579,11 +10876,11 @@ export type UpdateSamplesMutation = {
       hasTempoTempos: Array<{
         __typename?: "Tempo";
         smileTempoId: string;
-        billed: boolean;
+        billed?: boolean | null;
         billedBy?: string | null;
         costCenter?: string | null;
-        custodianInformation: string;
-        accessLevel: string;
+        custodianInformation?: string | null;
+        accessLevel?: string | null;
       }>;
     }>;
   };
@@ -11616,6 +10913,7 @@ export type CohortsListQuery = {
   cohorts: Array<{
     __typename?: "Cohort";
     cohortId: string;
+    initialCohortDeliveryDate?: string | null;
     hasCohortCompleteCohortCompletes: Array<{
       __typename?: "CohortComplete";
       type: string;
@@ -11636,7 +10934,7 @@ export type CohortsListQuery = {
       hasTempoTempos: Array<{
         __typename?: "Tempo";
         smileTempoId: string;
-        billed: boolean;
+        billed?: boolean | null;
       }>;
     }>;
   }>;
@@ -11934,6 +11232,7 @@ export const CohortsListDocument = gql`
     }
     cohorts(where: $where, options: $options) {
       cohortId
+      initialCohortDeliveryDate
       hasCohortCompleteCohortCompletes(
         options: $hasCohortCompleteCohortCompletesOptions2
       ) {

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -349,7 +349,9 @@ export type BamCompletesConnection = {
 
 export type Cohort = {
   __typename?: "Cohort";
+  billed?: Maybe<Scalars["String"]>;
   cohortId: Scalars["String"];
+  endUsers?: Maybe<Scalars["String"]>;
   hasCohortCompleteCohortCompletes: Array<CohortComplete>;
   hasCohortCompleteCohortCompletesAggregate?: Maybe<CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection>;
   hasCohortCompleteCohortCompletesConnection: CohortHasCohortCompleteCohortCompletesConnection;
@@ -357,6 +359,13 @@ export type Cohort = {
   hasCohortSampleSamplesAggregate?: Maybe<CohortSampleHasCohortSampleSamplesAggregationSelection>;
   hasCohortSampleSamplesConnection: CohortHasCohortSampleSamplesConnection;
   initialCohortDeliveryDate?: Maybe<Scalars["String"]>;
+  pmUsers?: Maybe<Scalars["String"]>;
+  projectSubtitle?: Maybe<Scalars["String"]>;
+  projectTitle?: Maybe<Scalars["String"]>;
+  smileSampleIds?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  status?: Maybe<Scalars["String"]>;
+  totalSampleCount?: Maybe<Scalars["Int"]>;
+  type?: Maybe<Scalars["String"]>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesArgs = {
@@ -401,9 +410,17 @@ export type CohortHasCohortSampleSamplesConnectionArgs = {
 
 export type CohortAggregateSelection = {
   __typename?: "CohortAggregateSelection";
+  billed: StringAggregateSelectionNullable;
   cohortId: StringAggregateSelectionNonNullable;
   count: Scalars["Int"];
+  endUsers: StringAggregateSelectionNullable;
   initialCohortDeliveryDate: StringAggregateSelectionNullable;
+  pmUsers: StringAggregateSelectionNullable;
+  projectSubtitle: StringAggregateSelectionNullable;
+  projectTitle: StringAggregateSelectionNullable;
+  status: StringAggregateSelectionNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
+  type: StringAggregateSelectionNullable;
 };
 
 export type CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection =
@@ -481,8 +498,16 @@ export type CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection = {
 export type CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection =
   {
     __typename?: "CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection";
+    billed: StringAggregateSelectionNullable;
     cohortId: StringAggregateSelectionNonNullable;
+    endUsers: StringAggregateSelectionNullable;
     initialCohortDeliveryDate: StringAggregateSelectionNullable;
+    pmUsers: StringAggregateSelectionNullable;
+    projectSubtitle: StringAggregateSelectionNullable;
+    projectTitle: StringAggregateSelectionNullable;
+    status: StringAggregateSelectionNullable;
+    totalSampleCount: IntAggregateSelectionNullable;
+    type: StringAggregateSelectionNullable;
   };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateInput = {
@@ -551,6 +576,26 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput>
   >;
+  billed_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  billed_EQUAL?: InputMaybe<Scalars["String"]>;
+  billed_GT?: InputMaybe<Scalars["Int"]>;
+  billed_GTE?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billed_LT?: InputMaybe<Scalars["Int"]>;
+  billed_LTE?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   cohortId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   cohortId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   cohortId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -571,6 +616,26 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   cohortId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  endUsers_EQUAL?: InputMaybe<Scalars["String"]>;
+  endUsers_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   initialCohortDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   initialCohortDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   initialCohortDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -591,6 +656,131 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   initialCohortDeliveryDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   initialCohortDeliveryDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   initialCohortDeliveryDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  pmUsers_EQUAL?: InputMaybe<Scalars["String"]>;
+  pmUsers_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_EQUAL?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_GT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_GTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  projectTitle_EQUAL?: InputMaybe<Scalars["String"]>;
+  projectTitle_GT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_GTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  status_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  status_EQUAL?: InputMaybe<Scalars["String"]>;
+  status_GT?: InputMaybe<Scalars["Int"]>;
+  status_GTE?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  status_LT?: InputMaybe<Scalars["Int"]>;
+  status_LTE?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
+  type_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  type_EQUAL?: InputMaybe<Scalars["String"]>;
+  type_GT?: InputMaybe<Scalars["Int"]>;
+  type_GTE?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  type_LT?: InputMaybe<Scalars["Int"]>;
+  type_LTE?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteRelationship = {
@@ -805,10 +995,19 @@ export type CohortConnectWhere = {
 };
 
 export type CohortCreateInput = {
+  billed?: InputMaybe<Scalars["String"]>;
   cohortId: Scalars["String"];
+  endUsers?: InputMaybe<Scalars["String"]>;
   hasCohortCompleteCohortCompletes?: InputMaybe<CohortHasCohortCompleteCohortCompletesFieldInput>;
   hasCohortSampleSamples?: InputMaybe<CohortHasCohortSampleSamplesFieldInput>;
   initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
+  pmUsers?: InputMaybe<Scalars["String"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]>;
+  projectTitle?: InputMaybe<Scalars["String"]>;
+  smileSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  status?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  type?: InputMaybe<Scalars["String"]>;
 };
 
 export type CohortDeleteInput = {
@@ -1263,12 +1462,22 @@ export type CohortSampleHasCohortSampleSamplesNodeAggregateSelection = {
 
 /** Fields to sort Cohorts by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortSort object. */
 export type CohortSort = {
+  billed?: InputMaybe<SortDirection>;
   cohortId?: InputMaybe<SortDirection>;
+  endUsers?: InputMaybe<SortDirection>;
   initialCohortDeliveryDate?: InputMaybe<SortDirection>;
+  pmUsers?: InputMaybe<SortDirection>;
+  projectSubtitle?: InputMaybe<SortDirection>;
+  projectTitle?: InputMaybe<SortDirection>;
+  status?: InputMaybe<SortDirection>;
+  totalSampleCount?: InputMaybe<SortDirection>;
+  type?: InputMaybe<SortDirection>;
 };
 
 export type CohortUpdateInput = {
+  billed?: InputMaybe<Scalars["String"]>;
   cohortId?: InputMaybe<Scalars["String"]>;
+  endUsers?: InputMaybe<Scalars["String"]>;
   hasCohortCompleteCohortCompletes?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesUpdateFieldInput>
   >;
@@ -1276,11 +1485,32 @@ export type CohortUpdateInput = {
     Array<CohortHasCohortSampleSamplesUpdateFieldInput>
   >;
   initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
+  pmUsers?: InputMaybe<Scalars["String"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]>;
+  projectTitle?: InputMaybe<Scalars["String"]>;
+  smileSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  smileSampleIds_POP?: InputMaybe<Scalars["Int"]>;
+  smileSampleIds_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  status?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_DECREMENT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_INCREMENT?: InputMaybe<Scalars["Int"]>;
+  type?: InputMaybe<Scalars["String"]>;
 };
 
 export type CohortWhere = {
   AND?: InputMaybe<Array<CohortWhere>>;
   OR?: InputMaybe<Array<CohortWhere>>;
+  billed?: InputMaybe<Scalars["String"]>;
+  billed_CONTAINS?: InputMaybe<Scalars["String"]>;
+  billed_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  billed_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  billed_NOT?: InputMaybe<Scalars["String"]>;
+  billed_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  billed_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  billed_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  billed_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  billed_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   cohortId?: InputMaybe<Scalars["String"]>;
   cohortId_CONTAINS?: InputMaybe<Scalars["String"]>;
   cohortId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
@@ -1291,6 +1521,16 @@ export type CohortWhere = {
   cohortId_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   cohortId_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   cohortId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers?: InputMaybe<Scalars["String"]>;
+  endUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
+  endUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  endUsers_NOT?: InputMaybe<Scalars["String"]>;
+  endUsers_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  endUsers_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  endUsers_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  endUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   hasCohortCompleteCohortCompletesAggregate?: InputMaybe<CohortHasCohortCompleteCohortCompletesAggregateInput>;
   hasCohortCompleteCohortCompletesConnection_ALL?: InputMaybe<CohortHasCohortCompleteCohortCompletesConnectionWhere>;
   hasCohortCompleteCohortCompletesConnection_NONE?: InputMaybe<CohortHasCohortCompleteCohortCompletesConnectionWhere>;
@@ -1331,6 +1571,68 @@ export type CohortWhere = {
   >;
   initialCohortDeliveryDate_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   initialCohortDeliveryDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers?: InputMaybe<Scalars["String"]>;
+  pmUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
+  pmUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  pmUsers_NOT?: InputMaybe<Scalars["String"]>;
+  pmUsers_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  pmUsers_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  pmUsers_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  pmUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectSubtitle_NOT?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectSubtitle_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  projectTitle?: InputMaybe<Scalars["String"]>;
+  projectTitle_CONTAINS?: InputMaybe<Scalars["String"]>;
+  projectTitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  projectTitle_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectTitle_NOT?: InputMaybe<Scalars["String"]>;
+  projectTitle_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  projectTitle_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  projectTitle_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  projectTitle_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  projectTitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smileSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  smileSampleIds_INCLUDES?: InputMaybe<Scalars["String"]>;
+  smileSampleIds_NOT?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  smileSampleIds_NOT_INCLUDES?: InputMaybe<Scalars["String"]>;
+  status?: InputMaybe<Scalars["String"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  status_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  status_NOT?: InputMaybe<Scalars["String"]>;
+  status_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  status_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  status_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  status_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_IN?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_NOT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["Int"]>>>;
+  type?: InputMaybe<Scalars["String"]>;
+  type_CONTAINS?: InputMaybe<Scalars["String"]>;
+  type_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  type_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  type_NOT?: InputMaybe<Scalars["String"]>;
+  type_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  type_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  type_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  type_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  type_STARTS_WITH?: InputMaybe<Scalars["String"]>;
 };
 
 export type CohortsConnection = {
@@ -5866,8 +6168,16 @@ export type SampleCohortCohortsHasCohortSampleAggregationSelection = {
 
 export type SampleCohortCohortsHasCohortSampleNodeAggregateSelection = {
   __typename?: "SampleCohortCohortsHasCohortSampleNodeAggregateSelection";
+  billed: StringAggregateSelectionNullable;
   cohortId: StringAggregateSelectionNonNullable;
+  endUsers: StringAggregateSelectionNullable;
   initialCohortDeliveryDate: StringAggregateSelectionNullable;
+  pmUsers: StringAggregateSelectionNullable;
+  projectSubtitle: StringAggregateSelectionNullable;
+  projectTitle: StringAggregateSelectionNullable;
+  status: StringAggregateSelectionNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
+  type: StringAggregateSelectionNullable;
 };
 
 export type SampleCohortsHasCohortSampleAggregateInput = {
@@ -5928,6 +6238,26 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
     Array<SampleCohortsHasCohortSampleNodeAggregationWhereInput>
   >;
   OR?: InputMaybe<Array<SampleCohortsHasCohortSampleNodeAggregationWhereInput>>;
+  billed_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  billed_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  billed_EQUAL?: InputMaybe<Scalars["String"]>;
+  billed_GT?: InputMaybe<Scalars["Int"]>;
+  billed_GTE?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  billed_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  billed_LT?: InputMaybe<Scalars["Int"]>;
+  billed_LTE?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  billed_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   cohortId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   cohortId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   cohortId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -5948,6 +6278,26 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
   cohortId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   cohortId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  endUsers_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  endUsers_EQUAL?: InputMaybe<Scalars["String"]>;
+  endUsers_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_LTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  endUsers_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   initialCohortDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   initialCohortDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   initialCohortDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -5968,6 +6318,131 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
   initialCohortDeliveryDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   initialCohortDeliveryDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   initialCohortDeliveryDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  pmUsers_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  pmUsers_EQUAL?: InputMaybe<Scalars["String"]>;
+  pmUsers_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_LTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  pmUsers_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  projectSubtitle_EQUAL?: InputMaybe<Scalars["String"]>;
+  projectSubtitle_GT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_GTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_LTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectSubtitle_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  projectTitle_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  projectTitle_EQUAL?: InputMaybe<Scalars["String"]>;
+  projectTitle_GT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_GTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_LTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectTitle_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  status_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  status_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  status_EQUAL?: InputMaybe<Scalars["String"]>;
+  status_GT?: InputMaybe<Scalars["Int"]>;
+  status_GTE?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  status_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  status_LT?: InputMaybe<Scalars["Int"]>;
+  status_LTE?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  status_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
+  type_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  type_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  type_EQUAL?: InputMaybe<Scalars["String"]>;
+  type_GT?: InputMaybe<Scalars["Int"]>;
+  type_GTE?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  type_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  type_LT?: InputMaybe<Scalars["Int"]>;
+  type_LTE?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  type_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
 };
 
 export type SampleCohortsHasCohortSampleRelationship = {
@@ -11298,16 +11773,25 @@ export type CohortsListQuery = {
   cohorts: Array<{
     __typename?: "Cohort";
     cohortId: string;
+    smileSampleIds?: Array<string | null> | null;
+    totalSampleCount?: number | null;
+    billed?: string | null;
     initialCohortDeliveryDate?: string | null;
+    endUsers?: string | null;
+    pmUsers?: string | null;
+    projectTitle?: string | null;
+    projectSubtitle?: string | null;
+    status?: string | null;
+    type?: string | null;
     hasCohortCompleteCohortCompletes: Array<{
       __typename?: "CohortComplete";
-      type: string;
+      date: string;
       endUsers: string;
       pmUsers: string;
       projectTitle: string;
       projectSubtitle: string;
       status: string;
-      date: string;
+      type: string;
     }>;
     hasCohortSampleSamplesConnection: {
       __typename?: "CohortHasCohortSampleSamplesConnection";
@@ -11615,17 +12099,26 @@ export const CohortsListDocument = gql`
     }
     cohorts(where: $where, options: $options) {
       cohortId
+      smileSampleIds
+      totalSampleCount
+      billed
       initialCohortDeliveryDate
+      endUsers
+      pmUsers
+      projectTitle
+      projectSubtitle
+      status
+      type
       hasCohortCompleteCohortCompletes(
         options: $hasCohortCompleteCohortCompletesOptions2
       ) {
-        type
+        date
         endUsers
         pmUsers
         projectTitle
         projectSubtitle
         status
-        date
+        type
       }
       hasCohortSampleSamplesConnection {
         totalCount

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -10493,7 +10493,6 @@ export type UpdateTemposMutationResponse = {
 export type RequestsListQueryVariables = Exact<{
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
-  requestsConnectionWhere2?: InputMaybe<RequestWhere>;
 }>;
 
 export type RequestsListQuery = {
@@ -10529,7 +10528,6 @@ export type RequestsListQuery = {
 export type PatientsListQueryVariables = Exact<{
   options?: InputMaybe<PatientOptions>;
   where?: InputMaybe<PatientWhere>;
-  patientsConnectionWhere2?: InputMaybe<PatientWhere>;
 }>;
 
 export type PatientsListQuery = {
@@ -10903,7 +10901,6 @@ export type GetPatientIdsTripletsQuery = {
 export type CohortsListQueryVariables = Exact<{
   where?: InputMaybe<CohortWhere>;
   options?: InputMaybe<CohortOptions>;
-  cohortsConnectionWhere2?: InputMaybe<CohortWhere>;
   hasCohortCompleteCohortCompletesOptions2?: InputMaybe<CohortCompleteOptions>;
 }>;
 
@@ -11013,12 +11010,8 @@ export const TempoPartsFragmentDoc = gql`
   }
 `;
 export const RequestsListDocument = gql`
-  query RequestsList(
-    $options: RequestOptions
-    $where: RequestWhere
-    $requestsConnectionWhere2: RequestWhere
-  ) {
-    requestsConnection(where: $requestsConnectionWhere2) {
+  query RequestsList($options: RequestOptions, $where: RequestWhere) {
+    requestsConnection(where: $where) {
       totalCount
     }
     requests(where: $where, options: $options) {
@@ -11035,12 +11028,8 @@ export type RequestsListQueryResult = Apollo.QueryResult<
   RequestsListQueryVariables
 >;
 export const PatientsListDocument = gql`
-  query PatientsList(
-    $options: PatientOptions
-    $where: PatientWhere
-    $patientsConnectionWhere2: PatientWhere
-  ) {
-    patientsConnection(where: $patientsConnectionWhere2) {
+  query PatientsList($options: PatientOptions, $where: PatientWhere) {
+    patientsConnection(where: $where) {
       totalCount
     }
     patients(where: $where, options: $options) {
@@ -11224,10 +11213,9 @@ export const CohortsListDocument = gql`
   query CohortsList(
     $where: CohortWhere
     $options: CohortOptions
-    $cohortsConnectionWhere2: CohortWhere
     $hasCohortCompleteCohortCompletesOptions2: CohortCompleteOptions
   ) {
-    cohortsConnection(where: $cohortsConnectionWhere2) {
+    cohortsConnection(where: $where) {
       totalCount
     }
     cohorts(where: $where, options: $options) {

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -142,6 +142,38 @@ function buildResolvers(
         };
       },
     },
+    Query: {
+      async cohorts(parent: any, args: any, context: any, info: any) {
+        const cohorts = await ogm.model("Cohort").find({
+          where: args?.where,
+          options: args?.options,
+          selectionSet: `{
+            cohortId
+            hasCohortCompleteCohortCompletes {
+              type
+              endUsers
+              pmUsers
+              projectTitle
+              projectSubtitle
+              status
+              date
+            }
+            hasCohortSampleSamplesConnection {
+              totalCount
+            }
+            hasCohortSampleSamples {
+              smileSampleId
+              hasTempoTempos {
+                smileTempoId
+                billed
+              }
+            }
+          }`,
+        });
+
+        return cohorts;
+      },
+    },
   };
 }
 

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -64,7 +64,16 @@ export async function buildNeo4jDbSchema() {
     }
 
     extend type Cohort {
+      totalSampleCount: Int
+      smileSampleIds: [String]
+      billed: String
       initialCohortDeliveryDate: String
+      endUsers: String
+      pmUsers: String
+      projectTitle: String
+      projectSubtitle: String
+      status: String
+      type: String
     }
   `;
 
@@ -215,10 +224,41 @@ function buildResolvers(
       },
     },
     Cohort: {
+      totalSampleCount: (parent: CohortsListQuery["cohorts"][number]) => {
+        return parent.hasCohortSampleSamplesConnection?.totalCount;
+      },
+      smileSampleIds: (parent: CohortsListQuery["cohorts"][number]) => {
+        return parent.hasCohortSampleSamples?.map((s) => s.smileSampleId);
+      },
+      billed: (parent: CohortsListQuery["cohorts"][number]) => {
+        const samples = parent.hasCohortSampleSamples;
+        const allSamplesBilled =
+          samples?.length > 0 &&
+          samples.every((sample) => sample.hasTempoTempos?.[0]?.billed);
+        return allSamplesBilled ? "Yes" : "No";
+      },
       initialCohortDeliveryDate: (
         parent: CohortsListQuery["cohorts"][number]
       ) => {
         return parent.hasCohortCompleteCohortCompletes?.slice(-1)[0]?.date;
+      },
+      endUsers: (parent: CohortsListQuery["cohorts"][number]) => {
+        return parent.hasCohortCompleteCohortCompletes?.[0]?.endUsers; // latest
+      },
+      pmUsers: (parent: CohortsListQuery["cohorts"][number]) => {
+        return parent.hasCohortCompleteCohortCompletes?.[0]?.pmUsers;
+      },
+      projectTitle: (parent: CohortsListQuery["cohorts"][number]) => {
+        return parent.hasCohortCompleteCohortCompletes?.[0]?.projectTitle;
+      },
+      projectSubtitle: (parent: CohortsListQuery["cohorts"][number]) => {
+        return parent.hasCohortCompleteCohortCompletes?.[0]?.projectSubtitle;
+      },
+      status: (parent: CohortsListQuery["cohorts"][number]) => {
+        return parent.hasCohortCompleteCohortCompletes?.[0]?.status;
+      },
+      type: (parent: CohortsListQuery["cohorts"][number]) => {
+        return parent.hasCohortCompleteCohortCompletes?.[0]?.type;
       },
     },
   };

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -19657,6 +19657,70 @@
         "description": null,
         "fields": [
           {
+            "name": "cmoPatientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "hasSampleSamples",
             "description": null,
             "args": [
@@ -20037,6 +20101,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -20049,6 +20125,54 @@
         "name": "PatientAggregateSelection",
         "description": null,
         "fields": [
+          {
+            "name": "cmoPatientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "count",
             "description": null,
@@ -20066,6 +20190,22 @@
             "deprecationReason": null
           },
           {
+            "name": "dmpPatientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "smilePatientId",
             "description": null,
             "args": [],
@@ -20075,6 +20215,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -21116,6 +21272,966 @@
             "deprecationReason": null
           },
           {
+            "name": "cmoPatientId_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "smilePatientId_AVERAGE_EQUAL",
             "description": null,
             "type": {
@@ -21345,6 +22461,306 @@
           },
           {
             "name": "smilePatientId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -21641,6 +23057,70 @@
         "description": null,
         "fields": [
           {
+            "name": "cmoPatientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "smilePatientId",
             "description": null,
             "args": [],
@@ -21650,6 +23130,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -22366,6 +23862,70 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "cmoPatientId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "hasSampleSamples",
             "description": null,
             "type": {
@@ -22400,6 +23960,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -25773,7 +27345,67 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "cmoPatientId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "smilePatientId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -25795,6 +27427,98 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "cmoPatientId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_POP",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_PUSH",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "hasSampleSamples",
             "description": null,
@@ -25841,6 +27565,42 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_DECREMENT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_INCREMENT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "defaultValue": null,
@@ -25893,6 +27653,574 @@
                   "ofType": null
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_INCLUDES",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_NOT",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_NOT_INCLUDES",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -26245,6 +28573,110 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -74700,6 +77132,70 @@
         "description": null,
         "fields": [
           {
+            "name": "cmoPatientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "smilePatientId",
             "description": null,
             "args": [],
@@ -74709,6 +77205,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -75247,6 +77759,966 @@
             "deprecationReason": null
           },
           {
+            "name": "cmoPatientId_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartA_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consentPartC_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "smilePatientId_AVERAGE_EQUAL",
             "description": null,
             "type": {
@@ -75476,6 +78948,306 @@
           },
           {
             "name": "smilePatientId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -3242,6 +3242,18 @@
         "description": null,
         "fields": [
           {
+            "name": "billed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cohortId",
             "description": null,
             "args": [],
@@ -3253,6 +3265,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3634,6 +3658,94 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "pmUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileSampleIds",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -3646,6 +3758,22 @@
         "name": "CohortAggregateSelection",
         "description": null,
         "fields": [
+          {
+            "name": "billed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "cohortId",
             "description": null,
@@ -3679,7 +3807,119 @@
             "deprecationReason": null
           },
           {
+            "name": "endUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "initialCohortDeliveryDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
             "description": null,
             "args": [],
             "type": {
@@ -4352,6 +4592,22 @@
         "description": null,
         "fields": [
           {
+            "name": "billed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cohortId",
             "description": null,
             "args": [],
@@ -4368,7 +4624,119 @@
             "deprecationReason": null
           },
           {
+            "name": "endUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "initialCohortDeliveryDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
             "description": null,
             "args": [],
             "type": {
@@ -4915,6 +5283,246 @@
             "deprecationReason": null
           },
           {
+            "name": "billed_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cohortId_AVERAGE_EQUAL",
             "description": null,
             "type": {
@@ -5155,6 +5763,246 @@
             "deprecationReason": null
           },
           {
+            "name": "endUsers_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "initialCohortDeliveryDate_AVERAGE_EQUAL",
             "description": null,
             "type": {
@@ -5384,6 +6232,1506 @@
           },
           {
             "name": "initialCohortDeliveryDate_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_SHORTEST_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -7437,6 +9785,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "billed",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cohortId",
             "description": null,
             "type": {
@@ -7447,6 +9807,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -7478,6 +9850,94 @@
           },
           {
             "name": "initialCohortDeliveryDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileSampleIds",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -11927,6 +14387,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "billed",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cohortId",
             "description": null,
             "type": {
@@ -11939,7 +14411,91 @@
             "deprecationReason": null
           },
           {
+            "name": "endUsers",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "initialCohortDeliveryDate",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -11962,7 +14518,31 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "billed",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cohortId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -12024,6 +14604,146 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "pmUsers",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileSampleIds",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileSampleIds_POP",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileSampleIds_PUSH",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_DECREMENT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_INCREMENT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -12071,6 +14791,134 @@
                   "ofType": null
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -12202,6 +15050,134 @@
           },
           {
             "name": "cohortId_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_STARTS_WITH",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -12546,6 +15522,806 @@
           },
           {
             "name": "initialCohortDeliveryDate_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileSampleIds",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileSampleIds_INCLUDES",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileSampleIds_NOT",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileSampleIds_NOT_INCLUDES",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_STARTS_WITH",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -57078,6 +60854,22 @@
         "description": null,
         "fields": [
           {
+            "name": "billed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cohortId",
             "description": null,
             "args": [],
@@ -57094,7 +60886,119 @@
             "deprecationReason": null
           },
           {
+            "name": "endUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "initialCohortDeliveryDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
             "description": null,
             "args": [],
             "type": {
@@ -57641,6 +61545,246 @@
             "deprecationReason": null
           },
           {
+            "name": "billed_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cohortId_AVERAGE_EQUAL",
             "description": null,
             "type": {
@@ -57881,6 +62025,246 @@
             "deprecationReason": null
           },
           {
+            "name": "endUsers_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endUsers_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "initialCohortDeliveryDate_AVERAGE_EQUAL",
             "description": null,
             "type": {
@@ -58110,6 +62494,1506 @@
           },
           {
             "name": "initialCohortDeliveryDate_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pmUsers_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectSubtitle_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTitle_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type_SHORTEST_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -13525,6 +13525,65 @@
       },
       {
         "kind": "OBJECT",
+        "name": "IntAggregateSelectionNullable",
+        "description": null,
+        "fields": [
+          {
+            "name": "average",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sum",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "MafComplete",
         "description": null,
         "fields": [
@@ -31850,6 +31909,306 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -32465,6 +32824,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -39670,6 +40045,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -39996,6 +40383,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -40454,6 +40857,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "defaultValue": null,
@@ -46433,6 +46848,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -46775,6 +47202,42 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_DECREMENT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_INCREMENT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "defaultValue": null,
@@ -49715,6 +50178,110 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -75583,6 +76150,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -80665,6 +81248,306 @@
           },
           {
             "name": "strand_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -685,7 +685,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -733,7 +733,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -3622,6 +3622,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -3660,6 +3672,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -4333,6 +4361,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -5100,6 +5144,246 @@
           },
           {
             "name": "cohortId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_SHORTEST_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -7186,6 +7470,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "CohortHasCohortSampleSamplesFieldInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -11641,6 +11937,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -11700,6 +12008,18 @@
                   "ofType": null
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -12102,6 +12422,134 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SampleWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -13812,7 +14260,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -13860,7 +14308,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -33414,7 +33862,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -33462,7 +33910,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -38594,189 +39042,6 @@
             "deprecationReason": null
           },
           {
-            "name": "hasMetadataRequestMetadata",
-            "description": null,
-            "args": [
-              {
-                "name": "directed",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": "true",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "options",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataOptions",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataWhere",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "RequestMetadata",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadataAggregate",
-            "description": null,
-            "args": [
-              {
-                "name": "directed",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": "true",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataWhere",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadataConnection",
-            "description": null,
-            "args": [
-              {
-                "name": "after",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "directed",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": "true",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "first",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "sort",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "RequestHasMetadataRequestMetadataConnectionSort",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataConnectionWhere",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "RequestHasMetadataRequestMetadataConnection",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "hasSampleSamples",
             "description": null,
             "args": [
@@ -39750,26 +40015,6 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "hasMetadataRequestMetadata",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "hasSampleSamples",
             "description": null,
             "type": {
@@ -39922,18 +40167,6 @@
                 "name": "String",
                 "ofType": null
               }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadata",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestHasMetadataRequestMetadataFieldInput",
-              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -40239,26 +40472,6 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "hasMetadataRequestMetadata",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataDeleteFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "hasSampleSamples",
             "description": null,
             "type": {
@@ -40309,26 +40522,6 @@
         "description": null,
         "fields": null,
         "inputFields": [
-          {
-            "name": "hasMetadataRequestMetadata",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataDisconnectFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
           {
             "name": "hasSampleSamples",
             "description": null,
@@ -40414,1437 +40607,6 @@
         ],
         "inputFields": null,
         "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestHasMetadataRequestMetadataAggregateInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "AND",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataAggregateInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "OR",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataAggregateInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "count",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "count_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "count_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "count_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "count_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestHasMetadataRequestMetadataNodeAggregationWhereInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "connect",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataConnectInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "where",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataConnectWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "RequestHasMetadataRequestMetadataConnection",
-        "description": null,
-        "fields": [
-          {
-            "name": "edges",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "RequestHasMetadataRequestMetadataRelationship",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pageInfo",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "totalCount",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestHasMetadataRequestMetadataConnectionSort",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "node",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataSort",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestHasMetadataRequestMetadataConnectionWhere",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "AND",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataConnectionWhere",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "OR",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataConnectionWhere",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node_NOT",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "node",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "RequestMetadataCreateInput",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestHasMetadataRequestMetadataDeleteFieldInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "delete",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataDeleteInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "where",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestHasMetadataRequestMetadataDisconnectFieldInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "disconnect",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataDisconnectInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "where",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestHasMetadataRequestMetadataFieldInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "connect",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "create",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestHasMetadataRequestMetadataNodeAggregationWhereInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "AND",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataNodeAggregationWhereInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "OR",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataNodeAggregationWhereInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "RequestHasMetadataRequestMetadataRelationship",
-        "description": null,
-        "fields": [
-          {
-            "name": "cursor",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "RequestMetadata",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestHasMetadataRequestMetadataUpdateConnectionInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "node",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataUpdateInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestHasMetadataRequestMetadataUpdateFieldInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "connect",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "create",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "delete",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataDeleteFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "disconnect",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataDisconnectFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "update",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestHasMetadataRequestMetadataUpdateConnectionInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "where",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -43754,189 +42516,6 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadata",
-            "description": null,
-            "args": [
-              {
-                "name": "directed",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": "true",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "options",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestOptions",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestWhere",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Request",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadataAggregate",
-            "description": null,
-            "args": [
-              {
-                "name": "directed",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": "true",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestWhere",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "RequestMetadataRequestRequestsHasMetadataAggregationSelection",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadataConnection",
-            "description": null,
-            "args": [
-              {
-                "name": "after",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "directed",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": "true",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "first",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "sort",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "RequestMetadataRequestsHasMetadataConnectionSort",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "RequestMetadataRequestsHasMetadataConnection",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -44037,26 +42616,6 @@
                 "ofType": {
                   "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesConnectFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadata",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
                   "ofType": null
                 }
               }
@@ -44229,18 +42788,6 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadata",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataRequestsHasMetadataFieldInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -44272,26 +42819,6 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadata",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataDeleteFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -44316,26 +42843,6 @@
                 "ofType": {
                   "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesDisconnectFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadata",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataDisconnectFieldInput",
                   "ofType": null
                 }
               }
@@ -45423,5651 +43930,6 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadata",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "RequestMetadataRequestRequestsHasMetadataAggregationSelection",
-        "description": null,
-        "fields": [
-          {
-            "name": "count",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection",
-        "description": null,
-        "fields": [
-          {
-            "name": "dataAccessEmails",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataAggregateInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "AND",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataAggregateInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "OR",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataAggregateInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "count",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "count_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "count_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "count_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "count_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataRequestsHasMetadataNodeAggregationWhereInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "connect",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestConnectInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "where",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestConnectWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataConnection",
-        "description": null,
-        "fields": [
-          {
-            "name": "edges",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "RequestMetadataRequestsHasMetadataRelationship",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pageInfo",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "totalCount",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataConnectionSort",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "node",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestSort",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "AND",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "OR",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node_NOT",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "node",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "RequestCreateInput",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataDeleteFieldInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "delete",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestDeleteInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "where",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataDisconnectFieldInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "disconnect",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestDisconnectInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "where",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataFieldInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "connect",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "create",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataNodeAggregationWhereInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "AND",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataNodeAggregationWhereInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "OR",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataNodeAggregationWhereInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAccessEmails_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystEmail_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataAnalystName_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "genePanel_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoProjectId_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "igoRequestId_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorEmail_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "investigatorName_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadEmail_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "labHeadName_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "libraryType_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "namespace_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherContactEmails_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "piEmail_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projectManagerName_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "qcAccessEmails_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestJson_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "smileRequestId_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_AVERAGE_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_AVERAGE_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_AVERAGE_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_AVERAGE_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_AVERAGE_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_LONGEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_LONGEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_LONGEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_LONGEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_LONGEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_SHORTEST_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_SHORTEST_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_SHORTEST_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_SHORTEST_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "strand_SHORTEST_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataRelationship",
-        "description": null,
-        "fields": [
-          {
-            "name": "cursor",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Request",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataUpdateConnectionInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "node",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestUpdateInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "RequestMetadataRequestsHasMetadataUpdateFieldInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "connect",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "create",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "delete",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataDeleteFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "disconnect",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataDisconnectFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "update",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataRequestsHasMetadataUpdateConnectionInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "where",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -51244,26 +44106,6 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadata",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestMetadataRequestsHasMetadataUpdateFieldInput",
-                  "ofType": null
-                }
-              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -51830,114 +44672,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadataAggregate",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataRequestsHasMetadataAggregateInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadataConnection_ALL",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadataConnection_NONE",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadataConnection_SINGLE",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadataConnection_SOME",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadata_ALL",
-            "description": "Return RequestMetadata where all of the related Requests match this filter",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadata_NONE",
-            "description": "Return RequestMetadata where none of the related Requests match this filter",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadata_SINGLE",
-            "description": "Return RequestMetadata where one of the related Requests match this filter",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestsHasMetadata_SOME",
-            "description": "Return RequestMetadata where some of the related Requests match this filter",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestWhere",
               "ofType": null
             },
             "defaultValue": null,
@@ -53284,26 +46018,6 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "hasMetadataRequestMetadata",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "hasSampleSamples",
             "description": null,
             "type": {
@@ -53345,104 +46059,6 @@
           }
         ],
         "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection",
-        "description": null,
-        "fields": [
-          {
-            "name": "count",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection",
-        "description": null,
-        "fields": [
-          {
-            "name": "igoRequestId",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "importDate",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requestMetadataJson",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -53884,26 +46500,6 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadata",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "RequestHasMetadataRequestMetadataUpdateFieldInput",
-                  "ofType": null
-                }
-              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -54798,114 +47394,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadataAggregate",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestHasMetadataRequestMetadataAggregateInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadataConnection_ALL",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadataConnection_NONE",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadataConnection_SINGLE",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadataConnection_SOME",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadata_ALL",
-            "description": "Return Requests where all of the related RequestMetadata match this filter",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadata_NONE",
-            "description": "Return Requests where none of the related RequestMetadata match this filter",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadata_SINGLE",
-            "description": "Return Requests where one of the related RequestMetadata match this filter",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataWhere",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasMetadataRequestMetadata_SOME",
-            "description": "Return Requests where some of the related RequestMetadata match this filter",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "RequestMetadataWhere",
               "ofType": null
             },
             "defaultValue": null,
@@ -61605,6 +54093,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -62367,6 +54871,246 @@
           },
           {
             "name": "cohortId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialCohortDeliveryDate_SHORTEST_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -89980,7 +82724,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -90028,7 +82772,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -102101,13 +94845,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -102117,13 +94857,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -102157,13 +94893,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -102936,7 +95668,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -103000,7 +95732,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "StringAggregateSelectionNonNullable",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -103239,13 +95971,9 @@
             "name": "accessLevel",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -103255,13 +95983,9 @@
             "name": "billed",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -103295,13 +96019,9 @@
             "name": "custodianInformation",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -110372,13 +103092,9 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "defaultValue": null,
@@ -110428,13 +103144,9 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "defaultValue": null,
@@ -110788,13 +103500,9 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "defaultValue": null,
@@ -110844,13 +103552,9 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "defaultValue": null,

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -240,6 +240,7 @@ query CohortsList(
   }
   cohorts(where: $where, options: $options) {
     cohortId
+    initialCohortDeliveryDate
     hasCohortCompleteCohortCompletes(
       options: $hasCohortCompleteCohortCompletesOptions2
     ) {

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -16,6 +16,12 @@ query PatientsList($options: PatientOptions, $where: PatientWhere) {
   }
   patients(where: $where, options: $options) {
     smilePatientId
+    cmoPatientId
+    dmpPatientId
+    totalSampleCount
+    cmoSampleIds
+    consentPartA
+    consentPartC
     hasSampleSamples {
       smileSampleId
       hasMetadataSampleMetadata {

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -238,17 +238,26 @@ query CohortsList(
   }
   cohorts(where: $where, options: $options) {
     cohortId
+    smileSampleIds
+    totalSampleCount
+    billed
     initialCohortDeliveryDate
+    endUsers
+    pmUsers
+    projectTitle
+    projectSubtitle
+    status
+    type
     hasCohortCompleteCohortCompletes(
       options: $hasCohortCompleteCohortCompletesOptions2
     ) {
-      type
+      date
       endUsers
       pmUsers
       projectTitle
       projectSubtitle
       status
-      date
+      type
     }
     hasCohortSampleSamplesConnection {
       totalCount

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -1,9 +1,5 @@
-query RequestsList(
-  $options: RequestOptions
-  $where: RequestWhere
-  $requestsConnectionWhere2: RequestWhere
-) {
-  requestsConnection(where: $requestsConnectionWhere2) {
+query RequestsList($options: RequestOptions, $where: RequestWhere) {
+  requestsConnection(where: $where) {
     totalCount
   }
   requests(where: $where, options: $options) {
@@ -14,12 +10,8 @@ query RequestsList(
   }
 }
 
-query PatientsList(
-  $options: PatientOptions
-  $where: PatientWhere
-  $patientsConnectionWhere2: PatientWhere
-) {
-  patientsConnection(where: $patientsConnectionWhere2) {
+query PatientsList($options: PatientOptions, $where: PatientWhere) {
+  patientsConnection(where: $where) {
     totalCount
   }
   patients(where: $where, options: $options) {
@@ -232,10 +224,9 @@ query GetPatientIdsTriplets($patientIds: [String!]!) {
 query CohortsList(
   $where: CohortWhere
   $options: CohortOptions
-  $cohortsConnectionWhere2: CohortWhere
   $hasCohortCompleteCohortCompletesOptions2: CohortCompleteOptions
 ) {
-  cohortsConnection(where: $cohortsConnectionWhere2) {
+  cohortsConnection(where: $where) {
     totalCount
   }
   cohorts(where: $where, options: $options) {

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -103,6 +103,7 @@ query FindSamplesByInputValue(
 fragment RequestParts on Request {
   igoRequestId
   igoProjectId
+  totalSampleCount
   genePanel
   dataAnalystName
   dataAnalystEmail


### PR DESCRIPTION
For [card #1211](https://github.com/mskcc/smile-server/issues/1211).

This PR "flattens" the GraphQL-queried data from Neo4j, bringing nested fields to the root level.
<table>
<tr>
<th> Before </th>
<th> After </th>
</tr>
<tr>
<td>

```gql
node {
  field1
  hasChildNode {
    field2
    field3
  }
}
```

</td>
<td>

```gql
node {        
  field1        
  field2        
  field3        
}



```

</td>
</tr>
</table>

This "flattening" is done by adding these fields to the Neo4j schema, then writing resolvers so that the Apollo Client knows how to return data for these fields.

Pros:
 - Right now, we’re unable to perform sorting of nested fields as that isn't natively supported by GraphQL[^1]. Having custom resolvers for these nested fields allow us to write logic to handle sorting in a future ticket.
 - Moving the data processing logic to the GraphQL/Apollo server and leaving the frontend responsible for just the “view” (better separation of concerns).
 - Ease of access to nested fields for the frontend.

Cons:
 - Generally, having fewer custom resolvers is better. Unfortunately, there is no workarounds at the moment to handle sorting of nested fields.
 - It's less clear which types in the "Neo4j" schema were generated directly from the Neo4j database, and which are the custom types. To handle this, we'll need to be more diligent with documentations (through self-documenting code and the README) to ensure future contributors understand the what and why of the extended types.

[^1]: GraphQL fields are resolved in a top-down fashion. That means the root-level fields are resolved first, then then fields in the next nested level, and so on.