### PR TITLE
Resolve CMO Patient ID from PatientAlias

### DIFF
--- a/graphql-server/src/utils/flattening.ts
+++ b/graphql-server/src/utils/flattening.ts
@@ -155,8 +155,9 @@ const nestedValueGetters: NestedValueGetters = {
   Patient: (parent, fieldName, _context) => {
     switch (fieldName) {
       case "cmoPatientId":
-        return parent.hasSampleSamples?.[0]?.hasMetadataSampleMetadata?.[0]
-          ?.cmoPatientId;
+        return parent.patientAliasesIsAlias?.find(
+          (patientAlias) => patientAlias.namespace === "cmoId"
+        )?.value;
       case "dmpPatientId":
         return parent.patientAliasesIsAlias?.find(
           (patientAlias) => patientAlias.namespace === "dmpId"


### PR DESCRIPTION
These changes resolve the CMO patient ID from a given Patient's aliases instead of from a patient's sample metadata > cmoPatientId.


Current behavior:

![image](https://github.com/user-attachments/assets/10b396e5-c55c-4087-b076-614bb2465ce0)


Expected behavior / behavior after changes from this PR:

![image](https://github.com/user-attachments/assets/252e8a82-92d6-4ec9-9676-c11676657e57)


Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
