### PR TITLE
Fix sample status showing warning icon when validationStatus is null

### DIFF
--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -224,7 +224,11 @@ export const SampleMetadataDetailsColumns: ColDef[] = [
     headerName: "Status",
     cellRenderer: (params: ICellRendererParams) => {
       if (params.data?.revisable) {
-        return params.data?.validationStatus ? <CheckIcon /> : <WarningIcon />;
+        return params.data?.validationStatus === false ? (
+          <WarningIcon />
+        ) : (
+          <CheckIcon />
+        );
       } else {
         return <LoadingIcon />;
       }


### PR DESCRIPTION
For [card 1268](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1268)

![CleanShot 153825](https://github.com/user-attachments/assets/e750316a-cc1e-4d12-a804-08901507c6f5)
