### PR TITLE
Auto sort the Requests and Cohorts views

### DIFF
--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -184,6 +184,7 @@ export default function RecordsList({
                 options: {
                   offset: 0,
                   limit: undefined,
+                  sort: defaultSort,
                 },
               },
             }).then(({ data }) => {

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -18,7 +18,7 @@ import {
 } from "ag-grid-community";
 import { DataName, useHookLazyGeneric } from "../shared/types";
 import SamplesList from "./SamplesList";
-import { Sample, SampleWhere } from "../generated/graphql";
+import { Sample, SampleWhere, SortDirection } from "../generated/graphql";
 import {
   defaultColDef,
   prepareSampleMetadataForAgGrid,
@@ -39,6 +39,7 @@ interface IRecordsListProps {
   queryFilterWhereVariables: (
     parsedSearchVals: string[]
   ) => Record<string, any>[];
+  defaultSort?: { [key: string]: SortDirection }[];
   userSearchVal: string;
   setUserSearchVal: Dispatch<SetStateAction<string>>;
   parsedSearchVals: string[];
@@ -69,6 +70,7 @@ export default function RecordsList({
   lazyRecordsQueryAddlVariables,
   prepareDataForAgGrid,
   queryFilterWhereVariables,
+  defaultSort,
   userSearchVal,
   setUserSearchVal,
   parsedSearchVals,
@@ -101,7 +103,11 @@ export default function RecordsList({
   const [initialFetch, { loading, error, data, fetchMore, refetch }] =
     lazyRecordsQuery({
       variables: {
-        options: { limit: 20, offset: 0 },
+        options: {
+          limit: 20,
+          offset: 0,
+          sort: defaultSort,
+        },
         ...lazyRecordsQueryAddlVariables,
       },
     });
@@ -119,9 +125,7 @@ export default function RecordsList({
           options: {
             offset: params.request.startRow,
             limit: params.request.endRow,
-            sort: params.request.sortModel.map((sortModel) => {
-              return { [sortModel.colId]: sortModel.sort?.toUpperCase() };
-            }),
+            sort: defaultSort,
           },
         };
 

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -3597,6 +3597,26 @@ export type ProjectHasRequestRequestsNodeAggregationWhereInput = {
   igoRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   igoRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   igoRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  importDate_EQUAL?: InputMaybe<Scalars["String"]>;
+  importDate_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   investigatorEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   investigatorEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   investigatorEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -3930,6 +3950,7 @@ export type ProjectRequestHasRequestRequestsNodeAggregateSelection = {
   genePanel: StringAggregateSelectionNonNullable;
   igoProjectId: StringAggregateSelectionNonNullable;
   igoRequestId: StringAggregateSelectionNonNullable;
+  importDate: StringAggregateSelectionNullable;
   investigatorEmail: StringAggregateSelectionNonNullable;
   investigatorName: StringAggregateSelectionNonNullable;
   labHeadEmail: StringAggregateSelectionNonNullable;
@@ -4661,11 +4682,15 @@ export type Request = {
   dataAnalystEmail: Scalars["String"];
   dataAnalystName: Scalars["String"];
   genePanel: Scalars["String"];
+  hasMetadataRequestMetadata: Array<RequestMetadata>;
+  hasMetadataRequestMetadataAggregate?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection>;
+  hasMetadataRequestMetadataConnection: RequestHasMetadataRequestMetadataConnection;
   hasSampleSamples: Array<Sample>;
   hasSampleSamplesAggregate?: Maybe<RequestSampleHasSampleSamplesAggregationSelection>;
   hasSampleSamplesConnection: RequestHasSampleSamplesConnection;
   igoProjectId: Scalars["String"];
   igoRequestId: Scalars["String"];
+  importDate?: Maybe<Scalars["String"]>;
   investigatorEmail: Scalars["String"];
   investigatorName: Scalars["String"];
   isCmoRequest: Scalars["Boolean"];
@@ -4685,6 +4710,25 @@ export type Request = {
   smileRequestId: Scalars["String"];
   strand?: Maybe<Scalars["String"]>;
   totalSampleCount?: Maybe<Scalars["Int"]>;
+};
+
+export type RequestHasMetadataRequestMetadataArgs = {
+  directed?: InputMaybe<Scalars["Boolean"]>;
+  options?: InputMaybe<RequestMetadataOptions>;
+  where?: InputMaybe<RequestMetadataWhere>;
+};
+
+export type RequestHasMetadataRequestMetadataAggregateArgs = {
+  directed?: InputMaybe<Scalars["Boolean"]>;
+  where?: InputMaybe<RequestMetadataWhere>;
+};
+
+export type RequestHasMetadataRequestMetadataConnectionArgs = {
+  after?: InputMaybe<Scalars["String"]>;
+  directed?: InputMaybe<Scalars["Boolean"]>;
+  first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionSort>>;
+  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
 };
 
 export type RequestHasSampleSamplesArgs = {
@@ -4734,6 +4778,7 @@ export type RequestAggregateSelection = {
   genePanel: StringAggregateSelectionNonNullable;
   igoProjectId: StringAggregateSelectionNonNullable;
   igoRequestId: StringAggregateSelectionNonNullable;
+  importDate: StringAggregateSelectionNullable;
   investigatorEmail: StringAggregateSelectionNonNullable;
   investigatorName: StringAggregateSelectionNonNullable;
   labHeadEmail: StringAggregateSelectionNonNullable;
@@ -4751,6 +4796,9 @@ export type RequestAggregateSelection = {
 };
 
 export type RequestConnectInput = {
+  hasMetadataRequestMetadata?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataConnectFieldInput>
+  >;
   hasSampleSamples?: InputMaybe<
     Array<RequestHasSampleSamplesConnectFieldInput>
   >;
@@ -4769,9 +4817,11 @@ export type RequestCreateInput = {
   dataAnalystEmail: Scalars["String"];
   dataAnalystName: Scalars["String"];
   genePanel: Scalars["String"];
+  hasMetadataRequestMetadata?: InputMaybe<RequestHasMetadataRequestMetadataFieldInput>;
   hasSampleSamples?: InputMaybe<RequestHasSampleSamplesFieldInput>;
   igoProjectId: Scalars["String"];
   igoRequestId: Scalars["String"];
+  importDate?: InputMaybe<Scalars["String"]>;
   investigatorEmail: Scalars["String"];
   investigatorName: Scalars["String"];
   isCmoRequest: Scalars["Boolean"];
@@ -4792,6 +4842,9 @@ export type RequestCreateInput = {
 };
 
 export type RequestDeleteInput = {
+  hasMetadataRequestMetadata?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataDeleteFieldInput>
+  >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesDeleteFieldInput>>;
   projectsHasRequest?: InputMaybe<
     Array<RequestProjectsHasRequestDeleteFieldInput>
@@ -4799,6 +4852,9 @@ export type RequestDeleteInput = {
 };
 
 export type RequestDisconnectInput = {
+  hasMetadataRequestMetadata?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataDisconnectFieldInput>
+  >;
   hasSampleSamples?: InputMaybe<
     Array<RequestHasSampleSamplesDisconnectFieldInput>
   >;
@@ -4811,6 +4867,153 @@ export type RequestEdge = {
   __typename?: "RequestEdge";
   cursor: Scalars["String"];
   node: Request;
+};
+
+export type RequestHasMetadataRequestMetadataAggregateInput = {
+  AND?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
+  OR?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
+  count?: InputMaybe<Scalars["Int"]>;
+  count_GT?: InputMaybe<Scalars["Int"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]>;
+  count_LT?: InputMaybe<Scalars["Int"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]>;
+  node?: InputMaybe<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>;
+};
+
+export type RequestHasMetadataRequestMetadataConnectFieldInput = {
+  connect?: InputMaybe<Array<RequestMetadataConnectInput>>;
+  where?: InputMaybe<RequestMetadataConnectWhere>;
+};
+
+export type RequestHasMetadataRequestMetadataConnection = {
+  __typename?: "RequestHasMetadataRequestMetadataConnection";
+  edges: Array<RequestHasMetadataRequestMetadataRelationship>;
+  pageInfo: PageInfo;
+  totalCount: Scalars["Int"];
+};
+
+export type RequestHasMetadataRequestMetadataConnectionSort = {
+  node?: InputMaybe<RequestMetadataSort>;
+};
+
+export type RequestHasMetadataRequestMetadataConnectionWhere = {
+  AND?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionWhere>>;
+  OR?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionWhere>>;
+  node?: InputMaybe<RequestMetadataWhere>;
+  node_NOT?: InputMaybe<RequestMetadataWhere>;
+};
+
+export type RequestHasMetadataRequestMetadataCreateFieldInput = {
+  node: RequestMetadataCreateInput;
+};
+
+export type RequestHasMetadataRequestMetadataDeleteFieldInput = {
+  delete?: InputMaybe<RequestMetadataDeleteInput>;
+  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
+};
+
+export type RequestHasMetadataRequestMetadataDisconnectFieldInput = {
+  disconnect?: InputMaybe<RequestMetadataDisconnectInput>;
+  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
+};
+
+export type RequestHasMetadataRequestMetadataFieldInput = {
+  connect?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataConnectFieldInput>
+  >;
+  create?: InputMaybe<Array<RequestHasMetadataRequestMetadataCreateFieldInput>>;
+};
+
+export type RequestHasMetadataRequestMetadataNodeAggregationWhereInput = {
+  AND?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>
+  >;
+  OR?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>
+  >;
+  igoRequestId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_EQUAL?: InputMaybe<Scalars["String"]>;
+  igoRequestId_GT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_GTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  importDate_EQUAL?: InputMaybe<Scalars["String"]>;
+  importDate_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  requestMetadataJson_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  requestMetadataJson_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  requestMetadataJson_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  requestMetadataJson_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  requestMetadataJson_EQUAL?: InputMaybe<Scalars["String"]>;
+  requestMetadataJson_GT?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_GTE?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LT?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LTE?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+};
+
+export type RequestHasMetadataRequestMetadataRelationship = {
+  __typename?: "RequestHasMetadataRequestMetadataRelationship";
+  cursor: Scalars["String"];
+  node: RequestMetadata;
+};
+
+export type RequestHasMetadataRequestMetadataUpdateConnectionInput = {
+  node?: InputMaybe<RequestMetadataUpdateInput>;
+};
+
+export type RequestHasMetadataRequestMetadataUpdateFieldInput = {
+  connect?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataConnectFieldInput>
+  >;
+  create?: InputMaybe<Array<RequestHasMetadataRequestMetadataCreateFieldInput>>;
+  delete?: InputMaybe<Array<RequestHasMetadataRequestMetadataDeleteFieldInput>>;
+  disconnect?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataDisconnectFieldInput>
+  >;
+  update?: InputMaybe<RequestHasMetadataRequestMetadataUpdateConnectionInput>;
+  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
 };
 
 export type RequestHasSampleSamplesAggregateInput = {
@@ -4978,6 +5181,9 @@ export type RequestMetadata = {
   igoRequestId: Scalars["String"];
   importDate: Scalars["String"];
   requestMetadataJson: Scalars["String"];
+  requestsHasMetadata: Array<Request>;
+  requestsHasMetadataAggregate?: Maybe<RequestMetadataRequestRequestsHasMetadataAggregationSelection>;
+  requestsHasMetadataConnection: RequestMetadataRequestsHasMetadataConnection;
 };
 
 export type RequestMetadataHasStatusStatusesArgs = {
@@ -4999,6 +5205,25 @@ export type RequestMetadataHasStatusStatusesConnectionArgs = {
   where?: InputMaybe<RequestMetadataHasStatusStatusesConnectionWhere>;
 };
 
+export type RequestMetadataRequestsHasMetadataArgs = {
+  directed?: InputMaybe<Scalars["Boolean"]>;
+  options?: InputMaybe<RequestOptions>;
+  where?: InputMaybe<RequestWhere>;
+};
+
+export type RequestMetadataRequestsHasMetadataAggregateArgs = {
+  directed?: InputMaybe<Scalars["Boolean"]>;
+  where?: InputMaybe<RequestWhere>;
+};
+
+export type RequestMetadataRequestsHasMetadataConnectionArgs = {
+  after?: InputMaybe<Scalars["String"]>;
+  directed?: InputMaybe<Scalars["Boolean"]>;
+  first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionSort>>;
+  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+};
+
 export type RequestMetadataAggregateSelection = {
   __typename?: "RequestMetadataAggregateSelection";
   count: Scalars["Int"];
@@ -5010,6 +5235,9 @@ export type RequestMetadataAggregateSelection = {
 export type RequestMetadataConnectInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesConnectFieldInput>
+  >;
+  requestsHasMetadata?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataConnectFieldInput>
   >;
 };
 
@@ -5029,17 +5257,24 @@ export type RequestMetadataCreateInput = {
   igoRequestId: Scalars["String"];
   importDate: Scalars["String"];
   requestMetadataJson: Scalars["String"];
+  requestsHasMetadata?: InputMaybe<RequestMetadataRequestsHasMetadataFieldInput>;
 };
 
 export type RequestMetadataDeleteInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesDeleteFieldInput>
   >;
+  requestsHasMetadata?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataDeleteFieldInput>
+  >;
 };
 
 export type RequestMetadataDisconnectInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesDisconnectFieldInput>
+  >;
+  requestsHasMetadata?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataDisconnectFieldInput>
   >;
 };
 
@@ -5167,6 +5402,558 @@ export type RequestMetadataRelationInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesCreateFieldInput>
   >;
+  requestsHasMetadata?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataCreateFieldInput>
+  >;
+};
+
+export type RequestMetadataRequestRequestsHasMetadataAggregationSelection = {
+  __typename?: "RequestMetadataRequestRequestsHasMetadataAggregationSelection";
+  count: Scalars["Int"];
+  node?: Maybe<RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection>;
+};
+
+export type RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection = {
+  __typename?: "RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection";
+  dataAccessEmails: StringAggregateSelectionNonNullable;
+  dataAnalystEmail: StringAggregateSelectionNonNullable;
+  dataAnalystName: StringAggregateSelectionNonNullable;
+  genePanel: StringAggregateSelectionNonNullable;
+  igoProjectId: StringAggregateSelectionNonNullable;
+  igoRequestId: StringAggregateSelectionNonNullable;
+  importDate: StringAggregateSelectionNullable;
+  investigatorEmail: StringAggregateSelectionNonNullable;
+  investigatorName: StringAggregateSelectionNonNullable;
+  labHeadEmail: StringAggregateSelectionNonNullable;
+  labHeadName: StringAggregateSelectionNonNullable;
+  libraryType: StringAggregateSelectionNullable;
+  namespace: StringAggregateSelectionNonNullable;
+  otherContactEmails: StringAggregateSelectionNonNullable;
+  piEmail: StringAggregateSelectionNonNullable;
+  projectManagerName: StringAggregateSelectionNonNullable;
+  qcAccessEmails: StringAggregateSelectionNonNullable;
+  requestJson: StringAggregateSelectionNonNullable;
+  smileRequestId: StringAggregateSelectionNonNullable;
+  strand: StringAggregateSelectionNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
+};
+
+export type RequestMetadataRequestsHasMetadataAggregateInput = {
+  AND?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
+  OR?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
+  count?: InputMaybe<Scalars["Int"]>;
+  count_GT?: InputMaybe<Scalars["Int"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]>;
+  count_LT?: InputMaybe<Scalars["Int"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]>;
+  node?: InputMaybe<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>;
+};
+
+export type RequestMetadataRequestsHasMetadataConnectFieldInput = {
+  connect?: InputMaybe<Array<RequestConnectInput>>;
+  where?: InputMaybe<RequestConnectWhere>;
+};
+
+export type RequestMetadataRequestsHasMetadataConnection = {
+  __typename?: "RequestMetadataRequestsHasMetadataConnection";
+  edges: Array<RequestMetadataRequestsHasMetadataRelationship>;
+  pageInfo: PageInfo;
+  totalCount: Scalars["Int"];
+};
+
+export type RequestMetadataRequestsHasMetadataConnectionSort = {
+  node?: InputMaybe<RequestSort>;
+};
+
+export type RequestMetadataRequestsHasMetadataConnectionWhere = {
+  AND?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionWhere>>;
+  OR?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionWhere>>;
+  node?: InputMaybe<RequestWhere>;
+  node_NOT?: InputMaybe<RequestWhere>;
+};
+
+export type RequestMetadataRequestsHasMetadataCreateFieldInput = {
+  node: RequestCreateInput;
+};
+
+export type RequestMetadataRequestsHasMetadataDeleteFieldInput = {
+  delete?: InputMaybe<RequestDeleteInput>;
+  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+};
+
+export type RequestMetadataRequestsHasMetadataDisconnectFieldInput = {
+  disconnect?: InputMaybe<RequestDisconnectInput>;
+  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+};
+
+export type RequestMetadataRequestsHasMetadataFieldInput = {
+  connect?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataConnectFieldInput>
+  >;
+  create?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataCreateFieldInput>
+  >;
+};
+
+export type RequestMetadataRequestsHasMetadataNodeAggregationWhereInput = {
+  AND?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>
+  >;
+  OR?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>
+  >;
+  dataAccessEmails_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  dataAccessEmails_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  dataAccessEmails_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  dataAccessEmails_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  dataAccessEmails_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  dataAccessEmails_EQUAL?: InputMaybe<Scalars["String"]>;
+  dataAccessEmails_GT?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LT?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  dataAnalystEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  dataAnalystEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  dataAnalystEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  dataAnalystEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  dataAnalystEmail_EQUAL?: InputMaybe<Scalars["String"]>;
+  dataAnalystEmail_GT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  dataAnalystName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  dataAnalystName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  dataAnalystName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  dataAnalystName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  dataAnalystName_EQUAL?: InputMaybe<Scalars["String"]>;
+  dataAnalystName_GT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  genePanel_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  genePanel_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  genePanel_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  genePanel_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  genePanel_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  genePanel_EQUAL?: InputMaybe<Scalars["String"]>;
+  genePanel_GT?: InputMaybe<Scalars["Int"]>;
+  genePanel_GTE?: InputMaybe<Scalars["Int"]>;
+  genePanel_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  genePanel_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  genePanel_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  genePanel_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  genePanel_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  genePanel_LT?: InputMaybe<Scalars["Int"]>;
+  genePanel_LTE?: InputMaybe<Scalars["Int"]>;
+  genePanel_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  genePanel_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  genePanel_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  genePanel_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  genePanel_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  igoProjectId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  igoProjectId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  igoProjectId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  igoProjectId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  igoProjectId_EQUAL?: InputMaybe<Scalars["String"]>;
+  igoProjectId_GT?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_GTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LT?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_EQUAL?: InputMaybe<Scalars["String"]>;
+  igoRequestId_GT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_GTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  importDate_EQUAL?: InputMaybe<Scalars["String"]>;
+  importDate_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  investigatorEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  investigatorEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  investigatorEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  investigatorEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  investigatorEmail_EQUAL?: InputMaybe<Scalars["String"]>;
+  investigatorEmail_GT?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_GTE?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LT?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LTE?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  investigatorName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  investigatorName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  investigatorName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  investigatorName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  investigatorName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  investigatorName_EQUAL?: InputMaybe<Scalars["String"]>;
+  investigatorName_GT?: InputMaybe<Scalars["Int"]>;
+  investigatorName_GTE?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LT?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LTE?: InputMaybe<Scalars["Int"]>;
+  investigatorName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  investigatorName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  investigatorName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  investigatorName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  investigatorName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  labHeadEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  labHeadEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  labHeadEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  labHeadEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  labHeadEmail_EQUAL?: InputMaybe<Scalars["String"]>;
+  labHeadEmail_GT?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_GTE?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LT?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LTE?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  labHeadName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  labHeadName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  labHeadName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  labHeadName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  labHeadName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  labHeadName_EQUAL?: InputMaybe<Scalars["String"]>;
+  labHeadName_GT?: InputMaybe<Scalars["Int"]>;
+  labHeadName_GTE?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LT?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LTE?: InputMaybe<Scalars["Int"]>;
+  labHeadName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  labHeadName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  labHeadName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  labHeadName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  labHeadName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  libraryType_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  libraryType_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  libraryType_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  libraryType_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  libraryType_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  libraryType_EQUAL?: InputMaybe<Scalars["String"]>;
+  libraryType_GT?: InputMaybe<Scalars["Int"]>;
+  libraryType_GTE?: InputMaybe<Scalars["Int"]>;
+  libraryType_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  libraryType_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  libraryType_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  libraryType_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  libraryType_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  libraryType_LT?: InputMaybe<Scalars["Int"]>;
+  libraryType_LTE?: InputMaybe<Scalars["Int"]>;
+  libraryType_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  libraryType_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  libraryType_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  libraryType_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  libraryType_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  namespace_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  namespace_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  namespace_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  namespace_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  namespace_EQUAL?: InputMaybe<Scalars["String"]>;
+  namespace_GT?: InputMaybe<Scalars["Int"]>;
+  namespace_GTE?: InputMaybe<Scalars["Int"]>;
+  namespace_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  namespace_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  namespace_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  namespace_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  namespace_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_LT?: InputMaybe<Scalars["Int"]>;
+  namespace_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  namespace_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  namespace_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  namespace_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  namespace_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  otherContactEmails_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  otherContactEmails_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  otherContactEmails_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  otherContactEmails_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  otherContactEmails_EQUAL?: InputMaybe<Scalars["String"]>;
+  otherContactEmails_GT?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_GTE?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LT?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LTE?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  piEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  piEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  piEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  piEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  piEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  piEmail_EQUAL?: InputMaybe<Scalars["String"]>;
+  piEmail_GT?: InputMaybe<Scalars["Int"]>;
+  piEmail_GTE?: InputMaybe<Scalars["Int"]>;
+  piEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  piEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  piEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  piEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  piEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  piEmail_LT?: InputMaybe<Scalars["Int"]>;
+  piEmail_LTE?: InputMaybe<Scalars["Int"]>;
+  piEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  piEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  piEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  piEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  piEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  projectManagerName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  projectManagerName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  projectManagerName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  projectManagerName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  projectManagerName_EQUAL?: InputMaybe<Scalars["String"]>;
+  projectManagerName_GT?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_GTE?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LT?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LTE?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  qcAccessEmails_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  qcAccessEmails_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  qcAccessEmails_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  qcAccessEmails_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  qcAccessEmails_EQUAL?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails_GT?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_GTE?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LT?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LTE?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  requestJson_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  requestJson_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  requestJson_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  requestJson_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  requestJson_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  requestJson_EQUAL?: InputMaybe<Scalars["String"]>;
+  requestJson_GT?: InputMaybe<Scalars["Int"]>;
+  requestJson_GTE?: InputMaybe<Scalars["Int"]>;
+  requestJson_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  requestJson_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  requestJson_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  requestJson_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  requestJson_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  requestJson_LT?: InputMaybe<Scalars["Int"]>;
+  requestJson_LTE?: InputMaybe<Scalars["Int"]>;
+  requestJson_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  requestJson_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  requestJson_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  requestJson_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  requestJson_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  smileRequestId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  smileRequestId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  smileRequestId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  smileRequestId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  smileRequestId_EQUAL?: InputMaybe<Scalars["String"]>;
+  smileRequestId_GT?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_GTE?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LT?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LTE?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  strand_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  strand_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  strand_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  strand_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  strand_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  strand_EQUAL?: InputMaybe<Scalars["String"]>;
+  strand_GT?: InputMaybe<Scalars["Int"]>;
+  strand_GTE?: InputMaybe<Scalars["Int"]>;
+  strand_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  strand_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  strand_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  strand_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  strand_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  strand_LT?: InputMaybe<Scalars["Int"]>;
+  strand_LTE?: InputMaybe<Scalars["Int"]>;
+  strand_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  strand_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  strand_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  strand_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  strand_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
+};
+
+export type RequestMetadataRequestsHasMetadataRelationship = {
+  __typename?: "RequestMetadataRequestsHasMetadataRelationship";
+  cursor: Scalars["String"];
+  node: Request;
+};
+
+export type RequestMetadataRequestsHasMetadataUpdateConnectionInput = {
+  node?: InputMaybe<RequestUpdateInput>;
+};
+
+export type RequestMetadataRequestsHasMetadataUpdateFieldInput = {
+  connect?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataConnectFieldInput>
+  >;
+  create?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataCreateFieldInput>
+  >;
+  delete?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataDeleteFieldInput>
+  >;
+  disconnect?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataDisconnectFieldInput>
+  >;
+  update?: InputMaybe<RequestMetadataRequestsHasMetadataUpdateConnectionInput>;
+  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
 };
 
 /** Fields to sort RequestMetadata by. The order in which sorts are applied is not guaranteed when specifying many fields in one RequestMetadataSort object. */
@@ -5194,6 +5981,9 @@ export type RequestMetadataUpdateInput = {
   igoRequestId?: InputMaybe<Scalars["String"]>;
   importDate?: InputMaybe<Scalars["String"]>;
   requestMetadataJson?: InputMaybe<Scalars["String"]>;
+  requestsHasMetadata?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataUpdateFieldInput>
+  >;
 };
 
 export type RequestMetadataWhere = {
@@ -5242,6 +6032,19 @@ export type RequestMetadataWhere = {
   requestMetadataJson_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   requestMetadataJson_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   requestMetadataJson_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  requestsHasMetadataAggregate?: InputMaybe<RequestMetadataRequestsHasMetadataAggregateInput>;
+  requestsHasMetadataConnection_ALL?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+  requestsHasMetadataConnection_NONE?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+  requestsHasMetadataConnection_SINGLE?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+  requestsHasMetadataConnection_SOME?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+  /** Return RequestMetadata where all of the related Requests match this filter */
+  requestsHasMetadata_ALL?: InputMaybe<RequestWhere>;
+  /** Return RequestMetadata where none of the related Requests match this filter */
+  requestsHasMetadata_NONE?: InputMaybe<RequestWhere>;
+  /** Return RequestMetadata where one of the related Requests match this filter */
+  requestsHasMetadata_SINGLE?: InputMaybe<RequestWhere>;
+  /** Return RequestMetadata where some of the related Requests match this filter */
+  requestsHasMetadata_SOME?: InputMaybe<RequestWhere>;
 };
 
 export type RequestOptions = {
@@ -5381,11 +6184,29 @@ export type RequestProjectsHasRequestUpdateFieldInput = {
 };
 
 export type RequestRelationInput = {
+  hasMetadataRequestMetadata?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataCreateFieldInput>
+  >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesCreateFieldInput>>;
   projectsHasRequest?: InputMaybe<
     Array<RequestProjectsHasRequestCreateFieldInput>
   >;
 };
+
+export type RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection =
+  {
+    __typename?: "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection";
+    count: Scalars["Int"];
+    node?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection>;
+  };
+
+export type RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection =
+  {
+    __typename?: "RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection";
+    igoRequestId: StringAggregateSelectionNonNullable;
+    importDate: StringAggregateSelectionNonNullable;
+    requestMetadataJson: StringAggregateSelectionNonNullable;
+  };
 
 export type RequestSampleHasSampleSamplesAggregationSelection = {
   __typename?: "RequestSampleHasSampleSamplesAggregationSelection";
@@ -5410,6 +6231,7 @@ export type RequestSort = {
   genePanel?: InputMaybe<SortDirection>;
   igoProjectId?: InputMaybe<SortDirection>;
   igoRequestId?: InputMaybe<SortDirection>;
+  importDate?: InputMaybe<SortDirection>;
   investigatorEmail?: InputMaybe<SortDirection>;
   investigatorName?: InputMaybe<SortDirection>;
   isCmoRequest?: InputMaybe<SortDirection>;
@@ -5433,9 +6255,13 @@ export type RequestUpdateInput = {
   dataAnalystEmail?: InputMaybe<Scalars["String"]>;
   dataAnalystName?: InputMaybe<Scalars["String"]>;
   genePanel?: InputMaybe<Scalars["String"]>;
+  hasMetadataRequestMetadata?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataUpdateFieldInput>
+  >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesUpdateFieldInput>>;
   igoProjectId?: InputMaybe<Scalars["String"]>;
   igoRequestId?: InputMaybe<Scalars["String"]>;
+  importDate?: InputMaybe<Scalars["String"]>;
   investigatorEmail?: InputMaybe<Scalars["String"]>;
   investigatorName?: InputMaybe<Scalars["String"]>;
   isCmoRequest?: InputMaybe<Scalars["Boolean"]>;
@@ -5506,6 +6332,19 @@ export type RequestWhere = {
   genePanel_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   genePanel_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  hasMetadataRequestMetadataAggregate?: InputMaybe<RequestHasMetadataRequestMetadataAggregateInput>;
+  hasMetadataRequestMetadataConnection_ALL?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
+  hasMetadataRequestMetadataConnection_NONE?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
+  hasMetadataRequestMetadataConnection_SINGLE?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
+  hasMetadataRequestMetadataConnection_SOME?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
+  /** Return Requests where all of the related RequestMetadata match this filter */
+  hasMetadataRequestMetadata_ALL?: InputMaybe<RequestMetadataWhere>;
+  /** Return Requests where none of the related RequestMetadata match this filter */
+  hasMetadataRequestMetadata_NONE?: InputMaybe<RequestMetadataWhere>;
+  /** Return Requests where one of the related RequestMetadata match this filter */
+  hasMetadataRequestMetadata_SINGLE?: InputMaybe<RequestMetadataWhere>;
+  /** Return Requests where some of the related RequestMetadata match this filter */
+  hasMetadataRequestMetadata_SOME?: InputMaybe<RequestMetadataWhere>;
   hasSampleSamplesAggregate?: InputMaybe<RequestHasSampleSamplesAggregateInput>;
   hasSampleSamplesConnection_ALL?: InputMaybe<RequestHasSampleSamplesConnectionWhere>;
   hasSampleSamplesConnection_NONE?: InputMaybe<RequestHasSampleSamplesConnectionWhere>;
@@ -5539,6 +6378,16 @@ export type RequestWhere = {
   igoRequestId_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   igoRequestId_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  importDate?: InputMaybe<Scalars["String"]>;
+  importDate_CONTAINS?: InputMaybe<Scalars["String"]>;
+  importDate_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  importDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  importDate_NOT?: InputMaybe<Scalars["String"]>;
+  importDate_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  importDate_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  importDate_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  importDate_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  importDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   investigatorEmail?: InputMaybe<Scalars["String"]>;
   investigatorEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
   investigatorEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
@@ -8441,6 +9290,7 @@ export type SampleRequestRequestsHasSampleNodeAggregateSelection = {
   genePanel: StringAggregateSelectionNonNullable;
   igoProjectId: StringAggregateSelectionNonNullable;
   igoRequestId: StringAggregateSelectionNonNullable;
+  importDate: StringAggregateSelectionNullable;
   investigatorEmail: StringAggregateSelectionNonNullable;
   investigatorName: StringAggregateSelectionNonNullable;
   labHeadEmail: StringAggregateSelectionNonNullable;
@@ -8633,6 +9483,26 @@ export type SampleRequestsHasSampleNodeAggregationWhereInput = {
   igoRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   igoRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   igoRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  importDate_EQUAL?: InputMaybe<Scalars["String"]>;
+  importDate_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   investigatorEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   investigatorEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   investigatorEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -11355,9 +12225,10 @@ export type RequestsListQuery = {
   requestsConnection: { __typename?: "RequestsConnection"; totalCount: number };
   requests: Array<{
     __typename?: "Request";
+    importDate?: string | null;
+    totalSampleCount?: number | null;
     igoRequestId: string;
     igoProjectId: string;
-    totalSampleCount?: number | null;
     genePanel: string;
     dataAnalystName: string;
     dataAnalystEmail: string;
@@ -11374,6 +12245,10 @@ export type RequestsListQuery = {
     projectManagerName: string;
     qcAccessEmails: string;
     smileRequestId: string;
+    hasMetadataRequestMetadata: Array<{
+      __typename?: "RequestMetadata";
+      importDate: string;
+    }>;
     hasSampleSamplesConnection: {
       __typename?: "RequestHasSampleSamplesConnection";
       totalCount: number;
@@ -11485,7 +12360,6 @@ export type FindSamplesByInputValueQuery = {
               __typename?: "Request";
               igoRequestId: string;
               igoProjectId: string;
-              totalSampleCount?: number | null;
               genePanel: string;
               dataAnalystName: string;
               dataAnalystEmail: string;
@@ -11562,7 +12436,6 @@ export type RequestPartsFragment = {
   __typename?: "Request";
   igoRequestId: string;
   igoProjectId: string;
-  totalSampleCount?: number | null;
   genePanel: string;
   dataAnalystName: string;
   dataAnalystEmail: string;
@@ -11814,7 +12687,6 @@ export const RequestPartsFragmentDoc = gql`
   fragment RequestParts on Request {
     igoRequestId
     igoProjectId
-    totalSampleCount
     genePanel
     dataAnalystName
     dataAnalystEmail
@@ -11890,6 +12762,11 @@ export const RequestsListDocument = gql`
     }
     requests(where: $where, options: $options) {
       ...RequestParts
+      importDate
+      totalSampleCount
+      hasMetadataRequestMetadata {
+        importDate
+      }
       hasSampleSamplesConnection {
         totalCount
       }

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -144,6 +144,7 @@ export default function CohortsPage({
   const sampleQueryParamHeaderName = "Cohort ID";
   const sampleQueryParamValue = params[sampleQueryParamFieldName];
   const sampleKeyForUpdate = "hasTempoTempos";
+  const defaultSort = [{ initialCohortDeliveryDate: SortDirection.Desc }];
 
   return (
     <>
@@ -163,6 +164,7 @@ export default function CohortsPage({
         }
         prepareDataForAgGrid={prepareCohortDataForAgGrid}
         queryFilterWhereVariables={cohortFilterWhereVariables}
+        defaultSort={defaultSort}
         userSearchVal={userSearchVal}
         setUserSearchVal={setUserSearchVal}
         parsedSearchVals={parsedSearchVals}

--- a/frontend/src/pages/requests/RequestsPage.tsx
+++ b/frontend/src/pages/requests/RequestsPage.tsx
@@ -1,6 +1,7 @@
 import {
   RequestWhere,
   SampleWhere,
+  SortDirection,
   useRequestsListLazyQuery,
 } from "../../generated/graphql";
 import { useState } from "react";
@@ -69,6 +70,7 @@ export default function RequestsPage() {
   const sampleQueryParamFieldName = "igoRequestId";
   const sampleQueryParamHeaderName = "IGO Request ID";
   const sampleQueryParamValue = params[sampleQueryParamFieldName];
+  const defaultSort = [{ importDate: SortDirection.Desc }];
 
   return (
     <>
@@ -79,6 +81,7 @@ export default function RequestsPage() {
         dataName={dataName}
         lazyRecordsQuery={useRequestsListLazyQuery}
         queryFilterWhereVariables={requestFilterWhereVariables}
+        defaultSort={defaultSort}
         userSearchVal={userSearchVal}
         setUserSearchVal={setUserSearchVal}
         parsedSearchVals={parsedSearchVals}

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -75,6 +75,10 @@ export const RequestsListColumns: ColDef[] = [
     headerName: "IGO Project ID",
   },
   {
+    field: "importDate",
+    headerName: "Import Date",
+  },
+  {
     field: "totalSampleCount",
     headerName: "# Samples",
     cellClass: (params) => {

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -3596,6 +3596,26 @@ export type ProjectHasRequestRequestsNodeAggregationWhereInput = {
   igoRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   igoRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   igoRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  importDate_EQUAL?: InputMaybe<Scalars["String"]>;
+  importDate_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   investigatorEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   investigatorEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   investigatorEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -3929,6 +3949,7 @@ export type ProjectRequestHasRequestRequestsNodeAggregateSelection = {
   genePanel: StringAggregateSelectionNonNullable;
   igoProjectId: StringAggregateSelectionNonNullable;
   igoRequestId: StringAggregateSelectionNonNullable;
+  importDate: StringAggregateSelectionNullable;
   investigatorEmail: StringAggregateSelectionNonNullable;
   investigatorName: StringAggregateSelectionNonNullable;
   labHeadEmail: StringAggregateSelectionNonNullable;
@@ -4660,11 +4681,15 @@ export type Request = {
   dataAnalystEmail: Scalars["String"];
   dataAnalystName: Scalars["String"];
   genePanel: Scalars["String"];
+  hasMetadataRequestMetadata: Array<RequestMetadata>;
+  hasMetadataRequestMetadataAggregate?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection>;
+  hasMetadataRequestMetadataConnection: RequestHasMetadataRequestMetadataConnection;
   hasSampleSamples: Array<Sample>;
   hasSampleSamplesAggregate?: Maybe<RequestSampleHasSampleSamplesAggregationSelection>;
   hasSampleSamplesConnection: RequestHasSampleSamplesConnection;
   igoProjectId: Scalars["String"];
   igoRequestId: Scalars["String"];
+  importDate?: Maybe<Scalars["String"]>;
   investigatorEmail: Scalars["String"];
   investigatorName: Scalars["String"];
   isCmoRequest: Scalars["Boolean"];
@@ -4684,6 +4709,25 @@ export type Request = {
   smileRequestId: Scalars["String"];
   strand?: Maybe<Scalars["String"]>;
   totalSampleCount?: Maybe<Scalars["Int"]>;
+};
+
+export type RequestHasMetadataRequestMetadataArgs = {
+  directed?: InputMaybe<Scalars["Boolean"]>;
+  options?: InputMaybe<RequestMetadataOptions>;
+  where?: InputMaybe<RequestMetadataWhere>;
+};
+
+export type RequestHasMetadataRequestMetadataAggregateArgs = {
+  directed?: InputMaybe<Scalars["Boolean"]>;
+  where?: InputMaybe<RequestMetadataWhere>;
+};
+
+export type RequestHasMetadataRequestMetadataConnectionArgs = {
+  after?: InputMaybe<Scalars["String"]>;
+  directed?: InputMaybe<Scalars["Boolean"]>;
+  first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionSort>>;
+  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
 };
 
 export type RequestHasSampleSamplesArgs = {
@@ -4733,6 +4777,7 @@ export type RequestAggregateSelection = {
   genePanel: StringAggregateSelectionNonNullable;
   igoProjectId: StringAggregateSelectionNonNullable;
   igoRequestId: StringAggregateSelectionNonNullable;
+  importDate: StringAggregateSelectionNullable;
   investigatorEmail: StringAggregateSelectionNonNullable;
   investigatorName: StringAggregateSelectionNonNullable;
   labHeadEmail: StringAggregateSelectionNonNullable;
@@ -4750,6 +4795,9 @@ export type RequestAggregateSelection = {
 };
 
 export type RequestConnectInput = {
+  hasMetadataRequestMetadata?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataConnectFieldInput>
+  >;
   hasSampleSamples?: InputMaybe<
     Array<RequestHasSampleSamplesConnectFieldInput>
   >;
@@ -4768,9 +4816,11 @@ export type RequestCreateInput = {
   dataAnalystEmail: Scalars["String"];
   dataAnalystName: Scalars["String"];
   genePanel: Scalars["String"];
+  hasMetadataRequestMetadata?: InputMaybe<RequestHasMetadataRequestMetadataFieldInput>;
   hasSampleSamples?: InputMaybe<RequestHasSampleSamplesFieldInput>;
   igoProjectId: Scalars["String"];
   igoRequestId: Scalars["String"];
+  importDate?: InputMaybe<Scalars["String"]>;
   investigatorEmail: Scalars["String"];
   investigatorName: Scalars["String"];
   isCmoRequest: Scalars["Boolean"];
@@ -4791,6 +4841,9 @@ export type RequestCreateInput = {
 };
 
 export type RequestDeleteInput = {
+  hasMetadataRequestMetadata?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataDeleteFieldInput>
+  >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesDeleteFieldInput>>;
   projectsHasRequest?: InputMaybe<
     Array<RequestProjectsHasRequestDeleteFieldInput>
@@ -4798,6 +4851,9 @@ export type RequestDeleteInput = {
 };
 
 export type RequestDisconnectInput = {
+  hasMetadataRequestMetadata?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataDisconnectFieldInput>
+  >;
   hasSampleSamples?: InputMaybe<
     Array<RequestHasSampleSamplesDisconnectFieldInput>
   >;
@@ -4810,6 +4866,153 @@ export type RequestEdge = {
   __typename?: "RequestEdge";
   cursor: Scalars["String"];
   node: Request;
+};
+
+export type RequestHasMetadataRequestMetadataAggregateInput = {
+  AND?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
+  OR?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
+  count?: InputMaybe<Scalars["Int"]>;
+  count_GT?: InputMaybe<Scalars["Int"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]>;
+  count_LT?: InputMaybe<Scalars["Int"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]>;
+  node?: InputMaybe<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>;
+};
+
+export type RequestHasMetadataRequestMetadataConnectFieldInput = {
+  connect?: InputMaybe<Array<RequestMetadataConnectInput>>;
+  where?: InputMaybe<RequestMetadataConnectWhere>;
+};
+
+export type RequestHasMetadataRequestMetadataConnection = {
+  __typename?: "RequestHasMetadataRequestMetadataConnection";
+  edges: Array<RequestHasMetadataRequestMetadataRelationship>;
+  pageInfo: PageInfo;
+  totalCount: Scalars["Int"];
+};
+
+export type RequestHasMetadataRequestMetadataConnectionSort = {
+  node?: InputMaybe<RequestMetadataSort>;
+};
+
+export type RequestHasMetadataRequestMetadataConnectionWhere = {
+  AND?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionWhere>>;
+  OR?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionWhere>>;
+  node?: InputMaybe<RequestMetadataWhere>;
+  node_NOT?: InputMaybe<RequestMetadataWhere>;
+};
+
+export type RequestHasMetadataRequestMetadataCreateFieldInput = {
+  node: RequestMetadataCreateInput;
+};
+
+export type RequestHasMetadataRequestMetadataDeleteFieldInput = {
+  delete?: InputMaybe<RequestMetadataDeleteInput>;
+  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
+};
+
+export type RequestHasMetadataRequestMetadataDisconnectFieldInput = {
+  disconnect?: InputMaybe<RequestMetadataDisconnectInput>;
+  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
+};
+
+export type RequestHasMetadataRequestMetadataFieldInput = {
+  connect?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataConnectFieldInput>
+  >;
+  create?: InputMaybe<Array<RequestHasMetadataRequestMetadataCreateFieldInput>>;
+};
+
+export type RequestHasMetadataRequestMetadataNodeAggregationWhereInput = {
+  AND?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>
+  >;
+  OR?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>
+  >;
+  igoRequestId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_EQUAL?: InputMaybe<Scalars["String"]>;
+  igoRequestId_GT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_GTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  importDate_EQUAL?: InputMaybe<Scalars["String"]>;
+  importDate_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  requestMetadataJson_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  requestMetadataJson_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  requestMetadataJson_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  requestMetadataJson_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  requestMetadataJson_EQUAL?: InputMaybe<Scalars["String"]>;
+  requestMetadataJson_GT?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_GTE?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LT?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_LTE?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  requestMetadataJson_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+};
+
+export type RequestHasMetadataRequestMetadataRelationship = {
+  __typename?: "RequestHasMetadataRequestMetadataRelationship";
+  cursor: Scalars["String"];
+  node: RequestMetadata;
+};
+
+export type RequestHasMetadataRequestMetadataUpdateConnectionInput = {
+  node?: InputMaybe<RequestMetadataUpdateInput>;
+};
+
+export type RequestHasMetadataRequestMetadataUpdateFieldInput = {
+  connect?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataConnectFieldInput>
+  >;
+  create?: InputMaybe<Array<RequestHasMetadataRequestMetadataCreateFieldInput>>;
+  delete?: InputMaybe<Array<RequestHasMetadataRequestMetadataDeleteFieldInput>>;
+  disconnect?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataDisconnectFieldInput>
+  >;
+  update?: InputMaybe<RequestHasMetadataRequestMetadataUpdateConnectionInput>;
+  where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
 };
 
 export type RequestHasSampleSamplesAggregateInput = {
@@ -4977,6 +5180,9 @@ export type RequestMetadata = {
   igoRequestId: Scalars["String"];
   importDate: Scalars["String"];
   requestMetadataJson: Scalars["String"];
+  requestsHasMetadata: Array<Request>;
+  requestsHasMetadataAggregate?: Maybe<RequestMetadataRequestRequestsHasMetadataAggregationSelection>;
+  requestsHasMetadataConnection: RequestMetadataRequestsHasMetadataConnection;
 };
 
 export type RequestMetadataHasStatusStatusesArgs = {
@@ -4998,6 +5204,25 @@ export type RequestMetadataHasStatusStatusesConnectionArgs = {
   where?: InputMaybe<RequestMetadataHasStatusStatusesConnectionWhere>;
 };
 
+export type RequestMetadataRequestsHasMetadataArgs = {
+  directed?: InputMaybe<Scalars["Boolean"]>;
+  options?: InputMaybe<RequestOptions>;
+  where?: InputMaybe<RequestWhere>;
+};
+
+export type RequestMetadataRequestsHasMetadataAggregateArgs = {
+  directed?: InputMaybe<Scalars["Boolean"]>;
+  where?: InputMaybe<RequestWhere>;
+};
+
+export type RequestMetadataRequestsHasMetadataConnectionArgs = {
+  after?: InputMaybe<Scalars["String"]>;
+  directed?: InputMaybe<Scalars["Boolean"]>;
+  first?: InputMaybe<Scalars["Int"]>;
+  sort?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionSort>>;
+  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+};
+
 export type RequestMetadataAggregateSelection = {
   __typename?: "RequestMetadataAggregateSelection";
   count: Scalars["Int"];
@@ -5009,6 +5234,9 @@ export type RequestMetadataAggregateSelection = {
 export type RequestMetadataConnectInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesConnectFieldInput>
+  >;
+  requestsHasMetadata?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataConnectFieldInput>
   >;
 };
 
@@ -5028,17 +5256,24 @@ export type RequestMetadataCreateInput = {
   igoRequestId: Scalars["String"];
   importDate: Scalars["String"];
   requestMetadataJson: Scalars["String"];
+  requestsHasMetadata?: InputMaybe<RequestMetadataRequestsHasMetadataFieldInput>;
 };
 
 export type RequestMetadataDeleteInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesDeleteFieldInput>
   >;
+  requestsHasMetadata?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataDeleteFieldInput>
+  >;
 };
 
 export type RequestMetadataDisconnectInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesDisconnectFieldInput>
+  >;
+  requestsHasMetadata?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataDisconnectFieldInput>
   >;
 };
 
@@ -5166,6 +5401,558 @@ export type RequestMetadataRelationInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesCreateFieldInput>
   >;
+  requestsHasMetadata?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataCreateFieldInput>
+  >;
+};
+
+export type RequestMetadataRequestRequestsHasMetadataAggregationSelection = {
+  __typename?: "RequestMetadataRequestRequestsHasMetadataAggregationSelection";
+  count: Scalars["Int"];
+  node?: Maybe<RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection>;
+};
+
+export type RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection = {
+  __typename?: "RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection";
+  dataAccessEmails: StringAggregateSelectionNonNullable;
+  dataAnalystEmail: StringAggregateSelectionNonNullable;
+  dataAnalystName: StringAggregateSelectionNonNullable;
+  genePanel: StringAggregateSelectionNonNullable;
+  igoProjectId: StringAggregateSelectionNonNullable;
+  igoRequestId: StringAggregateSelectionNonNullable;
+  importDate: StringAggregateSelectionNullable;
+  investigatorEmail: StringAggregateSelectionNonNullable;
+  investigatorName: StringAggregateSelectionNonNullable;
+  labHeadEmail: StringAggregateSelectionNonNullable;
+  labHeadName: StringAggregateSelectionNonNullable;
+  libraryType: StringAggregateSelectionNullable;
+  namespace: StringAggregateSelectionNonNullable;
+  otherContactEmails: StringAggregateSelectionNonNullable;
+  piEmail: StringAggregateSelectionNonNullable;
+  projectManagerName: StringAggregateSelectionNonNullable;
+  qcAccessEmails: StringAggregateSelectionNonNullable;
+  requestJson: StringAggregateSelectionNonNullable;
+  smileRequestId: StringAggregateSelectionNonNullable;
+  strand: StringAggregateSelectionNullable;
+  totalSampleCount: IntAggregateSelectionNullable;
+};
+
+export type RequestMetadataRequestsHasMetadataAggregateInput = {
+  AND?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
+  OR?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
+  count?: InputMaybe<Scalars["Int"]>;
+  count_GT?: InputMaybe<Scalars["Int"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]>;
+  count_LT?: InputMaybe<Scalars["Int"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]>;
+  node?: InputMaybe<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>;
+};
+
+export type RequestMetadataRequestsHasMetadataConnectFieldInput = {
+  connect?: InputMaybe<Array<RequestConnectInput>>;
+  where?: InputMaybe<RequestConnectWhere>;
+};
+
+export type RequestMetadataRequestsHasMetadataConnection = {
+  __typename?: "RequestMetadataRequestsHasMetadataConnection";
+  edges: Array<RequestMetadataRequestsHasMetadataRelationship>;
+  pageInfo: PageInfo;
+  totalCount: Scalars["Int"];
+};
+
+export type RequestMetadataRequestsHasMetadataConnectionSort = {
+  node?: InputMaybe<RequestSort>;
+};
+
+export type RequestMetadataRequestsHasMetadataConnectionWhere = {
+  AND?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionWhere>>;
+  OR?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionWhere>>;
+  node?: InputMaybe<RequestWhere>;
+  node_NOT?: InputMaybe<RequestWhere>;
+};
+
+export type RequestMetadataRequestsHasMetadataCreateFieldInput = {
+  node: RequestCreateInput;
+};
+
+export type RequestMetadataRequestsHasMetadataDeleteFieldInput = {
+  delete?: InputMaybe<RequestDeleteInput>;
+  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+};
+
+export type RequestMetadataRequestsHasMetadataDisconnectFieldInput = {
+  disconnect?: InputMaybe<RequestDisconnectInput>;
+  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+};
+
+export type RequestMetadataRequestsHasMetadataFieldInput = {
+  connect?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataConnectFieldInput>
+  >;
+  create?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataCreateFieldInput>
+  >;
+};
+
+export type RequestMetadataRequestsHasMetadataNodeAggregationWhereInput = {
+  AND?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>
+  >;
+  OR?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>
+  >;
+  dataAccessEmails_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  dataAccessEmails_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  dataAccessEmails_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  dataAccessEmails_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  dataAccessEmails_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  dataAccessEmails_EQUAL?: InputMaybe<Scalars["String"]>;
+  dataAccessEmails_GT?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LT?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  dataAnalystEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  dataAnalystEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  dataAnalystEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  dataAnalystEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  dataAnalystEmail_EQUAL?: InputMaybe<Scalars["String"]>;
+  dataAnalystEmail_GT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  dataAnalystName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  dataAnalystName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  dataAnalystName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  dataAnalystName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  dataAnalystName_EQUAL?: InputMaybe<Scalars["String"]>;
+  dataAnalystName_GT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  dataAnalystName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  genePanel_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  genePanel_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  genePanel_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  genePanel_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  genePanel_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  genePanel_EQUAL?: InputMaybe<Scalars["String"]>;
+  genePanel_GT?: InputMaybe<Scalars["Int"]>;
+  genePanel_GTE?: InputMaybe<Scalars["Int"]>;
+  genePanel_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  genePanel_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  genePanel_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  genePanel_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  genePanel_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  genePanel_LT?: InputMaybe<Scalars["Int"]>;
+  genePanel_LTE?: InputMaybe<Scalars["Int"]>;
+  genePanel_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  genePanel_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  genePanel_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  genePanel_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  genePanel_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  igoProjectId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  igoProjectId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  igoProjectId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  igoProjectId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  igoProjectId_EQUAL?: InputMaybe<Scalars["String"]>;
+  igoProjectId_GT?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_GTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LT?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_LTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  igoRequestId_EQUAL?: InputMaybe<Scalars["String"]>;
+  igoRequestId_GT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_GTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  importDate_EQUAL?: InputMaybe<Scalars["String"]>;
+  importDate_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  investigatorEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  investigatorEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  investigatorEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  investigatorEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  investigatorEmail_EQUAL?: InputMaybe<Scalars["String"]>;
+  investigatorEmail_GT?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_GTE?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LT?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_LTE?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  investigatorEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  investigatorName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  investigatorName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  investigatorName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  investigatorName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  investigatorName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  investigatorName_EQUAL?: InputMaybe<Scalars["String"]>;
+  investigatorName_GT?: InputMaybe<Scalars["Int"]>;
+  investigatorName_GTE?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LT?: InputMaybe<Scalars["Int"]>;
+  investigatorName_LTE?: InputMaybe<Scalars["Int"]>;
+  investigatorName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  investigatorName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  investigatorName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  investigatorName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  investigatorName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  labHeadEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  labHeadEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  labHeadEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  labHeadEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  labHeadEmail_EQUAL?: InputMaybe<Scalars["String"]>;
+  labHeadEmail_GT?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_GTE?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LT?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_LTE?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  labHeadEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  labHeadName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  labHeadName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  labHeadName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  labHeadName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  labHeadName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  labHeadName_EQUAL?: InputMaybe<Scalars["String"]>;
+  labHeadName_GT?: InputMaybe<Scalars["Int"]>;
+  labHeadName_GTE?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LT?: InputMaybe<Scalars["Int"]>;
+  labHeadName_LTE?: InputMaybe<Scalars["Int"]>;
+  labHeadName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  labHeadName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  labHeadName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  labHeadName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  labHeadName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  libraryType_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  libraryType_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  libraryType_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  libraryType_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  libraryType_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  libraryType_EQUAL?: InputMaybe<Scalars["String"]>;
+  libraryType_GT?: InputMaybe<Scalars["Int"]>;
+  libraryType_GTE?: InputMaybe<Scalars["Int"]>;
+  libraryType_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  libraryType_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  libraryType_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  libraryType_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  libraryType_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  libraryType_LT?: InputMaybe<Scalars["Int"]>;
+  libraryType_LTE?: InputMaybe<Scalars["Int"]>;
+  libraryType_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  libraryType_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  libraryType_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  libraryType_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  libraryType_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  namespace_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  namespace_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  namespace_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  namespace_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  namespace_EQUAL?: InputMaybe<Scalars["String"]>;
+  namespace_GT?: InputMaybe<Scalars["Int"]>;
+  namespace_GTE?: InputMaybe<Scalars["Int"]>;
+  namespace_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  namespace_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  namespace_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  namespace_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  namespace_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_LT?: InputMaybe<Scalars["Int"]>;
+  namespace_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  namespace_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  namespace_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  namespace_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  namespace_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  otherContactEmails_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  otherContactEmails_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  otherContactEmails_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  otherContactEmails_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  otherContactEmails_EQUAL?: InputMaybe<Scalars["String"]>;
+  otherContactEmails_GT?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_GTE?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LT?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_LTE?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  otherContactEmails_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  piEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  piEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  piEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  piEmail_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  piEmail_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  piEmail_EQUAL?: InputMaybe<Scalars["String"]>;
+  piEmail_GT?: InputMaybe<Scalars["Int"]>;
+  piEmail_GTE?: InputMaybe<Scalars["Int"]>;
+  piEmail_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  piEmail_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  piEmail_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  piEmail_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  piEmail_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  piEmail_LT?: InputMaybe<Scalars["Int"]>;
+  piEmail_LTE?: InputMaybe<Scalars["Int"]>;
+  piEmail_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  piEmail_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  piEmail_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  piEmail_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  piEmail_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  projectManagerName_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  projectManagerName_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  projectManagerName_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  projectManagerName_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  projectManagerName_EQUAL?: InputMaybe<Scalars["String"]>;
+  projectManagerName_GT?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_GTE?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LT?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_LTE?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  projectManagerName_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  qcAccessEmails_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  qcAccessEmails_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  qcAccessEmails_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  qcAccessEmails_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  qcAccessEmails_EQUAL?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails_GT?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_GTE?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LT?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_LTE?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  qcAccessEmails_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  requestJson_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  requestJson_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  requestJson_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  requestJson_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  requestJson_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  requestJson_EQUAL?: InputMaybe<Scalars["String"]>;
+  requestJson_GT?: InputMaybe<Scalars["Int"]>;
+  requestJson_GTE?: InputMaybe<Scalars["Int"]>;
+  requestJson_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  requestJson_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  requestJson_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  requestJson_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  requestJson_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  requestJson_LT?: InputMaybe<Scalars["Int"]>;
+  requestJson_LTE?: InputMaybe<Scalars["Int"]>;
+  requestJson_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  requestJson_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  requestJson_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  requestJson_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  requestJson_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  smileRequestId_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  smileRequestId_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  smileRequestId_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  smileRequestId_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  smileRequestId_EQUAL?: InputMaybe<Scalars["String"]>;
+  smileRequestId_GT?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_GTE?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LT?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_LTE?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  smileRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  strand_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  strand_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  strand_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  strand_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  strand_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  strand_EQUAL?: InputMaybe<Scalars["String"]>;
+  strand_GT?: InputMaybe<Scalars["Int"]>;
+  strand_GTE?: InputMaybe<Scalars["Int"]>;
+  strand_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  strand_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  strand_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  strand_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  strand_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  strand_LT?: InputMaybe<Scalars["Int"]>;
+  strand_LTE?: InputMaybe<Scalars["Int"]>;
+  strand_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  strand_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  strand_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  strand_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  strand_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  totalSampleCount_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MAX_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_MIN_LTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_EQUAL?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_GTE?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LT?: InputMaybe<Scalars["Int"]>;
+  totalSampleCount_SUM_LTE?: InputMaybe<Scalars["Int"]>;
+};
+
+export type RequestMetadataRequestsHasMetadataRelationship = {
+  __typename?: "RequestMetadataRequestsHasMetadataRelationship";
+  cursor: Scalars["String"];
+  node: Request;
+};
+
+export type RequestMetadataRequestsHasMetadataUpdateConnectionInput = {
+  node?: InputMaybe<RequestUpdateInput>;
+};
+
+export type RequestMetadataRequestsHasMetadataUpdateFieldInput = {
+  connect?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataConnectFieldInput>
+  >;
+  create?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataCreateFieldInput>
+  >;
+  delete?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataDeleteFieldInput>
+  >;
+  disconnect?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataDisconnectFieldInput>
+  >;
+  update?: InputMaybe<RequestMetadataRequestsHasMetadataUpdateConnectionInput>;
+  where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
 };
 
 /** Fields to sort RequestMetadata by. The order in which sorts are applied is not guaranteed when specifying many fields in one RequestMetadataSort object. */
@@ -5193,6 +5980,9 @@ export type RequestMetadataUpdateInput = {
   igoRequestId?: InputMaybe<Scalars["String"]>;
   importDate?: InputMaybe<Scalars["String"]>;
   requestMetadataJson?: InputMaybe<Scalars["String"]>;
+  requestsHasMetadata?: InputMaybe<
+    Array<RequestMetadataRequestsHasMetadataUpdateFieldInput>
+  >;
 };
 
 export type RequestMetadataWhere = {
@@ -5241,6 +6031,19 @@ export type RequestMetadataWhere = {
   requestMetadataJson_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   requestMetadataJson_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   requestMetadataJson_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  requestsHasMetadataAggregate?: InputMaybe<RequestMetadataRequestsHasMetadataAggregateInput>;
+  requestsHasMetadataConnection_ALL?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+  requestsHasMetadataConnection_NONE?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+  requestsHasMetadataConnection_SINGLE?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+  requestsHasMetadataConnection_SOME?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
+  /** Return RequestMetadata where all of the related Requests match this filter */
+  requestsHasMetadata_ALL?: InputMaybe<RequestWhere>;
+  /** Return RequestMetadata where none of the related Requests match this filter */
+  requestsHasMetadata_NONE?: InputMaybe<RequestWhere>;
+  /** Return RequestMetadata where one of the related Requests match this filter */
+  requestsHasMetadata_SINGLE?: InputMaybe<RequestWhere>;
+  /** Return RequestMetadata where some of the related Requests match this filter */
+  requestsHasMetadata_SOME?: InputMaybe<RequestWhere>;
 };
 
 export type RequestOptions = {
@@ -5380,11 +6183,29 @@ export type RequestProjectsHasRequestUpdateFieldInput = {
 };
 
 export type RequestRelationInput = {
+  hasMetadataRequestMetadata?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataCreateFieldInput>
+  >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesCreateFieldInput>>;
   projectsHasRequest?: InputMaybe<
     Array<RequestProjectsHasRequestCreateFieldInput>
   >;
 };
+
+export type RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection =
+  {
+    __typename?: "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection";
+    count: Scalars["Int"];
+    node?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection>;
+  };
+
+export type RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection =
+  {
+    __typename?: "RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection";
+    igoRequestId: StringAggregateSelectionNonNullable;
+    importDate: StringAggregateSelectionNonNullable;
+    requestMetadataJson: StringAggregateSelectionNonNullable;
+  };
 
 export type RequestSampleHasSampleSamplesAggregationSelection = {
   __typename?: "RequestSampleHasSampleSamplesAggregationSelection";
@@ -5409,6 +6230,7 @@ export type RequestSort = {
   genePanel?: InputMaybe<SortDirection>;
   igoProjectId?: InputMaybe<SortDirection>;
   igoRequestId?: InputMaybe<SortDirection>;
+  importDate?: InputMaybe<SortDirection>;
   investigatorEmail?: InputMaybe<SortDirection>;
   investigatorName?: InputMaybe<SortDirection>;
   isCmoRequest?: InputMaybe<SortDirection>;
@@ -5432,9 +6254,13 @@ export type RequestUpdateInput = {
   dataAnalystEmail?: InputMaybe<Scalars["String"]>;
   dataAnalystName?: InputMaybe<Scalars["String"]>;
   genePanel?: InputMaybe<Scalars["String"]>;
+  hasMetadataRequestMetadata?: InputMaybe<
+    Array<RequestHasMetadataRequestMetadataUpdateFieldInput>
+  >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesUpdateFieldInput>>;
   igoProjectId?: InputMaybe<Scalars["String"]>;
   igoRequestId?: InputMaybe<Scalars["String"]>;
+  importDate?: InputMaybe<Scalars["String"]>;
   investigatorEmail?: InputMaybe<Scalars["String"]>;
   investigatorName?: InputMaybe<Scalars["String"]>;
   isCmoRequest?: InputMaybe<Scalars["Boolean"]>;
@@ -5505,6 +6331,19 @@ export type RequestWhere = {
   genePanel_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   genePanel_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  hasMetadataRequestMetadataAggregate?: InputMaybe<RequestHasMetadataRequestMetadataAggregateInput>;
+  hasMetadataRequestMetadataConnection_ALL?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
+  hasMetadataRequestMetadataConnection_NONE?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
+  hasMetadataRequestMetadataConnection_SINGLE?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
+  hasMetadataRequestMetadataConnection_SOME?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
+  /** Return Requests where all of the related RequestMetadata match this filter */
+  hasMetadataRequestMetadata_ALL?: InputMaybe<RequestMetadataWhere>;
+  /** Return Requests where none of the related RequestMetadata match this filter */
+  hasMetadataRequestMetadata_NONE?: InputMaybe<RequestMetadataWhere>;
+  /** Return Requests where one of the related RequestMetadata match this filter */
+  hasMetadataRequestMetadata_SINGLE?: InputMaybe<RequestMetadataWhere>;
+  /** Return Requests where some of the related RequestMetadata match this filter */
+  hasMetadataRequestMetadata_SOME?: InputMaybe<RequestMetadataWhere>;
   hasSampleSamplesAggregate?: InputMaybe<RequestHasSampleSamplesAggregateInput>;
   hasSampleSamplesConnection_ALL?: InputMaybe<RequestHasSampleSamplesConnectionWhere>;
   hasSampleSamplesConnection_NONE?: InputMaybe<RequestHasSampleSamplesConnectionWhere>;
@@ -5538,6 +6377,16 @@ export type RequestWhere = {
   igoRequestId_NOT_IN?: InputMaybe<Array<Scalars["String"]>>;
   igoRequestId_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  importDate?: InputMaybe<Scalars["String"]>;
+  importDate_CONTAINS?: InputMaybe<Scalars["String"]>;
+  importDate_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  importDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  importDate_NOT?: InputMaybe<Scalars["String"]>;
+  importDate_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  importDate_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  importDate_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  importDate_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  importDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   investigatorEmail?: InputMaybe<Scalars["String"]>;
   investigatorEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
   investigatorEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
@@ -8440,6 +9289,7 @@ export type SampleRequestRequestsHasSampleNodeAggregateSelection = {
   genePanel: StringAggregateSelectionNonNullable;
   igoProjectId: StringAggregateSelectionNonNullable;
   igoRequestId: StringAggregateSelectionNonNullable;
+  importDate: StringAggregateSelectionNullable;
   investigatorEmail: StringAggregateSelectionNonNullable;
   investigatorName: StringAggregateSelectionNonNullable;
   labHeadEmail: StringAggregateSelectionNonNullable;
@@ -8632,6 +9482,26 @@ export type SampleRequestsHasSampleNodeAggregationWhereInput = {
   igoRequestId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   igoRequestId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   igoRequestId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  importDate_EQUAL?: InputMaybe<Scalars["String"]>;
+  importDate_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_LTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  importDate_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   investigatorEmail_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   investigatorEmail_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   investigatorEmail_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -11354,9 +12224,10 @@ export type RequestsListQuery = {
   requestsConnection: { __typename?: "RequestsConnection"; totalCount: number };
   requests: Array<{
     __typename?: "Request";
+    importDate?: string | null;
+    totalSampleCount?: number | null;
     igoRequestId: string;
     igoProjectId: string;
-    totalSampleCount?: number | null;
     genePanel: string;
     dataAnalystName: string;
     dataAnalystEmail: string;
@@ -11373,6 +12244,10 @@ export type RequestsListQuery = {
     projectManagerName: string;
     qcAccessEmails: string;
     smileRequestId: string;
+    hasMetadataRequestMetadata: Array<{
+      __typename?: "RequestMetadata";
+      importDate: string;
+    }>;
     hasSampleSamplesConnection: {
       __typename?: "RequestHasSampleSamplesConnection";
       totalCount: number;
@@ -11484,7 +12359,6 @@ export type FindSamplesByInputValueQuery = {
               __typename?: "Request";
               igoRequestId: string;
               igoProjectId: string;
-              totalSampleCount?: number | null;
               genePanel: string;
               dataAnalystName: string;
               dataAnalystEmail: string;
@@ -11561,7 +12435,6 @@ export type RequestPartsFragment = {
   __typename?: "Request";
   igoRequestId: string;
   igoProjectId: string;
-  totalSampleCount?: number | null;
   genePanel: string;
   dataAnalystName: string;
   dataAnalystEmail: string;
@@ -11813,7 +12686,6 @@ export const RequestPartsFragmentDoc = gql`
   fragment RequestParts on Request {
     igoRequestId
     igoProjectId
-    totalSampleCount
     genePanel
     dataAnalystName
     dataAnalystEmail
@@ -11889,6 +12761,11 @@ export const RequestsListDocument = gql`
     }
     requests(where: $where, options: $options) {
       ...RequestParts
+      importDate
+      totalSampleCount
+      hasMetadataRequestMetadata {
+        importDate
+      }
       hasSampleSamplesConnection {
         totalCount
       }

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -178,6 +178,59 @@ function buildResolvers(
         };
       },
     },
+    Query: {
+      async requests(_source: undefined, args: any) {
+        const requests = await ogm.model("Request").find({
+          where: args.where,
+          options: args.options,
+          selectionSet: `{
+            igoRequestId
+            igoProjectId
+            genePanel
+            dataAnalystName
+            dataAnalystEmail
+            dataAccessEmails
+            bicAnalysis
+            investigatorEmail
+            investigatorName
+            isCmoRequest
+            labHeadEmail
+            labHeadName
+            libraryType
+            otherContactEmails
+            piEmail
+            projectManagerName
+            qcAccessEmails
+            smileRequestId
+            hasMetadataRequestMetadata {
+              importDate
+            }
+            hasSampleSamplesConnection {
+              totalCount
+            }
+          }`,
+        });
+
+        if (args.options?.sort) {
+          const sortField = Object.keys(args.options.sort[0])[0];
+          const sortOrder = Object.values(args.options.sort[0])[0];
+
+          if (sortField === "importDate") {
+            requests.sort((a, b) => {
+              const importDateA = a.hasMetadataRequestMetadata[0].importDate;
+              const importDateB = b.hasMetadataRequestMetadata[0].importDate;
+              if (sortOrder === "ASC") {
+                return importDateA > importDateB ? 1 : -1;
+              } else {
+                return importDateA < importDateB ? 1 : -1;
+              }
+            });
+          }
+        }
+
+        return requests;
+      },
+    },
     Request: {
       importDate: (parent: RequestsListQuery["requests"][number]) => {
         return parent.hasMetadataRequestMetadata[0].importDate;

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -51,6 +51,7 @@ export async function buildNeo4jDbSchema() {
     ${typeDefs}
 
     extend type Request {
+      importDate: String
       totalSampleCount: Int
     }
 
@@ -178,6 +179,9 @@ function buildResolvers(
       },
     },
     Request: {
+      importDate: (parent: RequestsListQuery["requests"][number]) => {
+        return parent.hasMetadataRequestMetadata[0].importDate;
+      },
       totalSampleCount: (parent: RequestsListQuery["requests"][number]) => {
         return parent.hasSampleSamplesConnection?.totalCount;
       },

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -230,6 +230,56 @@ function buildResolvers(
 
         return requests;
       },
+      async cohorts(_source: undefined, args: any) {
+        const cohorts = await ogm.model("Cohort").find({
+          where: args.where,
+          options: args.options,
+          selectionSet: `{
+            cohortId
+            smileSampleIds
+            hasCohortCompleteCohortCompletes {
+              date
+              endUsers
+              pmUsers
+              projectTitle
+              projectSubtitle
+              status
+              type
+            }
+            hasCohortSampleSamplesConnection {
+              totalCount
+            }
+            hasCohortSampleSamples {
+              smileSampleId
+              hasTempoTempos {
+                smileTempoId
+                billed
+              }
+            }
+          }`,
+        });
+
+        if (args.options?.sort) {
+          const sortField = Object.keys(args.options.sort[0])[0];
+          const sortOrder = Object.values(args.options.sort[0])[0];
+
+          if (sortField === "initialCohortDeliveryDate") {
+            cohorts.sort((a, b) => {
+              const dateA =
+                a.hasCohortCompleteCohortCompletes?.slice(-1)[0]?.date;
+              const dateB =
+                b.hasCohortCompleteCohortCompletes?.slice(-1)[0]?.date;
+              if (sortOrder === "ASC") {
+                return dateA > dateB ? 1 : -1;
+              } else {
+                return dateA < dateB ? 1 : -1;
+              }
+            });
+          }
+        }
+
+        return cohorts;
+      },
     },
     Request: {
       importDate: (parent: RequestsListQuery["requests"][number]) => {

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -34999,6 +34999,246 @@
             "deprecationReason": null
           },
           {
+            "name": "importDate_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "investigatorEmail_AVERAGE_EQUAL",
             "description": null,
             "type": {
@@ -38824,6 +39064,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
                 "ofType": null
               }
             },
@@ -45625,6 +45881,189 @@
             "deprecationReason": null
           },
           {
+            "name": "hasMetadataRequestMetadata",
+            "description": null,
+            "args": [
+              {
+                "name": "directed",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "true",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "options",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataOptions",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataWhere",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "RequestMetadata",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasMetadataRequestMetadataAggregate",
+            "description": null,
+            "args": [
+              {
+                "name": "directed",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "true",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataWhere",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasMetadataRequestMetadataConnection",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "directed",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "true",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "RequestHasMetadataRequestMetadataConnectionSort",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "RequestHasMetadataRequestMetadataConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "hasSampleSamples",
             "description": null,
             "args": [
@@ -45835,6 +46274,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -46390,6 +46841,22 @@
             "deprecationReason": null
           },
           {
+            "name": "importDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "investigatorEmail",
             "description": null,
             "args": [],
@@ -46626,6 +47093,26 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "hasMetadataRequestMetadata",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "hasSampleSamples",
             "description": null,
             "type": {
@@ -46784,6 +47271,18 @@
             "deprecationReason": null
           },
           {
+            "name": "hasMetadataRequestMetadata",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestHasMetadataRequestMetadataFieldInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "hasSampleSamples",
             "description": null,
             "type": {
@@ -46822,6 +47321,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -47095,6 +47606,26 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "hasMetadataRequestMetadata",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataDeleteFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "hasSampleSamples",
             "description": null,
             "type": {
@@ -47145,6 +47676,26 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "hasMetadataRequestMetadata",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataDisconnectFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "hasSampleSamples",
             "description": null,
@@ -47230,6 +47781,1437 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestHasMetadataRequestMetadataAggregateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "AND",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataAggregateInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OR",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataAggregateInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestHasMetadataRequestMetadataNodeAggregationWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "connect",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataConnectInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataConnectWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RequestHasMetadataRequestMetadataConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "RequestHasMetadataRequestMetadataRelationship",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestHasMetadataRequestMetadataConnectionSort",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataSort",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "AND",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OR",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node_NOT",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "RequestMetadataCreateInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestHasMetadataRequestMetadataDeleteFieldInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "delete",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataDeleteInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestHasMetadataRequestMetadataDisconnectFieldInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "disconnect",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataDisconnectInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestHasMetadataRequestMetadataFieldInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "connect",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "create",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestHasMetadataRequestMetadataNodeAggregationWhereInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "AND",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataNodeAggregationWhereInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OR",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataNodeAggregationWhereInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RequestHasMetadataRequestMetadataRelationship",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "RequestMetadata",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestHasMetadataRequestMetadataUpdateConnectionInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataUpdateInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestHasMetadataRequestMetadataUpdateFieldInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "connect",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "create",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delete",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataDeleteFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "disconnect",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataDisconnectFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestHasMetadataRequestMetadataUpdateConnectionInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -49139,6 +51121,189 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadata",
+            "description": null,
+            "args": [
+              {
+                "name": "directed",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "true",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "options",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestOptions",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestWhere",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Request",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadataAggregate",
+            "description": null,
+            "args": [
+              {
+                "name": "directed",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "true",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestWhere",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "RequestMetadataRequestRequestsHasMetadataAggregationSelection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadataConnection",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "directed",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "true",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "RequestMetadataRequestsHasMetadataConnectionSort",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "RequestMetadataRequestsHasMetadataConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -49239,6 +51404,26 @@
                 "ofType": {
                   "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesConnectFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadata",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
                   "ofType": null
                 }
               }
@@ -49411,6 +51596,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadata",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataRequestsHasMetadataFieldInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -49442,6 +51639,26 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadata",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataDeleteFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -49466,6 +51683,26 @@
                 "ofType": {
                   "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesDisconnectFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadata",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataDisconnectFieldInput",
                   "ofType": null
                 }
               }
@@ -50553,6 +52790,6223 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadata",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RequestMetadataRequestRequestsHasMetadataAggregationSelection",
+        "description": null,
+        "fields": [
+          {
+            "name": "count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection",
+        "description": null,
+        "fields": [
+          {
+            "name": "dataAccessEmails",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataAggregateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "AND",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataAggregateInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OR",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataAggregateInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataRequestsHasMetadataNodeAggregationWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "connect",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestConnectInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestConnectWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "RequestMetadataRequestsHasMetadataRelationship",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataConnectionSort",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestSort",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "AND",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OR",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node_NOT",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "RequestCreateInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataDeleteFieldInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "delete",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestDeleteInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataDisconnectFieldInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "disconnect",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestDisconnectInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataFieldInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "connect",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "create",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataNodeAggregationWhereInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "AND",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataNodeAggregationWhereInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OR",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataNodeAggregationWhereInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAccessEmails_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystEmail_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataAnalystName_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoProjectId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "igoRequestId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorEmail_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorName_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadEmail_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labHeadName_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "libraryType_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "namespace_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "otherContactEmails_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "piEmail_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectManagerName_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcAccessEmails_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestJson_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileRequestId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "strand_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MAX_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_MIN_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalSampleCount_SUM_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataRelationship",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Request",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataUpdateConnectionInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "node",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestUpdateInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RequestMetadataRequestsHasMetadataUpdateFieldInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "connect",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "create",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delete",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataDeleteFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "disconnect",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataDisconnectFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataRequestsHasMetadataUpdateConnectionInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -50729,6 +59183,26 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadata",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestMetadataRequestsHasMetadataUpdateFieldInput",
+                  "ofType": null
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -51295,6 +59769,114 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadataAggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataRequestsHasMetadataAggregateInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadataConnection_ALL",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadataConnection_NONE",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadataConnection_SINGLE",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadataConnection_SOME",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadata_ALL",
+            "description": "Return RequestMetadata where all of the related Requests match this filter",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadata_NONE",
+            "description": "Return RequestMetadata where none of the related Requests match this filter",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadata_SINGLE",
+            "description": "Return RequestMetadata where one of the related Requests match this filter",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestsHasMetadata_SOME",
+            "description": "Return RequestMetadata where some of the related Requests match this filter",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestWhere",
               "ofType": null
             },
             "defaultValue": null,
@@ -52641,6 +61223,26 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "hasMetadataRequestMetadata",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "hasSampleSamples",
             "description": null,
             "type": {
@@ -52682,6 +61284,104 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection",
+        "description": null,
+        "fields": [
+          {
+            "name": "count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection",
+        "description": null,
+        "fields": [
+          {
+            "name": "igoRequestId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestMetadataJson",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNonNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -52879,6 +61579,18 @@
           },
           {
             "name": "igoRequestId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -53141,6 +61853,26 @@
             "deprecationReason": null
           },
           {
+            "name": "hasMetadataRequestMetadata",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RequestHasMetadataRequestMetadataUpdateFieldInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "hasSampleSamples",
             "description": null,
             "type": {
@@ -53174,6 +61906,18 @@
           },
           {
             "name": "igoRequestId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -54072,6 +62816,114 @@
             "deprecationReason": null
           },
           {
+            "name": "hasMetadataRequestMetadataAggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestHasMetadataRequestMetadataAggregateInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasMetadataRequestMetadataConnection_ALL",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasMetadataRequestMetadataConnection_NONE",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasMetadataRequestMetadataConnection_SINGLE",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasMetadataRequestMetadataConnection_SOME",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasMetadataRequestMetadata_ALL",
+            "description": "Return Requests where all of the related RequestMetadata match this filter",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasMetadataRequestMetadata_NONE",
+            "description": "Return Requests where none of the related RequestMetadata match this filter",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasMetadataRequestMetadata_SINGLE",
+            "description": "Return Requests where one of the related RequestMetadata match this filter",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasMetadataRequestMetadata_SOME",
+            "description": "Return Requests where some of the related RequestMetadata match this filter",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "RequestMetadataWhere",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "hasSampleSamplesAggregate",
             "description": null,
             "type": {
@@ -54441,6 +63293,134 @@
           },
           {
             "name": "igoRequestId_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_STARTS_WITH",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -85600,6 +94580,22 @@
             "deprecationReason": null
           },
           {
+            "name": "importDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "investigatorEmail",
             "description": null,
             "args": [],
@@ -87784,6 +96780,246 @@
           },
           {
             "name": "igoRequestId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate_SHORTEST_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -4,6 +4,11 @@ query RequestsList($options: RequestOptions, $where: RequestWhere) {
   }
   requests(where: $where, options: $options) {
     ...RequestParts
+    importDate
+    totalSampleCount
+    hasMetadataRequestMetadata {
+      importDate
+    }
     hasSampleSamplesConnection {
       totalCount
     }
@@ -109,7 +114,6 @@ query FindSamplesByInputValue(
 fragment RequestParts on Request {
   igoRequestId
   igoProjectId
-  totalSampleCount
   genePanel
   dataAnalystName
   dataAnalystEmail


### PR DESCRIPTION
This PR is a superset of #140, so we can either merge them both in order or just merge this one.

This PR introduces the following changes:
- Tab name updates in Samples page
- Show Import Date in Requests view
- Auto-sort the initial load of Requests view by Import Date
- Auto-sort the initial load of Cohorts view by Initial Cohort Delivery Date

Note that this PR only applies sorting to the initial load of the aforementioned views. The ability to manually sort fields will be introduced in a future PR for card [#1152](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1152).