### PR TITLE
Hide hidden columns from the exported file

### DIFF
--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -93,7 +93,7 @@ export default function RecordsList({
   const [rowCount, setRowCount] = useState<number>(0);
   const [uniqueSampleCount, setUniqueSampleCount] = useState<number>(0);
 
-  const grid = useRef<AgGridReactType>(null);
+  const gridRef = useRef<AgGridReactType>(null);
   const navigate = useNavigate();
   const params = useParams();
 
@@ -114,7 +114,7 @@ export default function RecordsList({
   const totalCountNodeName = `${dataName}Connection`;
 
   const getSortModel = useCallback(() => {
-    const sortModel = grid.current?.columnApi
+    const sortModel = gridRef.current?.columnApi
       ?.getColumnState()
       .filter(({ sort }) => sort)
       .map(({ colId, sort }) => ({
@@ -211,7 +211,11 @@ export default function RecordsList({
               agGridData = prepareDataForAgGrid(data, filterModel, sortModel);
             }
 
-            return buildTsvString(agGridData[dataName], colDefs);
+            return buildTsvString(
+              agGridData[dataName],
+              colDefs,
+              gridRef.current?.columnApi?.getAllGridColumns()
+            );
           }}
           onComplete={() => setShowDownloadModal(false)}
           exportFileName={`${dataName}.tsv`}
@@ -309,7 +313,7 @@ export default function RecordsList({
             style={{ width: width }}
           >
             <AgGridReact
-              ref={grid}
+              ref={gridRef}
               rowModelType={"serverSide"}
               columnDefs={colDefs}
               serverSideDatasource={datasource}

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -266,7 +266,13 @@ export default function SamplesList({
         <DownloadModal
           loader={() => {
             return sampleCount <= MAX_ROWS_TABLE
-              ? Promise.resolve(buildTsvString(samples!, columnDefs))
+              ? Promise.resolve(
+                  buildTsvString(
+                    samples!,
+                    columnDefs,
+                    gridRef.current?.columnApi?.getAllGridColumns()
+                  )
+                )
               : refetch({
                   options: {
                     limit: MAX_ROWS_EXPORT,

--- a/frontend/src/utils/stringBuilders.ts
+++ b/frontend/src/utils/stringBuilders.ts
@@ -1,8 +1,16 @@
-import { ColDef } from "ag-grid-community";
+import { ColDef, Column } from "ag-grid-community";
 
-export function buildTsvString(rows: any[], colDefs: ColDef[]) {
+export function buildTsvString(
+  rows: any[],
+  colDefs: ColDef[],
+  cols?: Column[]
+) {
+  const fieldsHiddenByUser =
+    cols?.filter((col) => !col.isVisible()).map((col) => col.getColId()) ?? [];
+
   const colDefsToExport = colDefs.filter(
-    (colDef) => colDef.headerName !== "View Samples" && colDef.hide !== true
+    ({ field, hide }) =>
+      field && hide !== true && !fieldsHiddenByUser.includes(field)
   );
 
   const colHeadersAsTsvRow = colDefsToExport

--- a/frontend/src/utils/stringBuilders.ts
+++ b/frontend/src/utils/stringBuilders.ts
@@ -2,7 +2,7 @@ import { ColDef } from "ag-grid-community";
 
 export function buildTsvString(rows: any[], colDefs: ColDef[]) {
   const colDefsToExport = colDefs.filter(
-    (colDef) => colDef.headerName !== "View Samples"
+    (colDef) => colDef.headerName !== "View Samples" && colDef.hide !== true
   );
 
   const colHeadersAsTsvRow = colDefsToExport


### PR DESCRIPTION
For card [#1258](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1258). This PR ensures we only export visible columns when generating report from the dashboard.

The only page that is affected is the Patients page, where the exported file contains columns "Patient MRN" and "SMILE Patient ID" even though they're hidden and user is not in PHI mode.

Views manually tested for dashboard's columns == exported table's columns:
- [x] Requests
    - [x] Request Samples
- [x] Patients
    - [x] Patient Samples
- [x] Samples
    - [x] Samples - WES only
- [x] Cohorts
    - [x] Cohort Samples