### PR TITLE
Add cached Oncotree data to Samples views

### DIFF
--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -7524,6 +7524,46 @@ export type SampleHasMetadataSampleMetadataNodeAggregationWhereInput = {
   baitSet_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   baitSet_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   baitSet_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_EQUAL?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_GT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cancerType_EQUAL?: InputMaybe<Scalars["String"]>;
+  cancerType_GT?: InputMaybe<Scalars["Int"]>;
+  cancerType_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_LT?: InputMaybe<Scalars["Int"]>;
+  cancerType_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   cfDNA2dBarcode_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   cfDNA2dBarcode_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   cfDNA2dBarcode_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -8208,6 +8248,8 @@ export type SampleMetadata = {
   __typename?: "SampleMetadata";
   additionalProperties: Scalars["String"];
   baitSet?: Maybe<Scalars["String"]>;
+  cancerType?: Maybe<Scalars["String"]>;
+  cancerTypeDetailed?: Maybe<Scalars["String"]>;
   cfDNA2dBarcode?: Maybe<Scalars["String"]>;
   cmoInfoIgoId?: Maybe<Scalars["String"]>;
   cmoPatientId?: Maybe<Scalars["String"]>;
@@ -8283,6 +8325,8 @@ export type SampleMetadataAggregateSelection = {
   __typename?: "SampleMetadataAggregateSelection";
   additionalProperties: StringAggregateSelectionNonNullable;
   baitSet: StringAggregateSelectionNullable;
+  cancerType: StringAggregateSelectionNullable;
+  cancerTypeDetailed: StringAggregateSelectionNullable;
   cfDNA2dBarcode: StringAggregateSelectionNullable;
   cmoInfoIgoId: StringAggregateSelectionNullable;
   cmoPatientId: StringAggregateSelectionNullable;
@@ -8333,6 +8377,8 @@ export type SampleMetadataConnection = {
 export type SampleMetadataCreateInput = {
   additionalProperties: Scalars["String"];
   baitSet?: InputMaybe<Scalars["String"]>;
+  cancerType?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
   cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
   cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
   cmoPatientId?: InputMaybe<Scalars["String"]>;
@@ -8690,6 +8736,8 @@ export type SampleMetadataSamplesHasMetadataUpdateFieldInput = {
 export type SampleMetadataSort = {
   additionalProperties?: InputMaybe<SortDirection>;
   baitSet?: InputMaybe<SortDirection>;
+  cancerType?: InputMaybe<SortDirection>;
+  cancerTypeDetailed?: InputMaybe<SortDirection>;
   cfDNA2dBarcode?: InputMaybe<SortDirection>;
   cmoInfoIgoId?: InputMaybe<SortDirection>;
   cmoPatientId?: InputMaybe<SortDirection>;
@@ -8731,6 +8779,8 @@ export type SampleMetadataStatusHasStatusStatusesNodeAggregateSelection = {
 export type SampleMetadataUpdateInput = {
   additionalProperties?: InputMaybe<Scalars["String"]>;
   baitSet?: InputMaybe<Scalars["String"]>;
+  cancerType?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
   cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
   cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
   cmoPatientId?: InputMaybe<Scalars["String"]>;
@@ -8787,6 +8837,26 @@ export type SampleMetadataWhere = {
   baitSet_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   baitSet_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   baitSet_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerType?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cancerTypeDetailed_NOT?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cancerTypeDetailed_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerType_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cancerType_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cancerType_NOT?: InputMaybe<Scalars["String"]>;
+  cancerType_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cancerType_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerType_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cancerType_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerType_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
   cfDNA2dBarcode_CONTAINS?: InputMaybe<Scalars["String"]>;
   cfDNA2dBarcode_ENDS_WITH?: InputMaybe<Scalars["String"]>;
@@ -10000,6 +10070,8 @@ export type SampleSampleMetadataHasMetadataSampleMetadataNodeAggregateSelection 
     __typename?: "SampleSampleMetadataHasMetadataSampleMetadataNodeAggregateSelection";
     additionalProperties: StringAggregateSelectionNonNullable;
     baitSet: StringAggregateSelectionNullable;
+    cancerType: StringAggregateSelectionNullable;
+    cancerTypeDetailed: StringAggregateSelectionNullable;
     cfDNA2dBarcode: StringAggregateSelectionNullable;
     cmoInfoIgoId: StringAggregateSelectionNullable;
     cmoPatientId: StringAggregateSelectionNullable;
@@ -10587,6 +10659,46 @@ export type StatusSampleMetadataHasStatusNodeAggregationWhereInput = {
   baitSet_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   baitSet_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   baitSet_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_EQUAL?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_GT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cancerType_EQUAL?: InputMaybe<Scalars["String"]>;
+  cancerType_GT?: InputMaybe<Scalars["Int"]>;
+  cancerType_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_LT?: InputMaybe<Scalars["Int"]>;
+  cancerType_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   cfDNA2dBarcode_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   cfDNA2dBarcode_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   cfDNA2dBarcode_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -11101,6 +11213,8 @@ export type StatusSampleMetadataSampleMetadataHasStatusNodeAggregateSelection =
     __typename?: "StatusSampleMetadataSampleMetadataHasStatusNodeAggregateSelection";
     additionalProperties: StringAggregateSelectionNonNullable;
     baitSet: StringAggregateSelectionNullable;
+    cancerType: StringAggregateSelectionNullable;
+    cancerTypeDetailed: StringAggregateSelectionNullable;
     cfDNA2dBarcode: StringAggregateSelectionNullable;
     cmoInfoIgoId: StringAggregateSelectionNullable;
     cmoPatientId: StringAggregateSelectionNullable;
@@ -12382,6 +12496,8 @@ export type FindSamplesByInputValueQuery = {
           investigatorSampleId?: string | null;
           libraries: string;
           oncotreeCode?: string | null;
+          cancerType?: string | null;
+          cancerTypeDetailed?: string | null;
           preservation?: string | null;
           primaryId: string;
           qcReports: string;
@@ -12538,6 +12654,8 @@ export type SampleMetadataPartsFragment = {
   investigatorSampleId?: string | null;
   libraries: string;
   oncotreeCode?: string | null;
+  cancerType?: string | null;
+  cancerTypeDetailed?: string | null;
   preservation?: string | null;
   primaryId: string;
   qcReports: string;
@@ -12594,6 +12712,8 @@ export type SamplesQuery = {
       investigatorSampleId?: string | null;
       libraries: string;
       oncotreeCode?: string | null;
+      cancerType?: string | null;
+      cancerTypeDetailed?: string | null;
       preservation?: string | null;
       primaryId: string;
       qcReports: string;
@@ -12653,6 +12773,8 @@ export type UpdateSamplesMutation = {
         investigatorSampleId?: string | null;
         libraries: string;
         oncotreeCode?: string | null;
+        cancerType?: string | null;
+        cancerTypeDetailed?: string | null;
         preservation?: string | null;
         primaryId: string;
         qcReports: string;
@@ -12789,6 +12911,8 @@ export const SampleMetadataPartsFragmentDoc = gql`
     investigatorSampleId
     libraries
     oncotreeCode
+    cancerType
+    cancerTypeDetailed
     preservation
     primaryId
     qcReports

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -335,6 +335,14 @@ export const SampleMetadataDetailsColumns: ColDef<SampleMetadataExtended>[] = [
     headerName: "Oncotree Code",
   },
   {
+    field: "cancerType",
+    headerName: "Cancer Type",
+  },
+  {
+    field: "cancerTypeDetailed",
+    headerName: "Cancer Type Detailed",
+  },
+  {
     field: "collectionYear",
     headerName: "Collection Year",
   },

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -216,6 +216,9 @@ function LoadingIcon() {
   );
 }
 
+const ONCOTREE_CODE_NA_TOOLTIP =
+  "This code might have been remapped (renamed) between different versions of the Oncotree API. For remapping details, visit the docs at https://oncotree.mskcc.org/";
+
 export const SampleMetadataDetailsColumns: ColDef<SampleMetadataExtended>[] = [
   {
     field: "primaryId",
@@ -337,10 +340,36 @@ export const SampleMetadataDetailsColumns: ColDef<SampleMetadataExtended>[] = [
   {
     field: "cancerType",
     headerName: "Cancer Type",
+    cellRenderer: (params: ICellRendererParams) => (
+      <>
+        {params.value}{" "}
+        {params.value === "N/A" && (
+          <span dangerouslySetInnerHTML={{ __html: toolTipIcon }} />
+        )}
+      </>
+    ),
+    tooltipValueGetter: (params: ITooltipParams) => {
+      if (params.value === "N/A") {
+        return ONCOTREE_CODE_NA_TOOLTIP;
+      }
+    },
   },
   {
     field: "cancerTypeDetailed",
     headerName: "Cancer Type Detailed",
+    cellRenderer: (params: ICellRendererParams) => (
+      <>
+        {params.value}{" "}
+        {params.value === "N/A" && (
+          <span dangerouslySetInnerHTML={{ __html: toolTipIcon }} />
+        )}
+      </>
+    ),
+    tooltipValueGetter: (params: ITooltipParams) => {
+      if (params.value === "N/A") {
+        return ONCOTREE_CODE_NA_TOOLTIP;
+      }
+    },
   },
   {
     field: "collectionYear",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -217,7 +217,7 @@ function LoadingIcon() {
 }
 
 const ONCOTREE_CODE_NA_TOOLTIP =
-  "This code might have been remapped (renamed) between different versions of the Oncotree API. For remapping details, visit the docs at https://oncotree.mskcc.org/";
+  "This code might have been remapped (renamed) between different versions of the Oncotree API. For remapping details, visit the docs at https://oncotree.mskcc.org/#/home?tab=mapping";
 
 export const SampleMetadataDetailsColumns: ColDef<SampleMetadataExtended>[] = [
   {

--- a/graphql-server/package.json
+++ b/graphql-server/package.json
@@ -33,6 +33,7 @@
     "morgan": "^1.10.0",
     "nats": "^2.7.1",
     "neo4j-driver": "^4.4.6",
+    "node-cache": "^5.1.2",
     "openid-client": "^5.6.1",
     "oracledb": "^6.1.0",
     "passport": "^0.6.0",

--- a/graphql-server/src/env/application.properties.EXAMPLE
+++ b/graphql-server/src/env/application.properties.EXAMPLE
@@ -39,3 +39,6 @@ log_dir=
 [web]
 web_key_pem=
 web_cert_pem=
+
+[oncotree]
+oncotree_api=

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -7523,6 +7523,46 @@ export type SampleHasMetadataSampleMetadataNodeAggregationWhereInput = {
   baitSet_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   baitSet_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   baitSet_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_EQUAL?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_GT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cancerType_EQUAL?: InputMaybe<Scalars["String"]>;
+  cancerType_GT?: InputMaybe<Scalars["Int"]>;
+  cancerType_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_LT?: InputMaybe<Scalars["Int"]>;
+  cancerType_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   cfDNA2dBarcode_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   cfDNA2dBarcode_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   cfDNA2dBarcode_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -8207,6 +8247,8 @@ export type SampleMetadata = {
   __typename?: "SampleMetadata";
   additionalProperties: Scalars["String"];
   baitSet?: Maybe<Scalars["String"]>;
+  cancerType?: Maybe<Scalars["String"]>;
+  cancerTypeDetailed?: Maybe<Scalars["String"]>;
   cfDNA2dBarcode?: Maybe<Scalars["String"]>;
   cmoInfoIgoId?: Maybe<Scalars["String"]>;
   cmoPatientId?: Maybe<Scalars["String"]>;
@@ -8282,6 +8324,8 @@ export type SampleMetadataAggregateSelection = {
   __typename?: "SampleMetadataAggregateSelection";
   additionalProperties: StringAggregateSelectionNonNullable;
   baitSet: StringAggregateSelectionNullable;
+  cancerType: StringAggregateSelectionNullable;
+  cancerTypeDetailed: StringAggregateSelectionNullable;
   cfDNA2dBarcode: StringAggregateSelectionNullable;
   cmoInfoIgoId: StringAggregateSelectionNullable;
   cmoPatientId: StringAggregateSelectionNullable;
@@ -8332,6 +8376,8 @@ export type SampleMetadataConnection = {
 export type SampleMetadataCreateInput = {
   additionalProperties: Scalars["String"];
   baitSet?: InputMaybe<Scalars["String"]>;
+  cancerType?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
   cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
   cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
   cmoPatientId?: InputMaybe<Scalars["String"]>;
@@ -8689,6 +8735,8 @@ export type SampleMetadataSamplesHasMetadataUpdateFieldInput = {
 export type SampleMetadataSort = {
   additionalProperties?: InputMaybe<SortDirection>;
   baitSet?: InputMaybe<SortDirection>;
+  cancerType?: InputMaybe<SortDirection>;
+  cancerTypeDetailed?: InputMaybe<SortDirection>;
   cfDNA2dBarcode?: InputMaybe<SortDirection>;
   cmoInfoIgoId?: InputMaybe<SortDirection>;
   cmoPatientId?: InputMaybe<SortDirection>;
@@ -8730,6 +8778,8 @@ export type SampleMetadataStatusHasStatusStatusesNodeAggregateSelection = {
 export type SampleMetadataUpdateInput = {
   additionalProperties?: InputMaybe<Scalars["String"]>;
   baitSet?: InputMaybe<Scalars["String"]>;
+  cancerType?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
   cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
   cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
   cmoPatientId?: InputMaybe<Scalars["String"]>;
@@ -8786,6 +8836,26 @@ export type SampleMetadataWhere = {
   baitSet_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   baitSet_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   baitSet_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerType?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cancerTypeDetailed_NOT?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cancerTypeDetailed_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerType_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cancerType_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cancerType_NOT?: InputMaybe<Scalars["String"]>;
+  cancerType_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  cancerType_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerType_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  cancerType_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cancerType_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
   cfDNA2dBarcode_CONTAINS?: InputMaybe<Scalars["String"]>;
   cfDNA2dBarcode_ENDS_WITH?: InputMaybe<Scalars["String"]>;
@@ -9999,6 +10069,8 @@ export type SampleSampleMetadataHasMetadataSampleMetadataNodeAggregateSelection 
     __typename?: "SampleSampleMetadataHasMetadataSampleMetadataNodeAggregateSelection";
     additionalProperties: StringAggregateSelectionNonNullable;
     baitSet: StringAggregateSelectionNullable;
+    cancerType: StringAggregateSelectionNullable;
+    cancerTypeDetailed: StringAggregateSelectionNullable;
     cfDNA2dBarcode: StringAggregateSelectionNullable;
     cmoInfoIgoId: StringAggregateSelectionNullable;
     cmoPatientId: StringAggregateSelectionNullable;
@@ -10586,6 +10658,46 @@ export type StatusSampleMetadataHasStatusNodeAggregationWhereInput = {
   baitSet_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
   baitSet_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
   baitSet_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cancerTypeDetailed_EQUAL?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed_GT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerTypeDetailed_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_LT?: InputMaybe<Scalars["Float"]>;
+  cancerType_AVERAGE_LTE?: InputMaybe<Scalars["Float"]>;
+  cancerType_EQUAL?: InputMaybe<Scalars["String"]>;
+  cancerType_GT?: InputMaybe<Scalars["Int"]>;
+  cancerType_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerType_LONGEST_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_LT?: InputMaybe<Scalars["Int"]>;
+  cancerType_LTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_EQUAL?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_GT?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_GTE?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_LT?: InputMaybe<Scalars["Int"]>;
+  cancerType_SHORTEST_LTE?: InputMaybe<Scalars["Int"]>;
   cfDNA2dBarcode_AVERAGE_EQUAL?: InputMaybe<Scalars["Float"]>;
   cfDNA2dBarcode_AVERAGE_GT?: InputMaybe<Scalars["Float"]>;
   cfDNA2dBarcode_AVERAGE_GTE?: InputMaybe<Scalars["Float"]>;
@@ -11100,6 +11212,8 @@ export type StatusSampleMetadataSampleMetadataHasStatusNodeAggregateSelection =
     __typename?: "StatusSampleMetadataSampleMetadataHasStatusNodeAggregateSelection";
     additionalProperties: StringAggregateSelectionNonNullable;
     baitSet: StringAggregateSelectionNullable;
+    cancerType: StringAggregateSelectionNullable;
+    cancerTypeDetailed: StringAggregateSelectionNullable;
     cfDNA2dBarcode: StringAggregateSelectionNullable;
     cmoInfoIgoId: StringAggregateSelectionNullable;
     cmoPatientId: StringAggregateSelectionNullable;
@@ -12381,6 +12495,8 @@ export type FindSamplesByInputValueQuery = {
           investigatorSampleId?: string | null;
           libraries: string;
           oncotreeCode?: string | null;
+          cancerType?: string | null;
+          cancerTypeDetailed?: string | null;
           preservation?: string | null;
           primaryId: string;
           qcReports: string;
@@ -12537,6 +12653,8 @@ export type SampleMetadataPartsFragment = {
   investigatorSampleId?: string | null;
   libraries: string;
   oncotreeCode?: string | null;
+  cancerType?: string | null;
+  cancerTypeDetailed?: string | null;
   preservation?: string | null;
   primaryId: string;
   qcReports: string;
@@ -12593,6 +12711,8 @@ export type SamplesQuery = {
       investigatorSampleId?: string | null;
       libraries: string;
       oncotreeCode?: string | null;
+      cancerType?: string | null;
+      cancerTypeDetailed?: string | null;
       preservation?: string | null;
       primaryId: string;
       qcReports: string;
@@ -12652,6 +12772,8 @@ export type UpdateSamplesMutation = {
         investigatorSampleId?: string | null;
         libraries: string;
         oncotreeCode?: string | null;
+        cancerType?: string | null;
+        cancerTypeDetailed?: string | null;
         preservation?: string | null;
         primaryId: string;
         qcReports: string;
@@ -12788,6 +12910,8 @@ export const SampleMetadataPartsFragmentDoc = gql`
     investigatorSampleId
     libraries
     oncotreeCode
+    cancerType
+    cancerTypeDetailed
     preservation
     primaryId
     qcReports

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -30,19 +30,19 @@ import { gql } from "apollo-server";
 import {
   CachedOncotreeData,
   fetchOncotreeData,
-  setOncotreeCache,
+  updateOncotreeCache,
 } from "../utils/oncotree";
 import { ApolloServerContext } from "../utils/servers";
 
 type SortOptions = { [key: string]: SortDirection }[];
 
-export async function buildNeo4jDbSchema() {
-  const driver = neo4j.driver(
-    props.neo4j_graphql_uri,
-    neo4j.auth.basic(props.neo4j_username, props.neo4j_password),
-    { disableLosslessIntegers: true } // maps Cypher Integer to JavaScript Number
-  );
+export const driver = neo4j.driver(
+  props.neo4j_graphql_uri,
+  neo4j.auth.basic(props.neo4j_username, props.neo4j_password),
+  { disableLosslessIntegers: true } // maps Cypher Integer to JavaScript Number
+);
 
+export async function buildNeo4jDbSchema() {
   const sessionFactory = () =>
     driver.session({ defaultAccessMode: neo4j.session.WRITE });
 
@@ -423,10 +423,10 @@ function buildResolvers(
           let cachedData: CachedOncotreeData = oncotreeCache.get(oncotreeCode);
           if (!cachedData) {
             const data = await fetchOncotreeData();
-            setOncotreeCache(data, oncotreeCache);
+            updateOncotreeCache(data, oncotreeCache);
             cachedData = oncotreeCache.get(oncotreeCode);
           }
-          return cachedData ? cachedData.mainType : "N/A";
+          return cachedData?.mainType;
         }
         return null;
       },
@@ -439,10 +439,10 @@ function buildResolvers(
           let cachedData: CachedOncotreeData = oncotreeCache.get(oncotreeCode);
           if (!cachedData) {
             const data = await fetchOncotreeData();
-            setOncotreeCache(data, oncotreeCache);
+            updateOncotreeCache(data, oncotreeCache);
             cachedData = oncotreeCache.get(oncotreeCode);
           }
-          return cachedData ? cachedData.name : "N/A";
+          return cachedData?.name;
         }
         return null;
       },

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -80,6 +80,11 @@ export async function buildNeo4jDbSchema() {
       status: String
       type: String
     }
+
+    extend type SampleMetadata {
+      cancerType: String
+      cancerTypeDetailed: String
+    }
   `;
 
   const ogm = new OGM({ typeDefs: extendedTypeDefs, driver });
@@ -389,6 +394,14 @@ function buildResolvers(
       },
       type: (parent: CohortsListQuery["cohorts"][number]) => {
         return getNestedValue(parent, "Cohort", "type");
+      },
+    },
+    SampleMetadata: {
+      cancerType: async (parent: SampleMetadata) => {
+        return null;
+      },
+      cancerTypeDetailed: async (parent: SampleMetadata) => {
+        return null;
       },
     },
   };

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -398,10 +398,41 @@ function buildResolvers(
     },
     SampleMetadata: {
       cancerType: async (parent: SampleMetadata) => {
-        return null;
+        // TODO: incorporate error handling
+        // https://www.apollographql.com/docs/apollo-server/v3/data/errors
+        // TODO: add caching
+        if (parent.oncotreeCode) {
+          const response = await fetch(
+            `https://oncotree.mskcc.org/api/tumorTypes/search/code/${parent.oncotreeCode}?exactMatch=true`,
+            {
+              headers: {
+                Accept: "application/json",
+              },
+            }
+          );
+          if (response.ok) {
+            const data = await response.json();
+            return data[0]?.mainType;
+          }
+        }
+        return undefined;
       },
       cancerTypeDetailed: async (parent: SampleMetadata) => {
-        return null;
+        if (parent.oncotreeCode) {
+          const response = await fetch(
+            `https://oncotree.mskcc.org/api/tumorTypes/search/code/${parent.oncotreeCode}?exactMatch=true`,
+            {
+              headers: {
+                Accept: "application/json",
+              },
+            }
+          );
+          if (response.ok) {
+            const data = await response.json();
+            return data[0]?.name;
+          }
+        }
+        return undefined;
       },
     },
   };

--- a/graphql-server/src/utils/constants.ts
+++ b/graphql-server/src/utils/constants.ts
@@ -36,6 +36,8 @@ export const props = {
 
   web_key_pem: properties.get("web.web_key_pem"),
   web_cert_pem: properties.get("web.web_cert_pem"),
+
+  oncotree_api: properties.get("oncotree.oncotree_api"),
 };
 
 export const EXPRESS_SERVER_ORIGIN =

--- a/graphql-server/src/utils/oncotree.ts
+++ b/graphql-server/src/utils/oncotree.ts
@@ -3,6 +3,9 @@ import NodeCache from "node-cache";
 import { driver } from "../schemas/neo4j";
 import { props } from "./constants";
 
+/**
+ * Source: https://oncotree.mskcc.org/#/home?tab=api
+ */
 export type OncotreeTumorType = {
   children: Record<string, unknown>;
   code: string;

--- a/graphql-server/src/utils/oncotree.ts
+++ b/graphql-server/src/utils/oncotree.ts
@@ -1,0 +1,56 @@
+import NodeCache from "node-cache";
+
+export type OncotreeTumorType = {
+  children: Record<string, unknown>;
+  code: string;
+  color: string;
+  externalReferences: Record<string, unknown>;
+  history: string[];
+  level: number;
+  mainType: string;
+  name: string;
+  parent: string;
+  precursors: string[];
+  revocations: string[];
+  tissue: string;
+};
+
+export type CachedOncotreeData =
+  | Pick<OncotreeTumorType, "name" | "mainType">
+  | undefined;
+
+export async function fetchOncotreeData() {
+  try {
+    const response = await fetch(`https://oncotree.mskcc.org/api/tumorTypes`, {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+    if (!response.ok) {
+      throw new Error("Failed to fetch the Oncotree API");
+    }
+    return await response.json();
+  } catch (error) {
+    if (error instanceof Error) {
+      console.log(error.message);
+    }
+    return null;
+  }
+}
+
+export function setOncotreeCache(
+  data: OncotreeTumorType[],
+  oncotreeCache: NodeCache
+) {
+  // Restructure data for node-cache to store multiple k-v pairs in one go
+  const parsedData = data.map((obj) => {
+    return {
+      key: obj.code,
+      val: {
+        name: obj.name,
+        mainType: obj.mainType,
+      } as CachedOncotreeData,
+    };
+  });
+  oncotreeCache.mset(parsedData);
+}

--- a/graphql-server/src/utils/oncotree.ts
+++ b/graphql-server/src/utils/oncotree.ts
@@ -22,7 +22,14 @@ export type CachedOncotreeData =
   | Pick<OncotreeTumorType, "name" | "mainType">
   | undefined;
 
-export async function fetchOncotreeData() {
+export async function fetchAndCacheOncotreeData(oncotreeCache: NodeCache) {
+  const data = await fetchOncotreeData();
+  if (data) {
+    await updateOncotreeCache(data, oncotreeCache);
+  }
+}
+
+async function fetchOncotreeData() {
   try {
     const response = await fetch(props.oncotree_api, {
       headers: {
@@ -45,7 +52,7 @@ export async function fetchOncotreeData() {
   }
 }
 
-export async function updateOncotreeCache(
+async function updateOncotreeCache(
   oncotreeData: OncotreeTumorType[],
   oncotreeCache: NodeCache
 ) {

--- a/graphql-server/src/utils/servers.ts
+++ b/graphql-server/src/utils/servers.ts
@@ -13,7 +13,7 @@ import {
 import { updateActiveUserSessions } from "./session";
 import { corsOptions } from "./constants";
 import NodeCache from "node-cache";
-import { fetchOncotreeData, updateOncotreeCache } from "./oncotree";
+import { fetchAndCacheOncotreeData } from "./oncotree";
 
 export function initializeHttpsServer(app: Express) {
   const httpsServer = https.createServer(
@@ -45,8 +45,7 @@ export async function initializeApolloServer(
   });
 
   const oncotreeCache = new NodeCache({ stdTTL: 86400 }); // 1 day
-  const data = await fetchOncotreeData();
-  await updateOncotreeCache(data, oncotreeCache);
+  await fetchAndCacheOncotreeData(oncotreeCache);
 
   const apolloServer = new ApolloServer<ApolloServerContext>({
     schema: mergedSchema,

--- a/graphql-server/src/utils/servers.ts
+++ b/graphql-server/src/utils/servers.ts
@@ -46,7 +46,7 @@ export async function initializeApolloServer(
 
   const oncotreeCache = new NodeCache({ stdTTL: 86400 }); // 1 day
   const data = await fetchOncotreeData();
-  updateOncotreeCache(data, oncotreeCache);
+  await updateOncotreeCache(data, oncotreeCache);
 
   const apolloServer = new ApolloServer<ApolloServerContext>({
     schema: mergedSchema,

--- a/graphql-server/src/utils/servers.ts
+++ b/graphql-server/src/utils/servers.ts
@@ -2,7 +2,7 @@ import { Express } from "express";
 import fs from "fs";
 import https from "https";
 import { props } from "./constants";
-import { buildNeo4jDbSchema } from "../schemas/neo4j";
+import { buildNeo4jDbSchema, driver } from "../schemas/neo4j";
 import { mergeSchemas } from "@graphql-tools/schema";
 import { oracleDbSchema } from "../schemas/oracle";
 import { ApolloServer } from "apollo-server-express";
@@ -13,7 +13,7 @@ import {
 import { updateActiveUserSessions } from "./session";
 import { corsOptions } from "./constants";
 import NodeCache from "node-cache";
-import { fetchOncotreeData, setOncotreeCache } from "./oncotree";
+import { fetchOncotreeData, updateOncotreeCache } from "./oncotree";
 
 export function initializeHttpsServer(app: Express) {
   const httpsServer = https.createServer(
@@ -46,9 +46,7 @@ export async function initializeApolloServer(
 
   const oncotreeCache = new NodeCache({ stdTTL: 86400 }); // 1 day
   const data = await fetchOncotreeData();
-  if (data) {
-    setOncotreeCache(data, oncotreeCache);
-  }
+  updateOncotreeCache(data, oncotreeCache);
 
   const apolloServer = new ApolloServer<ApolloServerContext>({
     schema: mergedSchema,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -75118,6 +75118,486 @@
             "deprecationReason": null
           },
           {
+            "name": "cancerTypeDetailed_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cfDNA2dBarcode_AVERAGE_EQUAL",
             "description": null,
             "type": {
@@ -83008,6 +83488,30 @@
             "deprecationReason": null
           },
           {
+            "name": "cancerType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cfDNA2dBarcode",
             "description": null,
             "args": [],
@@ -83765,6 +84269,38 @@
             "deprecationReason": null
           },
           {
+            "name": "cancerType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cfDNA2dBarcode",
             "description": null,
             "args": [],
@@ -84339,6 +84875,30 @@
           },
           {
             "name": "baitSet",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -87744,6 +88304,30 @@
             "deprecationReason": null
           },
           {
+            "name": "cancerType",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cfDNA2dBarcode",
             "description": null,
             "type": {
@@ -88134,6 +88718,30 @@
           },
           {
             "name": "baitSet",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -88789,6 +89397,262 @@
           },
           {
             "name": "baitSet_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_NOT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_NOT_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_NOT_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_NOT_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_NOT_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_STARTS_WITH",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -102558,6 +103422,38 @@
             "deprecationReason": null
           },
           {
+            "name": "cancerType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cfDNA2dBarcode",
             "description": null,
             "args": [],
@@ -108068,6 +108964,486 @@
           },
           {
             "name": "baitSet_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed_SHORTEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_AVERAGE_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_AVERAGE_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_AVERAGE_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_AVERAGE_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_AVERAGE_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LONGEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LONGEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LONGEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LONGEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LONGEST_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_SHORTEST_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_SHORTEST_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_SHORTEST_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_SHORTEST_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType_SHORTEST_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -114086,6 +115462,38 @@
           },
           {
             "name": "baitSet",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelectionNullable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed",
             "description": null,
             "args": [],
             "type": {

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -162,6 +162,8 @@ fragment SampleMetadataParts on SampleMetadata {
   investigatorSampleId
   libraries
   oncotreeCode
+  cancerType
+  cancerTypeDetailed
   preservation
   primaryId
   qcReports

--- a/yarn.lock
+++ b/yarn.lock
@@ -5544,6 +5544,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -10030,6 +10035,13 @@ node-abort-controller@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.0.1.tgz#f91fa50b1dee3f909afabb7e261b1e1d6b0cb74e"
   integrity sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==
+
+node-cache@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
+  dependencies:
+    clone "2.x"
 
 node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"


### PR DESCRIPTION
PR for card [#1232](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1232).

# Description
This PR adds `cancerType` and `cancerTypeDetailed` fields corresponding to `oncotreeCode` values to views with SampleMetadata data.

Data for these fields are initially fetched from the Oncotree API's candidate release upon the GraphQL server startup, and it's then cached with a duration of 1 day (matches cBioPortal's setting). When the GraphQL custom resolver encounters a new `oncotreeCode` that isn't in the cache, it will refetch from the Oncotree API and refresh the cache.

Old `oncotreeCode` values (like "HIST") with no matching data from the Oncotree API have `cancerType` and `cancerTypeDetailed` fields as "N/A", along with a tooltip describing the issue. These "N/A" values are added to cache to avoid SMILE continuously fetching the Oncotree API for non-existent codes.

![CleanShot 103738](https://github.com/user-attachments/assets/9ed3c686-2f08-41cb-8d24-be69edba6573)

# Notes
- PMs have the ability to update the `oncotreeCode` value to see `cancerType` and `cancerTypeDetailed` fields automatically updated
- Searching `cancerType` and `cancerTypeDetailed` fields would require additional engineering work as we'd have to write a GraphQL custom resolver for the samples query. This work is captured in card [#1244](https://app.zenhub.com/workspaces/metadb-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1244)
- We're using `node-cache` instead of the built-in [GraphQL server-side cache](https://www.apollographql.com/docs/apollo-server/performance/caching/#in-your-resolvers-dynamic) for more control and flexibility over the cache (e.g. when we need to refresh the cache on the fly). 