### PR TITLE
Fix displayed consent part a/c status on patient table

### DIFF
--- a/graphql-server/src/utils/flattening.ts
+++ b/graphql-server/src/utils/flattening.ts
@@ -173,19 +173,25 @@ const nestedValueGetters: NestedValueGetters = {
           ?.join(", ");
       case "consentPartA":
         try {
-          return JSON.parse(
-            parent.hasSampleSamples[0].hasMetadataSampleMetadata[0]
-              .additionalProperties
-          )["consent-parta"];
+          return parent.hasSampleSamples
+            .map((s) => {
+              return JSON.parse(
+                s.hasMetadataSampleMetadata[0].additionalProperties
+              )["consent-parta"];
+            })
+            .find((value) => value !== undefined);
         } catch {
           return null;
         }
       case "consentPartC":
         try {
-          return JSON.parse(
-            parent.hasSampleSamples[0].hasMetadataSampleMetadata[0]
-              .additionalProperties
-          )["consent-partc"];
+          return parent.hasSampleSamples
+            .map((s) => {
+              return JSON.parse(
+                s.hasMetadataSampleMetadata[0].additionalProperties
+              )["consent-partc"];
+            })
+            .find((value) => value !== undefined);
         } catch {
           return null;
         }


### PR DESCRIPTION
Fixes issue where records in the Patient view weren't showing 12-245 Part A/C consent statuses even though they exist in the database. 

Current behavior:
![image](https://github.com/user-attachments/assets/fe7e013e-3696-41cd-8a30-c1675625dc7a)


Expected behavior / behavior after changes from PR:

![image](https://github.com/user-attachments/assets/294747e0-bdfb-4af3-92e6-8f3f5d56bc09)
