### PR TITLE
Increase the sample export limit

### DIFF
--- a/frontend/src/components/DownloadModal.tsx
+++ b/frontend/src/components/DownloadModal.tsx
@@ -1,26 +1,38 @@
-import { FunctionComponent } from "react";
+import { useEffect } from "react";
 import Modal from "react-bootstrap/Modal";
 import jsdownload from "js-file-download";
 import Spinner from "react-spinkit";
 
-export const DownloadModal: FunctionComponent<{
+interface DownloadModalProps {
   loader: () => Promise<string>;
   onComplete: () => void;
   exportFileName: string;
-}> = ({ loader, onComplete, exportFileName }) => {
-  loader().then((str) => {
-    jsdownload(str, exportFileName);
-    onComplete();
-  });
+}
+
+export function DownloadModal({
+  loader,
+  onComplete,
+  exportFileName,
+}: DownloadModalProps) {
+  // Wrapping the download call in a useEffect hook, set to run only on mount,
+  // to ensure it only runs once. Without this, the async loader function will
+  // trigger another unnecessary re-render when it resolves
+  useEffect(() => {
+    loader().then((str) => {
+      jsdownload(str, exportFileName);
+      onComplete();
+    });
+    // eslint-disable-next-line
+  }, []);
 
   return (
     <Modal show={true} size={"sm"}>
       <Modal.Body>
         <div className="d-flex flex-column align-items-center">
-          <p>Downloading data ...</p>
+          <p>Downloading data...</p>
           <Spinner fadeIn={"none"} color={"lightblue"} name="ball-grid-pulse" />
         </div>
       </Modal.Body>
     </Modal>
   );
-};
+}

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -40,7 +40,7 @@ const MAX_ROWS_EXPORT = 5000;
 const MAX_ROWS_SCROLLED_ALERT =
   "You've reached the maximum number of samples that can be displayed. Please refine your search to see more samples.";
 const MAX_ROWS_EXPORT_EXCEED_ALERT =
-  "You can only download up to 5,000 rows of data at a time. Please refine your search and try again. If you need the full dataset, contact the SMILE team.";
+  "You can only download up to 5,000 rows of data at a time. Please refine your search and try again. If you need the full dataset, contact the SMILE team at cmosmile@mskcc.org";
 const COST_CENTER_VALIDATION_ALERT =
   "Please update your Cost Center/Fund Number input as #####/##### (5 digits, a forward slash, then 5 digits). For example: 12345/12345.";
 const TEMPO_EVENT_OPTIONS = {

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -31,8 +31,6 @@ import {
   sortArrayByNestedField,
 } from "../utils/flattening";
 import { ApolloServerContext } from "../utils/servers";
-import { includeCancerTypeFieldsInSearch } from "../utils/oncotree";
-import { querySamplesList } from "../utils/ogm";
 
 type SortOptions = { [key: string]: SortDirection }[];
 
@@ -353,18 +351,18 @@ function buildResolvers(
       },
       async samples(
         _source: undefined,
-        { where }: any,
+        args: any,
         { samplesLoader }: ApolloServerContext
       ) {
-        const result = await samplesLoader.load(where);
+        const result = await samplesLoader.load(args);
         return result.data;
       },
       async samplesConnection(
         _source: undefined,
-        { where }: any,
+        args: any,
         { samplesLoader }: ApolloServerContext
       ) {
-        const result = await samplesLoader.load(where);
+        const result = await samplesLoader.load(args);
         return {
           totalCount: result.totalCount,
         };

--- a/graphql-server/src/utils/ogm.ts
+++ b/graphql-server/src/utils/ogm.ts
@@ -1,10 +1,14 @@
-import { GraphQLWhereArg, OGM } from "@neo4j/graphql-ogm";
+import { GraphQLOptionsArg, GraphQLWhereArg, OGM } from "@neo4j/graphql-ogm";
 import { sortArrayByNestedField } from "./flattening";
 import { SortDirection } from "../generated/graphql";
 
 const MAX_ROWS = 500;
 
-export async function querySamplesList(ogm: OGM, where: GraphQLWhereArg) {
+export async function querySamplesList(
+  ogm: OGM,
+  where: GraphQLWhereArg,
+  options: GraphQLOptionsArg
+) {
   const samples = await ogm.model("Sample").find({
     where: where,
     selectionSet: `{
@@ -114,6 +118,6 @@ export async function querySamplesList(ogm: OGM, where: GraphQLWhereArg) {
 
   return {
     totalCount: samples.length,
-    data: samples.slice(0, MAX_ROWS),
+    data: samples.slice(0, (options?.limit as number) || MAX_ROWS),
   };
 }

--- a/graphql-server/src/utils/oncotree.ts
+++ b/graphql-server/src/utils/oncotree.ts
@@ -2,7 +2,11 @@ import fetch from "node-fetch";
 import NodeCache from "node-cache";
 import { driver } from "../schemas/neo4j";
 import { props } from "./constants";
-import { SampleMetadataWhere, SampleWhere } from "../generated/graphql";
+import {
+  InputMaybe,
+  SampleMetadataWhere,
+  SampleWhere,
+} from "../generated/graphql";
 import { GraphQLWhereArg } from "@neo4j/graphql";
 
 /**
@@ -114,7 +118,7 @@ async function getOncotreeCodesFromNeo4j() {
 }
 
 export function includeCancerTypeFieldsInSearch(
-  where: SampleWhere,
+  where: InputMaybe<SampleWhere>,
   oncotreeCache: NodeCache
 ) {
   const customWhere = { ...where };


### PR DESCRIPTION
For [card 1237](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1237). This PR increases the max number of samples that can be exported from 500 to 5,000.

If users attempt to export more, they will see a popup asking them to either refine their search or reach out to our team.
<img src="https://github.com/user-attachments/assets/a4488a36-bfa1-4185-909a-44df82f67259" width="350">
