### PR TITLE
Automatically sort samples query results by importDate

### DIFF
--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -72,9 +72,6 @@ export default function SamplesList({
     useSamplesListQuery({
       variables: {
         where: parentWhereVariables || {},
-        options: {
-          limit: MAX_ROWS,
-        },
         sampleMetadataOptions: {
           sort: [{ importDate: SortDirection.Desc }],
           limit: 1,

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -24,27 +24,29 @@ const WES_SAMPLE_FILTERS = [
 export default function SamplesPage() {
   const [columnDefs, setColumnDefs] = useState(combinedSampleDetailsColumns);
 
+  const refetchWhereVariables = (parsedSearchVals: string[]) => {
+    const cohortSampleFilters = cohortSampleFilterWhereVariables(
+      parsedSearchVals
+    ).filter((filter) => filter.hasTempoTempos_SOME);
+    const sampleMetadataFilters = {
+      hasMetadataSampleMetadata_SOME: {
+        OR: sampleFilterWhereVariables(parsedSearchVals),
+      },
+    };
+    return {
+      OR: cohortSampleFilters.concat(sampleMetadataFilters),
+      ...(_.isEqual(columnDefs, ReadOnlyCohortSampleDetailsColumns) && {
+        hasMetadataSampleMetadata_SOME: {
+          OR: sampleFilterWhereVariables(WES_SAMPLE_FILTERS),
+        },
+      }),
+    };
+  };
+
   return (
     <SamplesList
       columnDefs={columnDefs}
-      refetchWhereVariables={(parsedSearchVals) => {
-        const cohortSampleFilters = cohortSampleFilterWhereVariables(
-          parsedSearchVals
-        ).filter((filter) => filter.hasTempoTempos_SOME);
-        const sampleMetadataFilters = {
-          hasMetadataSampleMetadata_SOME: {
-            OR: sampleFilterWhereVariables(parsedSearchVals),
-          },
-        };
-        return {
-          OR: cohortSampleFilters.concat(sampleMetadataFilters),
-          ...(_.isEqual(columnDefs, ReadOnlyCohortSampleDetailsColumns) && {
-            hasMetadataSampleMetadata_SOME: {
-              OR: sampleFilterWhereVariables(WES_SAMPLE_FILTERS),
-            },
-          }),
-        };
-      }}
+      refetchWhereVariables={refetchWhereVariables}
       customToolbarUI={
         <>
           <InfoToolTip>

--- a/graphql-server/package.json
+++ b/graphql-server/package.json
@@ -25,6 +25,7 @@
     "apollo-server": "^3.10.0",
     "apollo-server-core": "^3.10.2",
     "apollo-server-express": "^3.10.2",
+    "dataloader": "^2.2.2",
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "graphql": "^16.5.0",

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -160,7 +160,10 @@ export async function buildNeo4jDbSchema() {
   await ogm.init();
   const neo4jDbSchema = await neoSchema.getSchema();
 
-  return neo4jDbSchema;
+  return {
+    neo4jDbSchema,
+    ogm,
+  };
 }
 
 function buildResolvers(
@@ -351,19 +354,17 @@ function buildResolvers(
       async samples(
         _source: undefined,
         { where }: any,
-        { oncotreeCache }: ApolloServerContext
+        { samplesLoader }: ApolloServerContext
       ) {
-        let customWhere = includeCancerTypeFieldsInSearch(where, oncotreeCache);
-        const result = await querySamplesList(ogm, customWhere);
+        const result = await samplesLoader.load(where);
         return result.data;
       },
       async samplesConnection(
         _source: undefined,
         { where }: any,
-        { oncotreeCache }: ApolloServerContext
+        { samplesLoader }: ApolloServerContext
       ) {
-        let customWhere = includeCancerTypeFieldsInSearch(where, oncotreeCache);
-        const result = await querySamplesList(ogm, customWhere);
+        const result = await samplesLoader.load(where);
         return {
           totalCount: result.totalCount,
         };

--- a/graphql-server/src/utils/dataloader.ts
+++ b/graphql-server/src/utils/dataloader.ts
@@ -1,0 +1,28 @@
+import { OGM } from "@neo4j/graphql-ogm";
+import { includeCancerTypeFieldsInSearch } from "./oncotree";
+import { querySamplesList } from "./ogm";
+import DataLoader from "dataloader";
+import { SamplesListQuery, SampleWhere } from "../generated/graphql";
+import NodeCache from "node-cache";
+
+type SamplesQueryResult = {
+  totalCount: number;
+  data: SamplesListQuery["samples"];
+};
+
+/**
+ * Create a DataLoader instance that batches the child queries (e.g. `samples` and
+ * `samplesConnection` child queries of SamplesList query) and then caches the results
+ * of those child queries within the same frontend request.
+ *
+ * This enables the SamplesList query to make a single trip to the database.
+ * Without this, we would make two trips, one via the `samples` child query and one
+ * via the `samplesConnection` child query.
+ */
+export function createSamplesLoader(ogm: OGM, oncotreeCache: NodeCache) {
+  return new DataLoader<SampleWhere, SamplesQueryResult>(async (keys) => {
+    const customWhere = includeCancerTypeFieldsInSearch(keys[0], oncotreeCache);
+    const result = await querySamplesList(ogm, customWhere);
+    return keys.map(() => result);
+  });
+}

--- a/graphql-server/src/utils/flattening.ts
+++ b/graphql-server/src/utils/flattening.ts
@@ -307,16 +307,24 @@ const nestedValueGetters: NestedValueGetters = {
   },
 };
 
-export function sortArrayByNestedField(
+export async function sortArrayByNestedField(
   arr: any[],
   nodeLabel: keyof typeof nestedValueGetters,
   fieldName: string,
   sortOrder: SortDirection,
   context?: ApolloServerContext
 ) {
+  // Although the parts of nestedValueGetters that we use are all synchronous,
+  // it's still an async function and could return a promise
+  const resolvedValues = await Promise.all(
+    arr.map((obj) => nestedValueGetters[nodeLabel](obj, fieldName, context))
+  );
+
   arr.sort((objA, objB) => {
-    let a = nestedValueGetters[nodeLabel](objA, fieldName, context);
-    let b = nestedValueGetters[nodeLabel](objB, fieldName, context);
+    const indexA = arr.indexOf(objA);
+    const indexB = arr.indexOf(objB);
+    let a = resolvedValues[indexA];
+    let b = resolvedValues[indexB];
 
     if (a === null || a === undefined) return 1;
     if (b === null || b === undefined) return -1;


### PR DESCRIPTION
For card [#1225](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1225).

This PR implements the following changes:
- Automatically sort samples query results by importDate in descending order
- Improve performance of the React frontend by removing an unnecessary re-render on the Samples page
- Improve performance of the GraphQL server by batching child queries of the SamplesList query, removing an extra trip to the database

The performance improvements reduced the initial loading time by 2x, but it still takes a while; I'm seeing 1m30s - 2m.

In parallel, we'll add a new environment variable `NODE_OPTIONS="--max-old-space-size=16384"`. This increases the heap memory space available to the Node.js runtime from 4GB to 16GB. Fetching all samples and sorting them in each user request is expensive. This increase will also resolve the error we saw in card [#1264](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1264).

![CleanShot 061210](https://github.com/user-attachments/assets/5c8ac762-1a1e-4fa7-a769-ab9ddf0dee86)
