### PR TITLE
Enable sorting for all columns in Requests, Patients, and Cohorts views

### DIFF
--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -1,6 +1,6 @@
 import AutoSizer from "react-virtualized-auto-sizer";
 import { Button, Container, Modal } from "react-bootstrap";
-import { Dispatch, SetStateAction, useMemo, useRef } from "react";
+import { Dispatch, SetStateAction, useCallback, useMemo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { DownloadModal } from "./DownloadModal";
 import { buildTsvString } from "../utils/buildTsvString";
@@ -117,7 +117,7 @@ export default function RecordsList({
 
   const totalCountNodeName = `${dataName}Connection`;
 
-  function getSortModel() {
+  const getSortModel = useCallback(() => {
     const sortModel = grid.current?.columnApi
       ?.getColumnState()
       .filter(({ sort }) => sort)
@@ -128,7 +128,7 @@ export default function RecordsList({
       return sortModel;
     }
     return defaultSort;
-  }
+  }, [defaultSort]);
 
   const datasource: IServerSideDatasource = useMemo(() => {
     return {

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -35,7 +35,8 @@ interface IRecordsListProps {
   lazyRecordsQueryAddlVariables?: Record<string, any>;
   prepareDataForAgGrid?: (
     data: any,
-    filterModel: IServerSideGetRowsRequest["filterModel"]
+    filterModel: IServerSideGetRowsRequest["filterModel"],
+    sortModel?: { [key: string]: SortDirection }[] | undefined
   ) => any;
   queryFilterWhereVariables: (
     parsedSearchVals: string[]
@@ -191,6 +192,8 @@ export default function RecordsList({
       {showDownloadModal && (
         <DownloadModal
           loader={async () => {
+            const sortModel = getSortModel();
+
             const { data } = await fetchMore({
               variables: {
                 where: {
@@ -199,14 +202,16 @@ export default function RecordsList({
                 options: {
                   offset: 0,
                   limit: undefined,
-                  sort: getSortModel(),
+                  sort: sortModel,
                 },
               },
             });
+
             let agGridData = data;
             if (prepareDataForAgGrid) {
-              agGridData = prepareDataForAgGrid(data, filterModel);
+              agGridData = prepareDataForAgGrid(data, filterModel, sortModel);
             }
+
             return buildTsvString(agGridData[dataName], colDefs);
           }}
           onComplete={() => setShowDownloadModal(false)}

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -2428,7 +2428,7 @@ export type PageInfo = {
 export type Patient = {
   __typename?: "Patient";
   cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleIds?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  cmoSampleIds?: Maybe<Scalars["String"]>;
   consentPartA?: Maybe<Scalars["String"]>;
   consentPartC?: Maybe<Scalars["String"]>;
   dmpPatientId?: Maybe<Scalars["String"]>;
@@ -2483,6 +2483,7 @@ export type PatientPatientAliasesIsAliasConnectionArgs = {
 export type PatientAggregateSelection = {
   __typename?: "PatientAggregateSelection";
   cmoPatientId: StringAggregateSelectionNullable;
+  cmoSampleIds: StringAggregateSelectionNullable;
   consentPartA: StringAggregateSelectionNullable;
   consentPartC: StringAggregateSelectionNullable;
   count: Scalars["Int"];
@@ -2636,6 +2637,26 @@ export type PatientAliasIsAliasPatientsNodeAggregationWhereInput = {
   cmoPatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   cmoPatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   cmoPatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_EQUAL?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_GT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   consentPartA_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   consentPartA_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   consentPartA_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -2780,6 +2801,7 @@ export type PatientAliasPatientIsAliasPatientsAggregationSelection = {
 export type PatientAliasPatientIsAliasPatientsNodeAggregateSelection = {
   __typename?: "PatientAliasPatientIsAliasPatientsNodeAggregateSelection";
   cmoPatientId: StringAggregateSelectionNullable;
+  cmoSampleIds: StringAggregateSelectionNullable;
   consentPartA: StringAggregateSelectionNullable;
   consentPartC: StringAggregateSelectionNullable;
   dmpPatientId: StringAggregateSelectionNullable;
@@ -2867,7 +2889,7 @@ export type PatientConnectWhere = {
 
 export type PatientCreateInput = {
   cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds?: InputMaybe<Scalars["String"]>;
   consentPartA?: InputMaybe<Scalars["String"]>;
   consentPartC?: InputMaybe<Scalars["String"]>;
   dmpPatientId?: InputMaybe<Scalars["String"]>;
@@ -3227,6 +3249,7 @@ export type PatientSampleHasSampleSamplesNodeAggregateSelection = {
 /** Fields to sort Patients by. The order in which sorts are applied is not guaranteed when specifying many fields in one PatientSort object. */
 export type PatientSort = {
   cmoPatientId?: InputMaybe<SortDirection>;
+  cmoSampleIds?: InputMaybe<SortDirection>;
   consentPartA?: InputMaybe<SortDirection>;
   consentPartC?: InputMaybe<SortDirection>;
   dmpPatientId?: InputMaybe<SortDirection>;
@@ -3236,9 +3259,7 @@ export type PatientSort = {
 
 export type PatientUpdateInput = {
   cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoSampleIds_POP?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIds_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds?: InputMaybe<Scalars["String"]>;
   consentPartA?: InputMaybe<Scalars["String"]>;
   consentPartC?: InputMaybe<Scalars["String"]>;
   dmpPatientId?: InputMaybe<Scalars["String"]>;
@@ -3265,10 +3286,16 @@ export type PatientWhere = {
   cmoPatientId_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   cmoPatientId_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   cmoPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoSampleIds_INCLUDES?: InputMaybe<Scalars["String"]>;
-  cmoSampleIds_NOT?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoSampleIds_NOT_INCLUDES?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds_NOT?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   consentPartA?: InputMaybe<Scalars["String"]>;
   consentPartA_CONTAINS?: InputMaybe<Scalars["String"]>;
   consentPartA_ENDS_WITH?: InputMaybe<Scalars["String"]>;
@@ -9048,6 +9075,7 @@ export type SamplePatientPatientsHasSampleAggregationSelection = {
 export type SamplePatientPatientsHasSampleNodeAggregateSelection = {
   __typename?: "SamplePatientPatientsHasSampleNodeAggregateSelection";
   cmoPatientId: StringAggregateSelectionNullable;
+  cmoSampleIds: StringAggregateSelectionNullable;
   consentPartA: StringAggregateSelectionNullable;
   consentPartC: StringAggregateSelectionNullable;
   dmpPatientId: StringAggregateSelectionNullable;
@@ -9131,6 +9159,26 @@ export type SamplePatientsHasSampleNodeAggregationWhereInput = {
   cmoPatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   cmoPatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   cmoPatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_EQUAL?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_GT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   consentPartA_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   consentPartA_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   consentPartA_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -12270,7 +12318,7 @@ export type PatientsListQuery = {
     cmoPatientId?: string | null;
     dmpPatientId?: string | null;
     totalSampleCount?: number | null;
-    cmoSampleIds?: Array<string | null> | null;
+    cmoSampleIds?: string | null;
     consentPartA?: string | null;
     consentPartC?: string | null;
     hasSampleSamples: Array<{

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -176,37 +176,30 @@ export const PatientsListColumns: ColDef[] = [
   {
     field: "cmoPatientId",
     headerName: "CMO Patient ID",
-    sortable: false,
   },
   {
     field: "dmpPatientId",
     headerName: "DMP Patient ID",
-    sortable: false,
   },
   {
     field: "totalSampleCount",
     headerName: "# Samples",
-    sortable: false,
   },
   {
     field: "cmoSampleIds",
     headerName: "Sample IDs",
-    sortable: false,
   },
   {
     field: "consentPartA",
     headerName: "12-245 Part A",
-    sortable: false,
   },
   {
     field: "consentPartC",
     headerName: "12-245 Part C",
-    sortable: false,
   },
   {
     field: "smilePatientId",
     headerName: "SMILE Patient ID",
-    hide: true,
   },
 ];
 

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -87,7 +87,6 @@ export const RequestsListColumns: ColDef[] = [
       }
       return undefined;
     },
-    sortable: false,
   },
   {
     field: "projectManagerName",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -201,6 +201,7 @@ export const PatientsListColumns: ColDef[] = [
   {
     field: "smilePatientId",
     headerName: "SMILE Patient ID",
+    hide: true,
   },
 ];
 
@@ -476,6 +477,7 @@ export function prepareCohortDataForAgGrid(
   let newCohorts = [...cohortsListQueryResult.cohorts];
   let newCohortsConnection = { ...cohortsListQueryResult.cohortsConnection };
 
+  // Handle filtering
   if ("initialCohortDeliveryDate" in filterModel) {
     const { dateFrom, dateTo } = filterModel.initialCohortDeliveryDate;
     newCohorts = newCohorts.filter((cohort) => {
@@ -510,31 +512,14 @@ export function prepareCohortDataForAgGrid(
     });
   });
 
+  // Handle sorting the Cohort records when users perform an export while a sort is active
+  // The sorting logic cover cases when the value is null/undefined, string, and number
   if (sortModel) {
     const sortField = Object.keys(
       sortModel[0]
     )[0] as keyof typeof newCohorts[number];
     const sortOrder = sortModel[0][sortField];
-    newCohorts.sort((objA, objB) => {
-      let a = objA[sortField],
-        b = objB[sortField];
-
-      if (a === null || a === undefined) return 1;
-      if (b === null || b === undefined) return -1;
-
-      if (Array.isArray(a)) a = a.join(", ");
-      if (Array.isArray(b)) b = b.join(", ");
-
-      if (typeof a === "number" && typeof b === "number") {
-        return sortOrder === "ASC" ? a - b : b - a;
-      } else if (typeof a === "string" && typeof b === "string") {
-        return sortOrder === "ASC"
-          ? a.localeCompare(b, "en", { sensitivity: "base" })
-          : b.localeCompare(a, "en", { sensitivity: "base" });
-      } else {
-        return 0;
-      }
-    });
+    sortArray(newCohorts, sortField, sortOrder);
   }
 
   return {
@@ -542,6 +527,29 @@ export function prepareCohortDataForAgGrid(
     cohortsConnection: newCohortsConnection,
     uniqueSampleCount: uniqueSmileSampleIds.size,
   };
+}
+
+function sortArray(arr: any[], sortField: string, sortOrder: SortDirection) {
+  arr.sort((objA, objB) => {
+    let a = objA[sortField],
+      b = objB[sortField];
+
+    if (a === null || a === undefined) return 1;
+    if (b === null || b === undefined) return -1;
+
+    if (Array.isArray(a)) a = a.join(", ");
+    if (Array.isArray(b)) b = b.join(", ");
+
+    if (typeof a === "number" && typeof b === "number") {
+      return sortOrder === "ASC" ? a - b : b - a;
+    } else if (typeof a === "string" && typeof b === "string") {
+      return sortOrder === "ASC"
+        ? a.localeCompare(b, "en", { sensitivity: "base" })
+        : b.localeCompare(a, "en", { sensitivity: "base" });
+    } else {
+      return 0;
+    }
+  });
 }
 
 export const CohortsListColumns: ColDef[] = [

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -544,12 +544,10 @@ export const CohortsListColumns: ColDef[] = [
   {
     field: "totalSampleCount",
     headerName: "# Samples",
-    sortable: false,
   },
   {
     field: "billed",
     headerName: "Billed",
-    sortable: false,
     filter: true,
     filterParams: {
       values: ["Yes", "No"],
@@ -559,7 +557,6 @@ export const CohortsListColumns: ColDef[] = [
   {
     field: "initialCohortDeliveryDate",
     headerName: "Initial Cohort Delivery Date",
-    sortable: false,
     filter: "agDateColumnFilter",
     filterParams: {
       buttons: ["apply", "reset"],
@@ -579,32 +576,26 @@ export const CohortsListColumns: ColDef[] = [
   {
     field: "endUsers",
     headerName: "End Users",
-    sortable: false,
   },
   {
     field: "pmUsers",
     headerName: "PM Users",
-    sortable: false,
   },
   {
     field: "projectTitle",
     headerName: "Project Title",
-    sortable: false,
   },
   {
     field: "projectSubtitle",
     headerName: "Project Subtitle",
-    sortable: false,
   },
   {
     field: "status",
     headerName: "Status",
-    sortable: false,
   },
   {
     field: "type",
     headerName: "Type",
-    sortable: false,
   },
 ];
 

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -2427,7 +2427,7 @@ export type PageInfo = {
 export type Patient = {
   __typename?: "Patient";
   cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleIds?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  cmoSampleIds?: Maybe<Scalars["String"]>;
   consentPartA?: Maybe<Scalars["String"]>;
   consentPartC?: Maybe<Scalars["String"]>;
   dmpPatientId?: Maybe<Scalars["String"]>;
@@ -2482,6 +2482,7 @@ export type PatientPatientAliasesIsAliasConnectionArgs = {
 export type PatientAggregateSelection = {
   __typename?: "PatientAggregateSelection";
   cmoPatientId: StringAggregateSelectionNullable;
+  cmoSampleIds: StringAggregateSelectionNullable;
   consentPartA: StringAggregateSelectionNullable;
   consentPartC: StringAggregateSelectionNullable;
   count: Scalars["Int"];
@@ -2635,6 +2636,26 @@ export type PatientAliasIsAliasPatientsNodeAggregationWhereInput = {
   cmoPatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   cmoPatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   cmoPatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_EQUAL?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_GT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   consentPartA_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   consentPartA_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   consentPartA_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -2779,6 +2800,7 @@ export type PatientAliasPatientIsAliasPatientsAggregationSelection = {
 export type PatientAliasPatientIsAliasPatientsNodeAggregateSelection = {
   __typename?: "PatientAliasPatientIsAliasPatientsNodeAggregateSelection";
   cmoPatientId: StringAggregateSelectionNullable;
+  cmoSampleIds: StringAggregateSelectionNullable;
   consentPartA: StringAggregateSelectionNullable;
   consentPartC: StringAggregateSelectionNullable;
   dmpPatientId: StringAggregateSelectionNullable;
@@ -2866,7 +2888,7 @@ export type PatientConnectWhere = {
 
 export type PatientCreateInput = {
   cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds?: InputMaybe<Scalars["String"]>;
   consentPartA?: InputMaybe<Scalars["String"]>;
   consentPartC?: InputMaybe<Scalars["String"]>;
   dmpPatientId?: InputMaybe<Scalars["String"]>;
@@ -3226,6 +3248,7 @@ export type PatientSampleHasSampleSamplesNodeAggregateSelection = {
 /** Fields to sort Patients by. The order in which sorts are applied is not guaranteed when specifying many fields in one PatientSort object. */
 export type PatientSort = {
   cmoPatientId?: InputMaybe<SortDirection>;
+  cmoSampleIds?: InputMaybe<SortDirection>;
   consentPartA?: InputMaybe<SortDirection>;
   consentPartC?: InputMaybe<SortDirection>;
   dmpPatientId?: InputMaybe<SortDirection>;
@@ -3235,9 +3258,7 @@ export type PatientSort = {
 
 export type PatientUpdateInput = {
   cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoSampleIds_POP?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIds_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds?: InputMaybe<Scalars["String"]>;
   consentPartA?: InputMaybe<Scalars["String"]>;
   consentPartC?: InputMaybe<Scalars["String"]>;
   dmpPatientId?: InputMaybe<Scalars["String"]>;
@@ -3264,10 +3285,16 @@ export type PatientWhere = {
   cmoPatientId_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   cmoPatientId_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   cmoPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleIds?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoSampleIds_INCLUDES?: InputMaybe<Scalars["String"]>;
-  cmoSampleIds_NOT?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoSampleIds_NOT_INCLUDES?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds_NOT?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cmoSampleIds_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   consentPartA?: InputMaybe<Scalars["String"]>;
   consentPartA_CONTAINS?: InputMaybe<Scalars["String"]>;
   consentPartA_ENDS_WITH?: InputMaybe<Scalars["String"]>;
@@ -9047,6 +9074,7 @@ export type SamplePatientPatientsHasSampleAggregationSelection = {
 export type SamplePatientPatientsHasSampleNodeAggregateSelection = {
   __typename?: "SamplePatientPatientsHasSampleNodeAggregateSelection";
   cmoPatientId: StringAggregateSelectionNullable;
+  cmoSampleIds: StringAggregateSelectionNullable;
   consentPartA: StringAggregateSelectionNullable;
   consentPartC: StringAggregateSelectionNullable;
   dmpPatientId: StringAggregateSelectionNullable;
@@ -9130,6 +9158,26 @@ export type SamplePatientsHasSampleNodeAggregationWhereInput = {
   cmoPatientId_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   cmoPatientId_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   cmoPatientId_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cmoSampleIds_EQUAL?: InputMaybe<Scalars["String"]>;
+  cmoSampleIds_GT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_LTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cmoSampleIds_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   consentPartA_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   consentPartA_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   consentPartA_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -12269,7 +12317,7 @@ export type PatientsListQuery = {
     cmoPatientId?: string | null;
     dmpPatientId?: string | null;
     totalSampleCount?: number | null;
-    cmoSampleIds?: Array<string | null> | null;
+    cmoSampleIds?: string | null;
     consentPartA?: string | null;
     consentPartC?: string | null;
     hasSampleSamples: Array<{

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -187,7 +187,7 @@ function buildResolvers(
         const requests = await ogm.model("Request").find({
           where: args.where,
           options: {
-            sort: args.options.sort,
+            sort: args.options?.sort,
           },
           selectionSet: `{
             igoRequestId
@@ -227,13 +227,16 @@ function buildResolvers(
           }
         }
 
-        return requests.slice(args.options.offset, args.options.limit + 1);
+        if (args.options?.limit == null) {
+          return requests;
+        }
+        return requests.slice(args.options.offset, args.options.limit);
       },
       async patients(_source: undefined, args: any) {
         const patients = await ogm.model("Patient").find({
           where: args.where,
           options: {
-            sort: args.options.sort,
+            sort: args.options?.sort,
           },
           selectionSet: `{
             smilePatientId
@@ -274,6 +277,9 @@ function buildResolvers(
           }
         }
 
+        if (args.options?.limit == null) {
+          return patients;
+        }
         return patients.slice(args.options.offset, args.options.limit + 1);
       },
       async cohorts(_source: undefined, args: any) {
@@ -404,9 +410,9 @@ function sortArrayByNestedField(
     if (Array.isArray(a)) a = a.join(", ");
     if (Array.isArray(b)) b = b.join(", ");
 
-    if (typeof a === "number") {
+    if (typeof a === "number" && typeof b === "number") {
       return sortOrder === "ASC" ? a - b : b - a;
-    } else if (typeof a === "string") {
+    } else if (typeof a === "string" && typeof b === "string") {
       return sortOrder === "ASC"
         ? a.localeCompare(b, "en", { sensitivity: "base" })
         : b.localeCompare(a, "en", { sensitivity: "base" });

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -182,7 +182,9 @@ function buildResolvers(
       async requests(_source: undefined, args: any) {
         const requests = await ogm.model("Request").find({
           where: args.where,
-          options: args.options,
+          options: {
+            sort: args.options.sort,
+          },
           selectionSet: `{
             igoRequestId
             igoProjectId
@@ -240,7 +242,7 @@ function buildResolvers(
           }
         }
 
-        return requests;
+        return requests.slice(args.options.offset, args.options.limit + 1);
       },
       async cohorts(_source: undefined, args: any) {
         const cohorts = await ogm.model("Cohort").find({

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -226,6 +226,18 @@ function buildResolvers(
               }
             });
           }
+
+          if (sortField === "totalSampleCount") {
+            requests.sort((a, b) => {
+              const countA = a.hasSampleSamplesConnection?.totalCount;
+              const countB = b.hasSampleSamplesConnection?.totalCount;
+              if (sortOrder === "ASC") {
+                return countA > countB ? 1 : -1;
+              } else {
+                return countA < countB ? 1 : -1;
+              }
+            });
+          }
         }
 
         return requests;

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -23449,13 +23449,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -23903,6 +23899,22 @@
         "fields": [
           {
             "name": "cmoPatientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds",
             "description": null,
             "args": [],
             "type": {
@@ -25277,6 +25289,246 @@
           },
           {
             "name": "cmoPatientId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_SHORTEST_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -26849,6 +27101,22 @@
             "deprecationReason": null
           },
           {
+            "name": "cmoSampleIds",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "consentPartA",
             "description": null,
             "args": [],
@@ -27653,13 +27921,9 @@
             "name": "cmoSampleIds",
             "description": null,
             "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -31133,6 +31397,18 @@
             "deprecationReason": null
           },
           {
+            "name": "cmoSampleIds",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "consentPartA",
             "description": null,
             "type": {
@@ -31219,41 +31495,9 @@
             "name": "cmoSampleIds",
             "description": null,
             "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cmoSampleIds_POP",
-            "description": null,
-            "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "String",
               "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cmoSampleIds_PUSH",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -31566,20 +31810,16 @@
             "name": "cmoSampleIds",
             "description": null,
             "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "cmoSampleIds_INCLUDES",
+            "name": "cmoSampleIds_CONTAINS",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -31591,7 +31831,19 @@
             "deprecationReason": null
           },
           {
-            "name": "cmoSampleIds_NOT",
+            "name": "cmoSampleIds_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_IN",
             "description": null,
             "type": {
               "kind": "LIST",
@@ -31607,7 +31859,71 @@
             "deprecationReason": null
           },
           {
-            "name": "cmoSampleIds_NOT_INCLUDES",
+            "name": "cmoSampleIds_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_STARTS_WITH",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -92012,6 +92328,22 @@
             "deprecationReason": null
           },
           {
+            "name": "cmoSampleIds",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "consentPartA",
             "description": null,
             "args": [],
@@ -92852,6 +93184,246 @@
           },
           {
             "name": "cmoPatientId_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleIds_SHORTEST_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",


### PR DESCRIPTION
For card [#1152](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1152).

This PR enables users to sort any of the fields in Requests, Patients, and Cohorts views, including nested fields.

Demo on sorting Request columns:

https://github.com/user-attachments/assets/c0986e09-0c08-47df-8329-d42f88c4f4b6

