### PR TITLE
Re-enable editing for the new Samples query

### DIFF
--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -18,7 +18,7 @@ import {
 } from "ag-grid-community";
 import { DataName, useHookLazyGeneric } from "../shared/types";
 import SamplesList, { SampleContext } from "./SamplesList";
-import { Sample, SortDirection } from "../generated/graphql";
+import { SortDirection } from "../generated/graphql";
 import { defaultColDef } from "../shared/helpers";
 import { PatientIdsTriplet } from "../pages/patients/PatientsPage";
 import {
@@ -55,7 +55,6 @@ interface IRecordsListProps {
   handleDownload: () => void;
   samplesColDefs: ColDef[];
   sampleContext?: SampleContext;
-  sampleKeyForUpdate?: keyof Sample;
   userEmail?: string | null;
   setUserEmail?: Dispatch<SetStateAction<string | null>>;
   setCustomSearchVals?: Dispatch<SetStateAction<PatientIdsTriplet[]>>;
@@ -81,7 +80,6 @@ export default function RecordsList({
   handleDownload,
   samplesColDefs,
   sampleContext,
-  sampleKeyForUpdate,
   userEmail,
   setUserEmail,
   customToolbarUI,
@@ -272,7 +270,6 @@ export default function RecordsList({
                     parentDataName={dataName}
                     sampleContext={sampleContext}
                     setUnsavedChanges={setUnsavedChanges}
-                    sampleKeyForUpdate={sampleKeyForUpdate}
                     userEmail={userEmail}
                     setUserEmail={setUserEmail}
                   />

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -80,6 +80,7 @@ export default function SamplesList({
       variables: {
         searchVals: [],
         sampleContext,
+        limit: MAX_ROWS_TABLE,
       },
       pollInterval: POLLING_INTERVAL,
     });
@@ -93,6 +94,7 @@ export default function SamplesList({
     refetch({
       searchVals: parseUserSearchVal(userSearchVal),
       sampleContext,
+      limit: MAX_ROWS_TABLE,
     }).then(() => {
       gridRef.current?.api?.hideOverlay();
     });
@@ -238,7 +240,7 @@ export default function SamplesList({
                     gridRef.current?.columnApi?.getAllGridColumns()
                   )
                 )
-              : refetch().then((result) =>
+              : refetch({ limit: MAX_ROWS_EXPORT }).then((result) =>
                   buildTsvString(result.data.dashboardSamples!, columnDefs)
                 );
           }}
@@ -246,7 +248,7 @@ export default function SamplesList({
             setShowDownloadModal(false);
             // Reset the limit back to the default value of MAX_ROWS_TABLE.
             // Otherwise, polling will use the most recent value MAX_ROWS_EXPORT
-            refetch();
+            refetch({ limit: MAX_ROWS_TABLE });
           }}
           exportFileName={[
             parentDataName?.slice(0, -1),

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -1,9 +1,9 @@
-import { Sample, useDashboardSamplesQuery } from "../generated/graphql";
+import { useDashboardSamplesQuery } from "../generated/graphql";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { Button, Col, Container } from "react-bootstrap";
 import { Dispatch, SetStateAction, useRef } from "react";
 import { DownloadModal } from "./DownloadModal";
-// import { UpdateModal } from "./UpdateModal";
+import { UpdateModal } from "./UpdateModal";
 import { AlertModal } from "./AlertModal";
 import { buildTsvString } from "../utils/stringBuilders";
 import {
@@ -48,7 +48,6 @@ interface ISampleListProps {
   setUnsavedChanges?: (unsavedChanges: boolean) => void;
   parentDataName?: DataName;
   sampleContext?: SampleContext;
-  sampleKeyForUpdate?: keyof Sample;
   userEmail?: string | null;
   setUserEmail?: Dispatch<SetStateAction<string | null>>;
   customToolbarUI?: JSX.Element;
@@ -59,7 +58,6 @@ export default function SamplesList({
   parentDataName,
   sampleContext,
   setUnsavedChanges,
-  sampleKeyForUpdate = "hasMetadataSampleMetadata",
   userEmail,
   setUserEmail,
   customToolbarUI,
@@ -77,7 +75,7 @@ export default function SamplesList({
   const params = useParams();
   const hasParams = Object.keys(params).length > 0;
 
-  const { loading, error, data, startPolling, stopPolling, refetch } =
+  const { error, data, startPolling, stopPolling, refetch } =
     useDashboardSamplesQuery({
       variables: {
         searchVals: [],
@@ -260,16 +258,15 @@ export default function SamplesList({
         />
       )}
 
-      {/* {showUpdateModal && (
+      {showUpdateModal && (
         <UpdateModal
           changes={changes}
           samples={samples!}
           onSuccess={handleDiscardChanges}
           onHide={() => setShowUpdateModal(false)}
           onOpen={() => stopPolling()}
-          sampleKeyForUpdate={sampleKeyForUpdate}
         />
-      )} */}
+      )}
 
       <AlertModal
         show={showAlertModal}
@@ -382,7 +379,6 @@ export default function SamplesList({
                 setSampleCount(data?.dashboardSampleCount?.totalCount || 0);
               }}
               onGridColumnsChanged={() => handleSearch(userSearchVal)}
-              suppressClickEdit={true} // temporarily disable cell editing
             />
           </div>
         )}

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -232,16 +232,17 @@ export default function SamplesList({
       {showDownloadModal && (
         <DownloadModal
           loader={() => {
+            const allColumns = gridRef.current?.columnApi?.getAllGridColumns();
             return sampleCount <= MAX_ROWS_TABLE
               ? Promise.resolve(
-                  buildTsvString(
-                    samples!,
-                    columnDefs,
-                    gridRef.current?.columnApi?.getAllGridColumns()
-                  )
+                  buildTsvString(samples!, columnDefs, allColumns)
                 )
               : refetch({ limit: MAX_ROWS_EXPORT }).then((result) =>
-                  buildTsvString(result.data.dashboardSamples!, columnDefs)
+                  buildTsvString(
+                    result.data.dashboardSamples!,
+                    columnDefs,
+                    allColumns
+                  )
                 );
           }}
           onComplete={() => {

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1786,7 +1786,6 @@ export type DashboardSample = {
 
 export type DashboardSampleCount = {
   __typename?: "DashboardSampleCount";
-  count?: Maybe<Scalars["Int"]>;
   totalCount?: Maybe<Scalars["Int"]>;
 };
 
@@ -4613,6 +4612,7 @@ export type QueryDashboardSampleCountArgs = {
 };
 
 export type QueryDashboardSamplesArgs = {
+  limit?: InputMaybe<Scalars["Int"]>;
   sampleContext?: InputMaybe<SampleContext>;
   searchVals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
@@ -12465,6 +12465,7 @@ export type DashboardSamplesQueryVariables = Exact<{
     Array<InputMaybe<Scalars["String"]>> | InputMaybe<Scalars["String"]>
   >;
   sampleContext?: InputMaybe<SampleContext>;
+  limit?: InputMaybe<Scalars["Int"]>;
 }>;
 
 export type DashboardSamplesQuery = {
@@ -12935,14 +12936,22 @@ export type PatientsListQueryResult = Apollo.QueryResult<
   PatientsListQueryVariables
 >;
 export const DashboardSamplesDocument = gql`
-  query DashboardSamples($searchVals: [String], $sampleContext: SampleContext) {
+  query DashboardSamples(
+    $searchVals: [String]
+    $sampleContext: SampleContext
+    $limit: Int
+  ) {
     dashboardSampleCount(
       searchVals: $searchVals
       sampleContext: $sampleContext
     ) {
       totalCount
     }
-    dashboardSamples(searchVals: $searchVals, sampleContext: $sampleContext) {
+    dashboardSamples(
+      searchVals: $searchVals
+      sampleContext: $sampleContext
+      limit: $limit
+    ) {
       ...DashboardSampleParts
       ...DashboardSampleMetadataParts
       ...DashboardTempoParts
@@ -12967,6 +12976,7 @@ export const DashboardSamplesDocument = gql`
  *   variables: {
  *      searchVals: // value for 'searchVals'
  *      sampleContext: // value for 'sampleContext'
+ *      limit: // value for 'limit'
  *   },
  * });
  */

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1776,7 +1776,7 @@ export type DashboardSample = {
   sampleOrigin?: Maybe<Scalars["String"]>;
   sampleType?: Maybe<Scalars["String"]>;
   sex?: Maybe<Scalars["String"]>;
-  smileSampleId?: Maybe<Scalars["String"]>;
+  smileSampleId: Scalars["String"];
   species?: Maybe<Scalars["String"]>;
   tissueLocation?: Maybe<Scalars["String"]>;
   tumorOrNormal?: Maybe<Scalars["String"]>;
@@ -1799,6 +1799,7 @@ export type DashboardSampleInput = {
   billedBy?: InputMaybe<Scalars["String"]>;
   cancerType?: InputMaybe<Scalars["String"]>;
   cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
+  changedFieldNames: Array<Scalars["String"]>;
   cmoPatientId?: InputMaybe<Scalars["String"]>;
   cmoSampleName?: InputMaybe<Scalars["String"]>;
   collectionYear?: InputMaybe<Scalars["String"]>;
@@ -1825,7 +1826,7 @@ export type DashboardSampleInput = {
   sampleOrigin?: InputMaybe<Scalars["String"]>;
   sampleType?: InputMaybe<Scalars["String"]>;
   sex?: InputMaybe<Scalars["String"]>;
-  smileSampleId?: InputMaybe<Scalars["String"]>;
+  smileSampleId: Scalars["String"];
   species?: InputMaybe<Scalars["String"]>;
   tissueLocation?: InputMaybe<Scalars["String"]>;
   tumorOrNormal?: InputMaybe<Scalars["String"]>;
@@ -12474,7 +12475,7 @@ export type DashboardSamplesQuery = {
   } | null;
   dashboardSamples?: Array<{
     __typename?: "DashboardSample";
-    smileSampleId?: string | null;
+    smileSampleId: string;
     revisable?: boolean | null;
     primaryId?: string | null;
     cmoSampleName?: string | null;
@@ -12519,7 +12520,7 @@ export type DashboardSamplesQuery = {
 
 export type DashboardSamplePartsFragment = {
   __typename?: "DashboardSample";
-  smileSampleId?: string | null;
+  smileSampleId: string;
   revisable?: boolean | null;
 };
 
@@ -12706,7 +12707,7 @@ export type UpdateDashboardSamplesMutation = {
   __typename?: "Mutation";
   updateDashboardSamples?: Array<{
     __typename?: "DashboardSample";
-    smileSampleId?: string | null;
+    smileSampleId: string;
     revisable?: boolean | null;
     primaryId?: string | null;
     cmoSampleName?: string | null;

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1790,6 +1790,49 @@ export type DashboardSampleCount = {
   totalCount?: Maybe<Scalars["Int"]>;
 };
 
+export type DashboardSampleInput = {
+  accessLevel?: InputMaybe<Scalars["String"]>;
+  baitSet?: InputMaybe<Scalars["String"]>;
+  bamCompleteDate?: InputMaybe<Scalars["String"]>;
+  bamCompleteStatus?: InputMaybe<Scalars["String"]>;
+  billed?: InputMaybe<Scalars["Boolean"]>;
+  billedBy?: InputMaybe<Scalars["String"]>;
+  cancerType?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]>;
+  collectionYear?: InputMaybe<Scalars["String"]>;
+  costCenter?: InputMaybe<Scalars["String"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]>;
+  embargoDate?: InputMaybe<Scalars["String"]>;
+  genePanel?: InputMaybe<Scalars["String"]>;
+  importDate?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]>;
+  mafCompleteDate?: InputMaybe<Scalars["String"]>;
+  mafCompleteNormalPrimaryId?: InputMaybe<Scalars["String"]>;
+  mafCompleteStatus?: InputMaybe<Scalars["String"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]>;
+  preservation?: InputMaybe<Scalars["String"]>;
+  primaryId?: InputMaybe<Scalars["String"]>;
+  qcCompleteDate?: InputMaybe<Scalars["String"]>;
+  qcCompleteReason?: InputMaybe<Scalars["String"]>;
+  qcCompleteResult?: InputMaybe<Scalars["String"]>;
+  qcCompleteStatus?: InputMaybe<Scalars["String"]>;
+  recipe?: InputMaybe<Scalars["String"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]>;
+  sampleClass?: InputMaybe<Scalars["String"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]>;
+  sampleType?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]>;
+  smileSampleId?: InputMaybe<Scalars["String"]>;
+  species?: InputMaybe<Scalars["String"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]>;
+  validationReport?: InputMaybe<Scalars["String"]>;
+  validationStatus?: InputMaybe<Scalars["String"]>;
+};
+
 export type DeleteInfo = {
   __typename?: "DeleteInfo";
   bookmark?: Maybe<Scalars["String"]>;
@@ -2182,6 +2225,7 @@ export type Mutation = {
   updateBamCompletes: UpdateBamCompletesMutationResponse;
   updateCohortCompletes: UpdateCohortCompletesMutationResponse;
   updateCohorts: UpdateCohortsMutationResponse;
+  updateDashboardSamples?: Maybe<Array<Maybe<DashboardSample>>>;
   updateMafCompletes: UpdateMafCompletesMutationResponse;
   updatePatientAliases: UpdatePatientAliasesMutationResponse;
   updatePatients: UpdatePatientsMutationResponse;
@@ -2356,6 +2400,10 @@ export type MutationUpdateCohortsArgs = {
   disconnect?: InputMaybe<CohortDisconnectInput>;
   update?: InputMaybe<CohortUpdateInput>;
   where?: InputMaybe<CohortWhere>;
+};
+
+export type MutationUpdateDashboardSamplesArgs = {
+  newDashboardSamples?: InputMaybe<Array<InputMaybe<DashboardSampleInput>>>;
 };
 
 export type MutationUpdateMafCompletesArgs = {
@@ -12650,6 +12698,57 @@ export type SamplesQuery = {
   }>;
 };
 
+export type UpdateDashboardSamplesMutationVariables = Exact<{
+  newDashboardSamples: Array<DashboardSampleInput> | DashboardSampleInput;
+}>;
+
+export type UpdateDashboardSamplesMutation = {
+  __typename?: "Mutation";
+  updateDashboardSamples?: Array<{
+    __typename?: "DashboardSample";
+    smileSampleId?: string | null;
+    revisable?: boolean | null;
+    primaryId?: string | null;
+    cmoSampleName?: string | null;
+    importDate?: string | null;
+    cmoPatientId?: string | null;
+    investigatorSampleId?: string | null;
+    sampleType?: string | null;
+    species?: string | null;
+    genePanel?: string | null;
+    baitSet?: string | null;
+    preservation?: string | null;
+    tumorOrNormal?: string | null;
+    sampleClass?: string | null;
+    oncotreeCode?: string | null;
+    collectionYear?: string | null;
+    sampleOrigin?: string | null;
+    tissueLocation?: string | null;
+    sex?: string | null;
+    recipe?: string | null;
+    validationReport?: string | null;
+    validationStatus?: string | null;
+    cancerType?: string | null;
+    cancerTypeDetailed?: string | null;
+    billed?: boolean | null;
+    costCenter?: string | null;
+    billedBy?: string | null;
+    custodianInformation?: string | null;
+    accessLevel?: string | null;
+    initialPipelineRunDate?: string | null;
+    embargoDate?: string | null;
+    bamCompleteDate?: string | null;
+    bamCompleteStatus?: string | null;
+    mafCompleteDate?: string | null;
+    mafCompleteNormalPrimaryId?: string | null;
+    mafCompleteStatus?: string | null;
+    qcCompleteDate?: string | null;
+    qcCompleteResult?: string | null;
+    qcCompleteReason?: string | null;
+    qcCompleteStatus?: string | null;
+  } | null> | null;
+};
+
 export type UpdateSamplesMutationVariables = Exact<{
   where?: InputMaybe<SampleWhere>;
   update?: InputMaybe<SampleUpdateInput>;
@@ -13189,6 +13288,63 @@ export type SamplesLazyQueryHookResult = ReturnType<typeof useSamplesLazyQuery>;
 export type SamplesQueryResult = Apollo.QueryResult<
   SamplesQuery,
   SamplesQueryVariables
+>;
+export const UpdateDashboardSamplesDocument = gql`
+  mutation UpdateDashboardSamples(
+    $newDashboardSamples: [DashboardSampleInput!]!
+  ) {
+    updateDashboardSamples(newDashboardSamples: $newDashboardSamples) {
+      ...DashboardSampleParts
+      ...DashboardSampleMetadataParts
+      ...DashboardTempoParts
+    }
+  }
+  ${DashboardSamplePartsFragmentDoc}
+  ${DashboardSampleMetadataPartsFragmentDoc}
+  ${DashboardTempoPartsFragmentDoc}
+`;
+export type UpdateDashboardSamplesMutationFn = Apollo.MutationFunction<
+  UpdateDashboardSamplesMutation,
+  UpdateDashboardSamplesMutationVariables
+>;
+
+/**
+ * __useUpdateDashboardSamplesMutation__
+ *
+ * To run a mutation, you first call `useUpdateDashboardSamplesMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateDashboardSamplesMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateDashboardSamplesMutation, { data, loading, error }] = useUpdateDashboardSamplesMutation({
+ *   variables: {
+ *      newDashboardSamples: // value for 'newDashboardSamples'
+ *   },
+ * });
+ */
+export function useUpdateDashboardSamplesMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateDashboardSamplesMutation,
+    UpdateDashboardSamplesMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    UpdateDashboardSamplesMutation,
+    UpdateDashboardSamplesMutationVariables
+  >(UpdateDashboardSamplesDocument, options);
+}
+export type UpdateDashboardSamplesMutationHookResult = ReturnType<
+  typeof useUpdateDashboardSamplesMutation
+>;
+export type UpdateDashboardSamplesMutationResult =
+  Apollo.MutationResult<UpdateDashboardSamplesMutation>;
+export type UpdateDashboardSamplesMutationOptions = Apollo.BaseMutationOptions<
+  UpdateDashboardSamplesMutation,
+  UpdateDashboardSamplesMutationVariables
 >;
 export const UpdateSamplesDocument = gql`
   mutation UpdateSamples(

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1765,7 +1765,7 @@ export type DashboardSample = {
   mafCompleteStatus?: Maybe<Scalars["String"]>;
   oncotreeCode?: Maybe<Scalars["String"]>;
   preservation?: Maybe<Scalars["String"]>;
-  primaryId?: Maybe<Scalars["String"]>;
+  primaryId: Scalars["String"];
   qcCompleteDate?: Maybe<Scalars["String"]>;
   qcCompleteReason?: Maybe<Scalars["String"]>;
   qcCompleteResult?: Maybe<Scalars["String"]>;
@@ -1815,7 +1815,7 @@ export type DashboardSampleInput = {
   mafCompleteStatus?: InputMaybe<Scalars["String"]>;
   oncotreeCode?: InputMaybe<Scalars["String"]>;
   preservation?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
+  primaryId: Scalars["String"];
   qcCompleteDate?: InputMaybe<Scalars["String"]>;
   qcCompleteReason?: InputMaybe<Scalars["String"]>;
   qcCompleteResult?: InputMaybe<Scalars["String"]>;
@@ -4518,8 +4518,8 @@ export type Query = {
   cohorts: Array<Cohort>;
   cohortsAggregate: CohortAggregateSelection;
   cohortsConnection: CohortsConnection;
-  dashboardSampleCount?: Maybe<DashboardSampleCount>;
-  dashboardSamples?: Maybe<Array<Maybe<DashboardSample>>>;
+  dashboardSampleCount: DashboardSampleCount;
+  dashboardSamples: Array<DashboardSample>;
   mafCompletes: Array<MafComplete>;
   mafCompletesAggregate: MafCompleteAggregateSelection;
   mafCompletesConnection: MafCompletesConnection;
@@ -12469,15 +12469,15 @@ export type DashboardSamplesQueryVariables = Exact<{
 
 export type DashboardSamplesQuery = {
   __typename?: "Query";
-  dashboardSampleCount?: {
+  dashboardSampleCount: {
     __typename?: "DashboardSampleCount";
     totalCount?: number | null;
-  } | null;
-  dashboardSamples?: Array<{
+  };
+  dashboardSamples: Array<{
     __typename?: "DashboardSample";
     smileSampleId: string;
     revisable?: boolean | null;
-    primaryId?: string | null;
+    primaryId: string;
     cmoSampleName?: string | null;
     importDate?: string | null;
     cmoPatientId?: string | null;
@@ -12515,7 +12515,7 @@ export type DashboardSamplesQuery = {
     qcCompleteResult?: string | null;
     qcCompleteReason?: string | null;
     qcCompleteStatus?: string | null;
-  } | null> | null;
+  }>;
 };
 
 export type DashboardSamplePartsFragment = {
@@ -12526,7 +12526,7 @@ export type DashboardSamplePartsFragment = {
 
 export type DashboardSampleMetadataPartsFragment = {
   __typename?: "DashboardSample";
-  primaryId?: string | null;
+  primaryId: string;
   cmoSampleName?: string | null;
   importDate?: string | null;
   cmoPatientId?: string | null;
@@ -12592,113 +12592,6 @@ export type RequestPartsFragment = {
   smileRequestId: string;
 };
 
-export type SamplePartsFragment = {
-  __typename?: "Sample";
-  datasource: string;
-  revisable: boolean;
-  sampleCategory: string;
-  sampleClass: string;
-  smileSampleId: string;
-};
-
-export type SampleMetadataPartsFragment = {
-  __typename?: "SampleMetadata";
-  additionalProperties: string;
-  baitSet?: string | null;
-  cfDNA2dBarcode?: string | null;
-  cmoInfoIgoId?: string | null;
-  cmoPatientId?: string | null;
-  cmoSampleIdFields: string;
-  cmoSampleName?: string | null;
-  collectionYear: string;
-  genePanel: string;
-  igoComplete?: boolean | null;
-  igoRequestId?: string | null;
-  importDate: string;
-  investigatorSampleId?: string | null;
-  libraries: string;
-  oncotreeCode?: string | null;
-  preservation?: string | null;
-  primaryId: string;
-  qcReports: string;
-  sampleClass: string;
-  sampleName?: string | null;
-  sampleOrigin?: string | null;
-  sampleType: string;
-  sex: string;
-  species: string;
-  tissueLocation?: string | null;
-  tubeId?: string | null;
-  tumorOrNormal: string;
-};
-
-export type TempoPartsFragment = {
-  __typename?: "Tempo";
-  smileTempoId: string;
-  billed?: boolean | null;
-  billedBy?: string | null;
-  costCenter?: string | null;
-  custodianInformation?: string | null;
-  accessLevel?: string | null;
-};
-
-export type SamplesQueryVariables = Exact<{
-  where?: InputMaybe<SampleWhere>;
-  hasMetadataSampleMetadataWhere2?: InputMaybe<SampleMetadataWhere>;
-  hasMetadataSampleMetadataOptions2?: InputMaybe<SampleMetadataOptions>;
-}>;
-
-export type SamplesQuery = {
-  __typename?: "Query";
-  samples: Array<{
-    __typename?: "Sample";
-    smileSampleId: string;
-    revisable: boolean;
-    sampleCategory: string;
-    sampleClass: string;
-    datasource: string;
-    hasMetadataSampleMetadata: Array<{
-      __typename?: "SampleMetadata";
-      additionalProperties: string;
-      baitSet?: string | null;
-      cfDNA2dBarcode?: string | null;
-      cmoInfoIgoId?: string | null;
-      cmoPatientId?: string | null;
-      cmoSampleIdFields: string;
-      cmoSampleName?: string | null;
-      collectionYear: string;
-      genePanel: string;
-      igoComplete?: boolean | null;
-      igoRequestId?: string | null;
-      importDate: string;
-      investigatorSampleId?: string | null;
-      libraries: string;
-      oncotreeCode?: string | null;
-      preservation?: string | null;
-      primaryId: string;
-      qcReports: string;
-      sampleClass: string;
-      sampleName?: string | null;
-      sampleOrigin?: string | null;
-      sampleType: string;
-      sex: string;
-      species: string;
-      tissueLocation?: string | null;
-      tubeId?: string | null;
-      tumorOrNormal: string;
-    }>;
-    hasTempoTempos: Array<{
-      __typename?: "Tempo";
-      smileTempoId: string;
-      billed?: boolean | null;
-      billedBy?: string | null;
-      costCenter?: string | null;
-      custodianInformation?: string | null;
-      accessLevel?: string | null;
-    }>;
-  }>;
-};
-
 export type UpdateDashboardSamplesMutationVariables = Exact<{
   newDashboardSamples: Array<DashboardSampleInput> | DashboardSampleInput;
 }>;
@@ -12709,7 +12602,7 @@ export type UpdateDashboardSamplesMutation = {
     __typename?: "DashboardSample";
     smileSampleId: string;
     revisable?: boolean | null;
-    primaryId?: string | null;
+    primaryId: string;
     cmoSampleName?: string | null;
     importDate?: string | null;
     cmoPatientId?: string | null;
@@ -12748,66 +12641,6 @@ export type UpdateDashboardSamplesMutation = {
     qcCompleteReason?: string | null;
     qcCompleteStatus?: string | null;
   } | null> | null;
-};
-
-export type UpdateSamplesMutationVariables = Exact<{
-  where?: InputMaybe<SampleWhere>;
-  update?: InputMaybe<SampleUpdateInput>;
-  connect?: InputMaybe<SampleConnectInput>;
-}>;
-
-export type UpdateSamplesMutation = {
-  __typename?: "Mutation";
-  updateSamples: {
-    __typename?: "UpdateSamplesMutationResponse";
-    samples: Array<{
-      __typename?: "Sample";
-      smileSampleId: string;
-      revisable: boolean;
-      datasource: string;
-      sampleCategory: string;
-      sampleClass: string;
-      hasMetadataSampleMetadata: Array<{
-        __typename?: "SampleMetadata";
-        additionalProperties: string;
-        baitSet?: string | null;
-        cfDNA2dBarcode?: string | null;
-        cmoInfoIgoId?: string | null;
-        cmoPatientId?: string | null;
-        cmoSampleIdFields: string;
-        cmoSampleName?: string | null;
-        collectionYear: string;
-        genePanel: string;
-        igoComplete?: boolean | null;
-        igoRequestId?: string | null;
-        importDate: string;
-        investigatorSampleId?: string | null;
-        libraries: string;
-        oncotreeCode?: string | null;
-        preservation?: string | null;
-        primaryId: string;
-        qcReports: string;
-        sampleClass: string;
-        sampleName?: string | null;
-        sampleOrigin?: string | null;
-        sampleType: string;
-        sex: string;
-        species: string;
-        tissueLocation?: string | null;
-        tubeId?: string | null;
-        tumorOrNormal: string;
-      }>;
-      hasTempoTempos: Array<{
-        __typename?: "Tempo";
-        smileTempoId: string;
-        billed?: boolean | null;
-        billedBy?: string | null;
-        costCenter?: string | null;
-        custodianInformation?: string | null;
-        accessLevel?: string | null;
-      }>;
-    }>;
-  };
 };
 
 export type GetPatientIdsTripletsQueryVariables = Exact<{
@@ -12944,56 +12777,6 @@ export const RequestPartsFragmentDoc = gql`
     projectManagerName
     qcAccessEmails
     smileRequestId
-  }
-`;
-export const SamplePartsFragmentDoc = gql`
-  fragment SampleParts on Sample {
-    datasource
-    revisable
-    sampleCategory
-    sampleClass
-    smileSampleId
-  }
-`;
-export const SampleMetadataPartsFragmentDoc = gql`
-  fragment SampleMetadataParts on SampleMetadata {
-    additionalProperties
-    baitSet
-    cfDNA2dBarcode
-    cmoInfoIgoId
-    cmoPatientId
-    cmoSampleIdFields
-    cmoSampleName
-    collectionYear
-    genePanel
-    igoComplete
-    igoRequestId
-    importDate
-    investigatorSampleId
-    libraries
-    oncotreeCode
-    preservation
-    primaryId
-    qcReports
-    sampleClass
-    sampleName
-    sampleOrigin
-    sampleType
-    sex
-    species
-    tissueLocation
-    tubeId
-    tumorOrNormal
-  }
-`;
-export const TempoPartsFragmentDoc = gql`
-  fragment TempoParts on Tempo {
-    smileTempoId
-    billed
-    billedBy
-    costCenter
-    custodianInformation
-    accessLevel
   }
 `;
 export const RequestsListDocument = gql`
@@ -13221,75 +13004,6 @@ export type DashboardSamplesQueryResult = Apollo.QueryResult<
   DashboardSamplesQuery,
   DashboardSamplesQueryVariables
 >;
-export const SamplesDocument = gql`
-  query Samples(
-    $where: SampleWhere
-    $hasMetadataSampleMetadataWhere2: SampleMetadataWhere
-    $hasMetadataSampleMetadataOptions2: SampleMetadataOptions
-  ) {
-    samples(where: $where) {
-      smileSampleId
-      revisable
-      sampleCategory
-      sampleClass
-      datasource
-      hasMetadataSampleMetadata(
-        where: $hasMetadataSampleMetadataWhere2
-        options: $hasMetadataSampleMetadataOptions2
-      ) {
-        ...SampleMetadataParts
-      }
-      hasTempoTempos {
-        ...TempoParts
-      }
-    }
-  }
-  ${SampleMetadataPartsFragmentDoc}
-  ${TempoPartsFragmentDoc}
-`;
-
-/**
- * __useSamplesQuery__
- *
- * To run a query within a React component, call `useSamplesQuery` and pass it any options that fit your needs.
- * When your component renders, `useSamplesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useSamplesQuery({
- *   variables: {
- *      where: // value for 'where'
- *      hasMetadataSampleMetadataWhere2: // value for 'hasMetadataSampleMetadataWhere2'
- *      hasMetadataSampleMetadataOptions2: // value for 'hasMetadataSampleMetadataOptions2'
- *   },
- * });
- */
-export function useSamplesQuery(
-  baseOptions?: Apollo.QueryHookOptions<SamplesQuery, SamplesQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<SamplesQuery, SamplesQueryVariables>(
-    SamplesDocument,
-    options
-  );
-}
-export function useSamplesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<SamplesQuery, SamplesQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<SamplesQuery, SamplesQueryVariables>(
-    SamplesDocument,
-    options
-  );
-}
-export type SamplesQueryHookResult = ReturnType<typeof useSamplesQuery>;
-export type SamplesLazyQueryHookResult = ReturnType<typeof useSamplesLazyQuery>;
-export type SamplesQueryResult = Apollo.QueryResult<
-  SamplesQuery,
-  SamplesQueryVariables
->;
 export const UpdateDashboardSamplesDocument = gql`
   mutation UpdateDashboardSamples(
     $newDashboardSamples: [DashboardSampleInput!]!
@@ -13346,76 +13060,6 @@ export type UpdateDashboardSamplesMutationResult =
 export type UpdateDashboardSamplesMutationOptions = Apollo.BaseMutationOptions<
   UpdateDashboardSamplesMutation,
   UpdateDashboardSamplesMutationVariables
->;
-export const UpdateSamplesDocument = gql`
-  mutation UpdateSamples(
-    $where: SampleWhere
-    $update: SampleUpdateInput
-    $connect: SampleConnectInput
-  ) {
-    updateSamples(where: $where, update: $update, connect: $connect) {
-      samples {
-        smileSampleId
-        revisable
-        datasource
-        sampleCategory
-        sampleClass
-        hasMetadataSampleMetadata {
-          ...SampleMetadataParts
-        }
-        hasTempoTempos {
-          ...TempoParts
-        }
-      }
-    }
-  }
-  ${SampleMetadataPartsFragmentDoc}
-  ${TempoPartsFragmentDoc}
-`;
-export type UpdateSamplesMutationFn = Apollo.MutationFunction<
-  UpdateSamplesMutation,
-  UpdateSamplesMutationVariables
->;
-
-/**
- * __useUpdateSamplesMutation__
- *
- * To run a mutation, you first call `useUpdateSamplesMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUpdateSamplesMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [updateSamplesMutation, { data, loading, error }] = useUpdateSamplesMutation({
- *   variables: {
- *      where: // value for 'where'
- *      update: // value for 'update'
- *      connect: // value for 'connect'
- *   },
- * });
- */
-export function useUpdateSamplesMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    UpdateSamplesMutation,
-    UpdateSamplesMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    UpdateSamplesMutation,
-    UpdateSamplesMutationVariables
-  >(UpdateSamplesDocument, options);
-}
-export type UpdateSamplesMutationHookResult = ReturnType<
-  typeof useUpdateSamplesMutation
->;
-export type UpdateSamplesMutationResult =
-  Apollo.MutationResult<UpdateSamplesMutation>;
-export type UpdateSamplesMutationOptions = Apollo.BaseMutationOptions<
-  UpdateSamplesMutation,
-  UpdateSamplesMutationVariables
 >;
 export const GetPatientIdsTripletsDocument = gql`
   query GetPatientIdsTriplets($patientIds: [String!]!) {

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1781,7 +1781,7 @@ export type DashboardSample = {
   tissueLocation?: Maybe<Scalars["String"]>;
   tumorOrNormal?: Maybe<Scalars["String"]>;
   validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["String"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]>;
 };
 
 export type DashboardSampleCount = {
@@ -1830,7 +1830,7 @@ export type DashboardSampleInput = {
   tissueLocation?: InputMaybe<Scalars["String"]>;
   tumorOrNormal?: InputMaybe<Scalars["String"]>;
   validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["String"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]>;
 };
 
 export type DeleteInfo = {
@@ -4608,13 +4608,13 @@ export type QueryCohortsConnectionArgs = {
 
 export type QueryDashboardSampleCountArgs = {
   sampleContext?: InputMaybe<SampleContext>;
-  searchVals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  searchVals?: InputMaybe<Array<Scalars["String"]>>;
 };
 
 export type QueryDashboardSamplesArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
+  limit: Scalars["Int"];
   sampleContext?: InputMaybe<SampleContext>;
-  searchVals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  searchVals?: InputMaybe<Array<Scalars["String"]>>;
 };
 
 export type QueryMafCompletesArgs = {
@@ -12461,11 +12461,9 @@ export type PatientsListQuery = {
 };
 
 export type DashboardSamplesQueryVariables = Exact<{
-  searchVals?: InputMaybe<
-    Array<InputMaybe<Scalars["String"]>> | InputMaybe<Scalars["String"]>
-  >;
+  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
   sampleContext?: InputMaybe<SampleContext>;
-  limit?: InputMaybe<Scalars["Int"]>;
+  limit: Scalars["Int"];
 }>;
 
 export type DashboardSamplesQuery = {
@@ -12497,7 +12495,7 @@ export type DashboardSamplesQuery = {
     sex?: string | null;
     recipe?: string | null;
     validationReport?: string | null;
-    validationStatus?: string | null;
+    validationStatus?: boolean | null;
     cancerType?: string | null;
     cancerTypeDetailed?: string | null;
     billed?: boolean | null;
@@ -12546,7 +12544,7 @@ export type DashboardSampleMetadataPartsFragment = {
   sex?: string | null;
   recipe?: string | null;
   validationReport?: string | null;
-  validationStatus?: string | null;
+  validationStatus?: boolean | null;
   cancerType?: string | null;
   cancerTypeDetailed?: string | null;
 };
@@ -12622,7 +12620,7 @@ export type UpdateDashboardSamplesMutation = {
     sex?: string | null;
     recipe?: string | null;
     validationReport?: string | null;
-    validationStatus?: string | null;
+    validationStatus?: boolean | null;
     cancerType?: string | null;
     cancerTypeDetailed?: string | null;
     billed?: boolean | null;
@@ -12937,9 +12935,9 @@ export type PatientsListQueryResult = Apollo.QueryResult<
 >;
 export const DashboardSamplesDocument = gql`
   query DashboardSamples(
-    $searchVals: [String]
+    $searchVals: [String!]
     $sampleContext: SampleContext
-    $limit: Int
+    $limit: Int!
   ) {
     dashboardSampleCount(
       searchVals: $searchVals
@@ -12981,7 +12979,7 @@ export const DashboardSamplesDocument = gql`
  * });
  */
 export function useDashboardSamplesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
+  baseOptions: Apollo.QueryHookOptions<
     DashboardSamplesQuery,
     DashboardSamplesQueryVariables
   >

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -8,21 +8,14 @@ import App from "./App";
 import { REACT_APP_EXPRESS_SERVER_ORIGIN } from "./shared/constants";
 
 const cache = new InMemoryCache({
-  /* @ts-ignore */
   typePolicies: {
     Query: {
       fields: {
         requests: offsetLimitPagination(),
       },
     },
-    Sample: {
+    DashboardSample: {
       keyFields: ["smileSampleId"],
-    },
-    SampleMetadata: {
-      keyFields: ["primaryId"],
-    },
-    Tempo: {
-      keyFields: ["smileTempoId"],
     },
   },
 });

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -138,7 +138,6 @@ export default function CohortsPage({
   const dataName = "cohorts";
   const sampleQueryParamFieldName = "cohortId";
   const sampleQueryParamValue = params[sampleQueryParamFieldName];
-  const sampleKeyForUpdate = "hasTempoTempos";
   const defaultSort = [{ initialCohortDeliveryDate: SortDirection.Desc }];
 
   return (
@@ -174,7 +173,6 @@ export default function CohortsPage({
             }
           : undefined
       }
-      sampleKeyForUpdate={sampleKeyForUpdate}
       userEmail={userEmail}
       setUserEmail={setUserEmail}
     />

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -27,12 +27,6 @@ export type SampleChange = {
   rowNode: RowNode;
 };
 
-export type ChangesByPrimaryId = {
-  [primaryId: string]: {
-    [fieldName: string]: string;
-  };
-};
-
 export const RequestsListColumns: ColDef[] = [
   {
     headerName: "View Samples",

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1785,7 +1785,6 @@ export type DashboardSample = {
 
 export type DashboardSampleCount = {
   __typename?: "DashboardSampleCount";
-  count?: Maybe<Scalars["Int"]>;
   totalCount?: Maybe<Scalars["Int"]>;
 };
 
@@ -4612,6 +4611,7 @@ export type QueryDashboardSampleCountArgs = {
 };
 
 export type QueryDashboardSamplesArgs = {
+  limit?: InputMaybe<Scalars["Int"]>;
   sampleContext?: InputMaybe<SampleContext>;
   searchVals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
@@ -12464,6 +12464,7 @@ export type DashboardSamplesQueryVariables = Exact<{
     Array<InputMaybe<Scalars["String"]>> | InputMaybe<Scalars["String"]>
   >;
   sampleContext?: InputMaybe<SampleContext>;
+  limit?: InputMaybe<Scalars["Int"]>;
 }>;
 
 export type DashboardSamplesQuery = {
@@ -12838,14 +12839,22 @@ export type PatientsListQueryResult = Apollo.QueryResult<
   PatientsListQueryVariables
 >;
 export const DashboardSamplesDocument = gql`
-  query DashboardSamples($searchVals: [String], $sampleContext: SampleContext) {
+  query DashboardSamples(
+    $searchVals: [String]
+    $sampleContext: SampleContext
+    $limit: Int
+  ) {
     dashboardSampleCount(
       searchVals: $searchVals
       sampleContext: $sampleContext
     ) {
       totalCount
     }
-    dashboardSamples(searchVals: $searchVals, sampleContext: $sampleContext) {
+    dashboardSamples(
+      searchVals: $searchVals
+      sampleContext: $sampleContext
+      limit: $limit
+    ) {
       ...DashboardSampleParts
       ...DashboardSampleMetadataParts
       ...DashboardTempoParts

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1789,6 +1789,49 @@ export type DashboardSampleCount = {
   totalCount?: Maybe<Scalars["Int"]>;
 };
 
+export type DashboardSampleInput = {
+  accessLevel?: InputMaybe<Scalars["String"]>;
+  baitSet?: InputMaybe<Scalars["String"]>;
+  bamCompleteDate?: InputMaybe<Scalars["String"]>;
+  bamCompleteStatus?: InputMaybe<Scalars["String"]>;
+  billed?: InputMaybe<Scalars["Boolean"]>;
+  billedBy?: InputMaybe<Scalars["String"]>;
+  cancerType?: InputMaybe<Scalars["String"]>;
+  cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]>;
+  collectionYear?: InputMaybe<Scalars["String"]>;
+  costCenter?: InputMaybe<Scalars["String"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]>;
+  embargoDate?: InputMaybe<Scalars["String"]>;
+  genePanel?: InputMaybe<Scalars["String"]>;
+  importDate?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]>;
+  mafCompleteDate?: InputMaybe<Scalars["String"]>;
+  mafCompleteNormalPrimaryId?: InputMaybe<Scalars["String"]>;
+  mafCompleteStatus?: InputMaybe<Scalars["String"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]>;
+  preservation?: InputMaybe<Scalars["String"]>;
+  primaryId?: InputMaybe<Scalars["String"]>;
+  qcCompleteDate?: InputMaybe<Scalars["String"]>;
+  qcCompleteReason?: InputMaybe<Scalars["String"]>;
+  qcCompleteResult?: InputMaybe<Scalars["String"]>;
+  qcCompleteStatus?: InputMaybe<Scalars["String"]>;
+  recipe?: InputMaybe<Scalars["String"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]>;
+  sampleClass?: InputMaybe<Scalars["String"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]>;
+  sampleType?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]>;
+  smileSampleId?: InputMaybe<Scalars["String"]>;
+  species?: InputMaybe<Scalars["String"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]>;
+  validationReport?: InputMaybe<Scalars["String"]>;
+  validationStatus?: InputMaybe<Scalars["String"]>;
+};
+
 export type DeleteInfo = {
   __typename?: "DeleteInfo";
   bookmark?: Maybe<Scalars["String"]>;
@@ -2181,6 +2224,7 @@ export type Mutation = {
   updateBamCompletes: UpdateBamCompletesMutationResponse;
   updateCohortCompletes: UpdateCohortCompletesMutationResponse;
   updateCohorts: UpdateCohortsMutationResponse;
+  updateDashboardSamples?: Maybe<Array<Maybe<DashboardSample>>>;
   updateMafCompletes: UpdateMafCompletesMutationResponse;
   updatePatientAliases: UpdatePatientAliasesMutationResponse;
   updatePatients: UpdatePatientsMutationResponse;
@@ -2355,6 +2399,10 @@ export type MutationUpdateCohortsArgs = {
   disconnect?: InputMaybe<CohortDisconnectInput>;
   update?: InputMaybe<CohortUpdateInput>;
   where?: InputMaybe<CohortWhere>;
+};
+
+export type MutationUpdateDashboardSamplesArgs = {
+  newDashboardSamples?: InputMaybe<Array<InputMaybe<DashboardSampleInput>>>;
 };
 
 export type MutationUpdateMafCompletesArgs = {
@@ -12649,6 +12697,57 @@ export type SamplesQuery = {
   }>;
 };
 
+export type UpdateDashboardSamplesMutationVariables = Exact<{
+  newDashboardSamples: Array<DashboardSampleInput> | DashboardSampleInput;
+}>;
+
+export type UpdateDashboardSamplesMutation = {
+  __typename?: "Mutation";
+  updateDashboardSamples?: Array<{
+    __typename?: "DashboardSample";
+    smileSampleId?: string | null;
+    revisable?: boolean | null;
+    primaryId?: string | null;
+    cmoSampleName?: string | null;
+    importDate?: string | null;
+    cmoPatientId?: string | null;
+    investigatorSampleId?: string | null;
+    sampleType?: string | null;
+    species?: string | null;
+    genePanel?: string | null;
+    baitSet?: string | null;
+    preservation?: string | null;
+    tumorOrNormal?: string | null;
+    sampleClass?: string | null;
+    oncotreeCode?: string | null;
+    collectionYear?: string | null;
+    sampleOrigin?: string | null;
+    tissueLocation?: string | null;
+    sex?: string | null;
+    recipe?: string | null;
+    validationReport?: string | null;
+    validationStatus?: string | null;
+    cancerType?: string | null;
+    cancerTypeDetailed?: string | null;
+    billed?: boolean | null;
+    costCenter?: string | null;
+    billedBy?: string | null;
+    custodianInformation?: string | null;
+    accessLevel?: string | null;
+    initialPipelineRunDate?: string | null;
+    embargoDate?: string | null;
+    bamCompleteDate?: string | null;
+    bamCompleteStatus?: string | null;
+    mafCompleteDate?: string | null;
+    mafCompleteNormalPrimaryId?: string | null;
+    mafCompleteStatus?: string | null;
+    qcCompleteDate?: string | null;
+    qcCompleteResult?: string | null;
+    qcCompleteReason?: string | null;
+    qcCompleteStatus?: string | null;
+  } | null> | null;
+};
+
 export type UpdateSamplesMutationVariables = Exact<{
   where?: InputMaybe<SampleWhere>;
   update?: InputMaybe<SampleUpdateInput>;
@@ -13005,6 +13104,30 @@ export const SamplesDocument = gql`
 export type SamplesQueryResult = Apollo.QueryResult<
   SamplesQuery,
   SamplesQueryVariables
+>;
+export const UpdateDashboardSamplesDocument = gql`
+  mutation UpdateDashboardSamples(
+    $newDashboardSamples: [DashboardSampleInput!]!
+  ) {
+    updateDashboardSamples(newDashboardSamples: $newDashboardSamples) {
+      ...DashboardSampleParts
+      ...DashboardSampleMetadataParts
+      ...DashboardTempoParts
+    }
+  }
+  ${DashboardSamplePartsFragmentDoc}
+  ${DashboardSampleMetadataPartsFragmentDoc}
+  ${DashboardTempoPartsFragmentDoc}
+`;
+export type UpdateDashboardSamplesMutationFn = Apollo.MutationFunction<
+  UpdateDashboardSamplesMutation,
+  UpdateDashboardSamplesMutationVariables
+>;
+export type UpdateDashboardSamplesMutationResult =
+  Apollo.MutationResult<UpdateDashboardSamplesMutation>;
+export type UpdateDashboardSamplesMutationOptions = Apollo.BaseMutationOptions<
+  UpdateDashboardSamplesMutation,
+  UpdateDashboardSamplesMutationVariables
 >;
 export const UpdateSamplesDocument = gql`
   mutation UpdateSamples(

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1780,7 +1780,7 @@ export type DashboardSample = {
   tissueLocation?: Maybe<Scalars["String"]>;
   tumorOrNormal?: Maybe<Scalars["String"]>;
   validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["String"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]>;
 };
 
 export type DashboardSampleCount = {
@@ -1829,7 +1829,7 @@ export type DashboardSampleInput = {
   tissueLocation?: InputMaybe<Scalars["String"]>;
   tumorOrNormal?: InputMaybe<Scalars["String"]>;
   validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["String"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]>;
 };
 
 export type DeleteInfo = {
@@ -4607,13 +4607,13 @@ export type QueryCohortsConnectionArgs = {
 
 export type QueryDashboardSampleCountArgs = {
   sampleContext?: InputMaybe<SampleContext>;
-  searchVals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  searchVals?: InputMaybe<Array<Scalars["String"]>>;
 };
 
 export type QueryDashboardSamplesArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
+  limit: Scalars["Int"];
   sampleContext?: InputMaybe<SampleContext>;
-  searchVals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  searchVals?: InputMaybe<Array<Scalars["String"]>>;
 };
 
 export type QueryMafCompletesArgs = {
@@ -12460,11 +12460,9 @@ export type PatientsListQuery = {
 };
 
 export type DashboardSamplesQueryVariables = Exact<{
-  searchVals?: InputMaybe<
-    Array<InputMaybe<Scalars["String"]>> | InputMaybe<Scalars["String"]>
-  >;
+  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
   sampleContext?: InputMaybe<SampleContext>;
-  limit?: InputMaybe<Scalars["Int"]>;
+  limit: Scalars["Int"];
 }>;
 
 export type DashboardSamplesQuery = {
@@ -12496,7 +12494,7 @@ export type DashboardSamplesQuery = {
     sex?: string | null;
     recipe?: string | null;
     validationReport?: string | null;
-    validationStatus?: string | null;
+    validationStatus?: boolean | null;
     cancerType?: string | null;
     cancerTypeDetailed?: string | null;
     billed?: boolean | null;
@@ -12545,7 +12543,7 @@ export type DashboardSampleMetadataPartsFragment = {
   sex?: string | null;
   recipe?: string | null;
   validationReport?: string | null;
-  validationStatus?: string | null;
+  validationStatus?: boolean | null;
   cancerType?: string | null;
   cancerTypeDetailed?: string | null;
 };
@@ -12621,7 +12619,7 @@ export type UpdateDashboardSamplesMutation = {
     sex?: string | null;
     recipe?: string | null;
     validationReport?: string | null;
-    validationStatus?: string | null;
+    validationStatus?: boolean | null;
     cancerType?: string | null;
     cancerTypeDetailed?: string | null;
     billed?: boolean | null;
@@ -12840,9 +12838,9 @@ export type PatientsListQueryResult = Apollo.QueryResult<
 >;
 export const DashboardSamplesDocument = gql`
   query DashboardSamples(
-    $searchVals: [String]
+    $searchVals: [String!]
     $sampleContext: SampleContext
-    $limit: Int
+    $limit: Int!
   ) {
     dashboardSampleCount(
       searchVals: $searchVals

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1775,7 +1775,7 @@ export type DashboardSample = {
   sampleOrigin?: Maybe<Scalars["String"]>;
   sampleType?: Maybe<Scalars["String"]>;
   sex?: Maybe<Scalars["String"]>;
-  smileSampleId?: Maybe<Scalars["String"]>;
+  smileSampleId: Scalars["String"];
   species?: Maybe<Scalars["String"]>;
   tissueLocation?: Maybe<Scalars["String"]>;
   tumorOrNormal?: Maybe<Scalars["String"]>;
@@ -1798,6 +1798,7 @@ export type DashboardSampleInput = {
   billedBy?: InputMaybe<Scalars["String"]>;
   cancerType?: InputMaybe<Scalars["String"]>;
   cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
+  changedFieldNames: Array<Scalars["String"]>;
   cmoPatientId?: InputMaybe<Scalars["String"]>;
   cmoSampleName?: InputMaybe<Scalars["String"]>;
   collectionYear?: InputMaybe<Scalars["String"]>;
@@ -1824,7 +1825,7 @@ export type DashboardSampleInput = {
   sampleOrigin?: InputMaybe<Scalars["String"]>;
   sampleType?: InputMaybe<Scalars["String"]>;
   sex?: InputMaybe<Scalars["String"]>;
-  smileSampleId?: InputMaybe<Scalars["String"]>;
+  smileSampleId: Scalars["String"];
   species?: InputMaybe<Scalars["String"]>;
   tissueLocation?: InputMaybe<Scalars["String"]>;
   tumorOrNormal?: InputMaybe<Scalars["String"]>;
@@ -12473,7 +12474,7 @@ export type DashboardSamplesQuery = {
   } | null;
   dashboardSamples?: Array<{
     __typename?: "DashboardSample";
-    smileSampleId?: string | null;
+    smileSampleId: string;
     revisable?: boolean | null;
     primaryId?: string | null;
     cmoSampleName?: string | null;
@@ -12518,7 +12519,7 @@ export type DashboardSamplesQuery = {
 
 export type DashboardSamplePartsFragment = {
   __typename?: "DashboardSample";
-  smileSampleId?: string | null;
+  smileSampleId: string;
   revisable?: boolean | null;
 };
 
@@ -12705,7 +12706,7 @@ export type UpdateDashboardSamplesMutation = {
   __typename?: "Mutation";
   updateDashboardSamples?: Array<{
     __typename?: "DashboardSample";
-    smileSampleId?: string | null;
+    smileSampleId: string;
     revisable?: boolean | null;
     primaryId?: string | null;
     cmoSampleName?: string | null;

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1764,7 +1764,7 @@ export type DashboardSample = {
   mafCompleteStatus?: Maybe<Scalars["String"]>;
   oncotreeCode?: Maybe<Scalars["String"]>;
   preservation?: Maybe<Scalars["String"]>;
-  primaryId?: Maybe<Scalars["String"]>;
+  primaryId: Scalars["String"];
   qcCompleteDate?: Maybe<Scalars["String"]>;
   qcCompleteReason?: Maybe<Scalars["String"]>;
   qcCompleteResult?: Maybe<Scalars["String"]>;
@@ -1814,7 +1814,7 @@ export type DashboardSampleInput = {
   mafCompleteStatus?: InputMaybe<Scalars["String"]>;
   oncotreeCode?: InputMaybe<Scalars["String"]>;
   preservation?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
+  primaryId: Scalars["String"];
   qcCompleteDate?: InputMaybe<Scalars["String"]>;
   qcCompleteReason?: InputMaybe<Scalars["String"]>;
   qcCompleteResult?: InputMaybe<Scalars["String"]>;
@@ -4517,8 +4517,8 @@ export type Query = {
   cohorts: Array<Cohort>;
   cohortsAggregate: CohortAggregateSelection;
   cohortsConnection: CohortsConnection;
-  dashboardSampleCount?: Maybe<DashboardSampleCount>;
-  dashboardSamples?: Maybe<Array<Maybe<DashboardSample>>>;
+  dashboardSampleCount: DashboardSampleCount;
+  dashboardSamples: Array<DashboardSample>;
   mafCompletes: Array<MafComplete>;
   mafCompletesAggregate: MafCompleteAggregateSelection;
   mafCompletesConnection: MafCompletesConnection;
@@ -12468,15 +12468,15 @@ export type DashboardSamplesQueryVariables = Exact<{
 
 export type DashboardSamplesQuery = {
   __typename?: "Query";
-  dashboardSampleCount?: {
+  dashboardSampleCount: {
     __typename?: "DashboardSampleCount";
     totalCount?: number | null;
-  } | null;
-  dashboardSamples?: Array<{
+  };
+  dashboardSamples: Array<{
     __typename?: "DashboardSample";
     smileSampleId: string;
     revisable?: boolean | null;
-    primaryId?: string | null;
+    primaryId: string;
     cmoSampleName?: string | null;
     importDate?: string | null;
     cmoPatientId?: string | null;
@@ -12514,7 +12514,7 @@ export type DashboardSamplesQuery = {
     qcCompleteResult?: string | null;
     qcCompleteReason?: string | null;
     qcCompleteStatus?: string | null;
-  } | null> | null;
+  }>;
 };
 
 export type DashboardSamplePartsFragment = {
@@ -12525,7 +12525,7 @@ export type DashboardSamplePartsFragment = {
 
 export type DashboardSampleMetadataPartsFragment = {
   __typename?: "DashboardSample";
-  primaryId?: string | null;
+  primaryId: string;
   cmoSampleName?: string | null;
   importDate?: string | null;
   cmoPatientId?: string | null;
@@ -12591,113 +12591,6 @@ export type RequestPartsFragment = {
   smileRequestId: string;
 };
 
-export type SamplePartsFragment = {
-  __typename?: "Sample";
-  datasource: string;
-  revisable: boolean;
-  sampleCategory: string;
-  sampleClass: string;
-  smileSampleId: string;
-};
-
-export type SampleMetadataPartsFragment = {
-  __typename?: "SampleMetadata";
-  additionalProperties: string;
-  baitSet?: string | null;
-  cfDNA2dBarcode?: string | null;
-  cmoInfoIgoId?: string | null;
-  cmoPatientId?: string | null;
-  cmoSampleIdFields: string;
-  cmoSampleName?: string | null;
-  collectionYear: string;
-  genePanel: string;
-  igoComplete?: boolean | null;
-  igoRequestId?: string | null;
-  importDate: string;
-  investigatorSampleId?: string | null;
-  libraries: string;
-  oncotreeCode?: string | null;
-  preservation?: string | null;
-  primaryId: string;
-  qcReports: string;
-  sampleClass: string;
-  sampleName?: string | null;
-  sampleOrigin?: string | null;
-  sampleType: string;
-  sex: string;
-  species: string;
-  tissueLocation?: string | null;
-  tubeId?: string | null;
-  tumorOrNormal: string;
-};
-
-export type TempoPartsFragment = {
-  __typename?: "Tempo";
-  smileTempoId: string;
-  billed?: boolean | null;
-  billedBy?: string | null;
-  costCenter?: string | null;
-  custodianInformation?: string | null;
-  accessLevel?: string | null;
-};
-
-export type SamplesQueryVariables = Exact<{
-  where?: InputMaybe<SampleWhere>;
-  hasMetadataSampleMetadataWhere2?: InputMaybe<SampleMetadataWhere>;
-  hasMetadataSampleMetadataOptions2?: InputMaybe<SampleMetadataOptions>;
-}>;
-
-export type SamplesQuery = {
-  __typename?: "Query";
-  samples: Array<{
-    __typename?: "Sample";
-    smileSampleId: string;
-    revisable: boolean;
-    sampleCategory: string;
-    sampleClass: string;
-    datasource: string;
-    hasMetadataSampleMetadata: Array<{
-      __typename?: "SampleMetadata";
-      additionalProperties: string;
-      baitSet?: string | null;
-      cfDNA2dBarcode?: string | null;
-      cmoInfoIgoId?: string | null;
-      cmoPatientId?: string | null;
-      cmoSampleIdFields: string;
-      cmoSampleName?: string | null;
-      collectionYear: string;
-      genePanel: string;
-      igoComplete?: boolean | null;
-      igoRequestId?: string | null;
-      importDate: string;
-      investigatorSampleId?: string | null;
-      libraries: string;
-      oncotreeCode?: string | null;
-      preservation?: string | null;
-      primaryId: string;
-      qcReports: string;
-      sampleClass: string;
-      sampleName?: string | null;
-      sampleOrigin?: string | null;
-      sampleType: string;
-      sex: string;
-      species: string;
-      tissueLocation?: string | null;
-      tubeId?: string | null;
-      tumorOrNormal: string;
-    }>;
-    hasTempoTempos: Array<{
-      __typename?: "Tempo";
-      smileTempoId: string;
-      billed?: boolean | null;
-      billedBy?: string | null;
-      costCenter?: string | null;
-      custodianInformation?: string | null;
-      accessLevel?: string | null;
-    }>;
-  }>;
-};
-
 export type UpdateDashboardSamplesMutationVariables = Exact<{
   newDashboardSamples: Array<DashboardSampleInput> | DashboardSampleInput;
 }>;
@@ -12708,7 +12601,7 @@ export type UpdateDashboardSamplesMutation = {
     __typename?: "DashboardSample";
     smileSampleId: string;
     revisable?: boolean | null;
-    primaryId?: string | null;
+    primaryId: string;
     cmoSampleName?: string | null;
     importDate?: string | null;
     cmoPatientId?: string | null;
@@ -12747,66 +12640,6 @@ export type UpdateDashboardSamplesMutation = {
     qcCompleteReason?: string | null;
     qcCompleteStatus?: string | null;
   } | null> | null;
-};
-
-export type UpdateSamplesMutationVariables = Exact<{
-  where?: InputMaybe<SampleWhere>;
-  update?: InputMaybe<SampleUpdateInput>;
-  connect?: InputMaybe<SampleConnectInput>;
-}>;
-
-export type UpdateSamplesMutation = {
-  __typename?: "Mutation";
-  updateSamples: {
-    __typename?: "UpdateSamplesMutationResponse";
-    samples: Array<{
-      __typename?: "Sample";
-      smileSampleId: string;
-      revisable: boolean;
-      datasource: string;
-      sampleCategory: string;
-      sampleClass: string;
-      hasMetadataSampleMetadata: Array<{
-        __typename?: "SampleMetadata";
-        additionalProperties: string;
-        baitSet?: string | null;
-        cfDNA2dBarcode?: string | null;
-        cmoInfoIgoId?: string | null;
-        cmoPatientId?: string | null;
-        cmoSampleIdFields: string;
-        cmoSampleName?: string | null;
-        collectionYear: string;
-        genePanel: string;
-        igoComplete?: boolean | null;
-        igoRequestId?: string | null;
-        importDate: string;
-        investigatorSampleId?: string | null;
-        libraries: string;
-        oncotreeCode?: string | null;
-        preservation?: string | null;
-        primaryId: string;
-        qcReports: string;
-        sampleClass: string;
-        sampleName?: string | null;
-        sampleOrigin?: string | null;
-        sampleType: string;
-        sex: string;
-        species: string;
-        tissueLocation?: string | null;
-        tubeId?: string | null;
-        tumorOrNormal: string;
-      }>;
-      hasTempoTempos: Array<{
-        __typename?: "Tempo";
-        smileTempoId: string;
-        billed?: boolean | null;
-        billedBy?: string | null;
-        costCenter?: string | null;
-        custodianInformation?: string | null;
-        accessLevel?: string | null;
-      }>;
-    }>;
-  };
 };
 
 export type GetPatientIdsTripletsQueryVariables = Exact<{
@@ -12945,56 +12778,6 @@ export const RequestPartsFragmentDoc = gql`
     smileRequestId
   }
 `;
-export const SamplePartsFragmentDoc = gql`
-  fragment SampleParts on Sample {
-    datasource
-    revisable
-    sampleCategory
-    sampleClass
-    smileSampleId
-  }
-`;
-export const SampleMetadataPartsFragmentDoc = gql`
-  fragment SampleMetadataParts on SampleMetadata {
-    additionalProperties
-    baitSet
-    cfDNA2dBarcode
-    cmoInfoIgoId
-    cmoPatientId
-    cmoSampleIdFields
-    cmoSampleName
-    collectionYear
-    genePanel
-    igoComplete
-    igoRequestId
-    importDate
-    investigatorSampleId
-    libraries
-    oncotreeCode
-    preservation
-    primaryId
-    qcReports
-    sampleClass
-    sampleName
-    sampleOrigin
-    sampleType
-    sex
-    species
-    tissueLocation
-    tubeId
-    tumorOrNormal
-  }
-`;
-export const TempoPartsFragmentDoc = gql`
-  fragment TempoParts on Tempo {
-    smileTempoId
-    billed
-    billedBy
-    costCenter
-    custodianInformation
-    accessLevel
-  }
-`;
 export const RequestsListDocument = gql`
   query RequestsList($options: RequestOptions, $where: RequestWhere) {
     requestsConnection(where: $where) {
@@ -13076,36 +12859,6 @@ export type DashboardSamplesQueryResult = Apollo.QueryResult<
   DashboardSamplesQuery,
   DashboardSamplesQueryVariables
 >;
-export const SamplesDocument = gql`
-  query Samples(
-    $where: SampleWhere
-    $hasMetadataSampleMetadataWhere2: SampleMetadataWhere
-    $hasMetadataSampleMetadataOptions2: SampleMetadataOptions
-  ) {
-    samples(where: $where) {
-      smileSampleId
-      revisable
-      sampleCategory
-      sampleClass
-      datasource
-      hasMetadataSampleMetadata(
-        where: $hasMetadataSampleMetadataWhere2
-        options: $hasMetadataSampleMetadataOptions2
-      ) {
-        ...SampleMetadataParts
-      }
-      hasTempoTempos {
-        ...TempoParts
-      }
-    }
-  }
-  ${SampleMetadataPartsFragmentDoc}
-  ${TempoPartsFragmentDoc}
-`;
-export type SamplesQueryResult = Apollo.QueryResult<
-  SamplesQuery,
-  SamplesQueryVariables
->;
 export const UpdateDashboardSamplesDocument = gql`
   mutation UpdateDashboardSamples(
     $newDashboardSamples: [DashboardSampleInput!]!
@@ -13129,41 +12882,6 @@ export type UpdateDashboardSamplesMutationResult =
 export type UpdateDashboardSamplesMutationOptions = Apollo.BaseMutationOptions<
   UpdateDashboardSamplesMutation,
   UpdateDashboardSamplesMutationVariables
->;
-export const UpdateSamplesDocument = gql`
-  mutation UpdateSamples(
-    $where: SampleWhere
-    $update: SampleUpdateInput
-    $connect: SampleConnectInput
-  ) {
-    updateSamples(where: $where, update: $update, connect: $connect) {
-      samples {
-        smileSampleId
-        revisable
-        datasource
-        sampleCategory
-        sampleClass
-        hasMetadataSampleMetadata {
-          ...SampleMetadataParts
-        }
-        hasTempoTempos {
-          ...TempoParts
-        }
-      }
-    }
-  }
-  ${SampleMetadataPartsFragmentDoc}
-  ${TempoPartsFragmentDoc}
-`;
-export type UpdateSamplesMutationFn = Apollo.MutationFunction<
-  UpdateSamplesMutation,
-  UpdateSamplesMutationVariables
->;
-export type UpdateSamplesMutationResult =
-  Apollo.MutationResult<UpdateSamplesMutation>;
-export type UpdateSamplesMutationOptions = Apollo.BaseMutationOptions<
-  UpdateSamplesMutation,
-  UpdateSamplesMutationVariables
 >;
 export const GetPatientIdsTripletsDocument = gql`
   query GetPatientIdsTriplets($patientIds: [String!]!) {

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -387,7 +387,7 @@ const searchFiltersConfig = [
       "sampleOrigin",
       "tissueLocation",
       "sex",
-      "cmoSampleIdFields",
+      "cmoSampleIdFields", // for searching recipe
     ],
   },
   {
@@ -410,7 +410,7 @@ function buildPartialCypherQuery({
 }) {
   // Build search filters given user's search values input. For example:
   // latestSm.primaryId =~ '(?i).*(someInput).*' OR latestSm.cmoSampleName =~ '(?i).*(someInput).* OR ...
-  let searchFilters = searchVals?.length
+  const searchFilters = searchVals?.length
     ? searchFiltersConfig
         .map((c) =>
           buildSearchFilters({
@@ -421,12 +421,6 @@ function buildPartialCypherQuery({
         )
         .join(" OR ")
     : "";
-
-  // Search inside cmoSampleIdFields.recipe instead of the entire cmoSampleIdFields JSON string
-  searchFilters = searchFilters.replace(
-    /latestSm\.cmoSampleIdFields/g,
-    "apoc.convert.fromJsonMap(latestSm.cmoSampleIdFields).recipe"
-  );
 
   // Add add'l Oncotree codes to search if user inputted "cancerTypeDetailed" or "cancerType" values
   const addlOncotreeCodeFilters = addlOncotreeCodes.length

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -58,7 +58,7 @@ export async function buildCustomSchema(ogm: OGM) {
         _source: undefined,
         { newDashboardSamples }: { newDashboardSamples: DashboardSampleInput[] }
       ) {
-        await updateAllSamplesConcurrently(newDashboardSamples, ogm);
+        updateAllSamplesConcurrently(newDashboardSamples, ogm);
 
         // Here, we're returning newDashboardSamples for simplicity. However, if we were to follow
         // GraphQL's convention, we'd return the actual resulting data from the database update. This
@@ -82,7 +82,7 @@ export async function buildCustomSchema(ogm: OGM) {
 
       # (s:Sample)-[:HAS_METADATA]->(sm:SampleMetadata)
       ## Root-level fields
-      primaryId: String
+      primaryId: String!
       cmoSampleName: String
       importDate: String
       cmoPatientId: String
@@ -146,11 +146,11 @@ export async function buildCustomSchema(ogm: OGM) {
       dashboardSamples(
         searchVals: [String]
         sampleContext: SampleContext
-      ): [DashboardSample]
+      ): [DashboardSample!]!
       dashboardSampleCount(
         searchVals: [String]
         sampleContext: SampleContext
-      ): DashboardSampleCount
+      ): DashboardSampleCount!
     }
 
     # We have to define a separate "input" type and can't reuse DashboardSample.
@@ -164,7 +164,7 @@ export async function buildCustomSchema(ogm: OGM) {
 
       # (s:Sample)-[:HAS_METADATA]->(sm:SampleMetadata)
       ## Root-level fields
-      primaryId: String
+      primaryId: String!
       cmoSampleName: String
       importDate: String
       cmoPatientId: String
@@ -248,6 +248,7 @@ async function queryDashboardSamples({
   const cypherQuery = `
   ${partialCypherQuery}
   RETURN
+    sample.smileSampleId AS smileSampleId,
     sample.revisable AS revisable,
 
     latestSm.primaryId AS primaryId,

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -4,7 +4,7 @@ import { CachedOncotreeData } from "../utils/oncotree";
 import NodeCache from "node-cache";
 import { parseJsonSafely } from "../utils/json";
 import { gql } from "apollo-server";
-import { SampleContext } from "../generated/graphql";
+import { SampleContext, DashboardSampleInput } from "../generated/graphql";
 
 const resolvers = {
   Query: {
@@ -46,6 +46,14 @@ const resolvers = {
         sampleContext,
         addlOncotreeCodes: Array.from(addlOncotreeCodes),
       });
+    },
+  },
+  Mutation: {
+    async updateDashboardSamples(
+      _source: undefined,
+      { newDashboardSamples }: { newDashboardSamples: DashboardSampleInput[] }
+    ) {
+      return newDashboardSamples; // placeholder
     },
   },
 };
@@ -131,6 +139,70 @@ const typeDefs = gql`
       searchVals: [String]
       sampleContext: SampleContext
     ): DashboardSampleCount
+  }
+
+  input DashboardSampleInput {
+    # (s:Sample)
+    smileSampleId: String
+    revisable: Boolean
+
+    # (s:Sample)-[:HAS_METADATA]->(sm:SampleMetadata)
+    ## Root-level fields
+    primaryId: String
+    cmoSampleName: String
+    importDate: String
+    cmoPatientId: String
+    investigatorSampleId: String
+    sampleType: String
+    species: String
+    genePanel: String
+    baitSet: String
+    preservation: String
+    tumorOrNormal: String
+    sampleClass: String
+    oncotreeCode: String
+    collectionYear: String
+    sampleOrigin: String
+    tissueLocation: String
+    sex: String
+    ## Custom fields
+    recipe: String
+    ## (sm:SampleMetadata)-[:HAS_STATUS]->(s:Status)
+    validationReport: String
+    validationStatus: String
+
+    # Oncotree API
+    cancerType: String
+    cancerTypeDetailed: String
+
+    ## (s:Sample)-[:HAS_TEMPO]->(t:Tempo)
+    ## Root-level fields
+    billed: Boolean
+    costCenter: String
+    billedBy: String
+    custodianInformation: String
+    accessLevel: String
+    ## Custom fields
+    initialPipelineRunDate: String
+    embargoDate: String
+    ## (t:Tempo)-[:HAS_EVENT]->(bc:BamComplete)
+    bamCompleteDate: String
+    bamCompleteStatus: String
+    ## (t:Tempo)-[:HAS_EVENT]->(mc:MafComplete)
+    mafCompleteDate: String
+    mafCompleteNormalPrimaryId: String
+    mafCompleteStatus: String
+    # (t:Tempo)-[:HAS_EVENT]->(qc:QcComplete)
+    qcCompleteDate: String
+    qcCompleteResult: String
+    qcCompleteReason: String
+    qcCompleteStatus: String
+  }
+
+  type Mutation {
+    updateDashboardSamples(
+      newDashboardSamples: [DashboardSampleInput]
+    ): [DashboardSample]
   }
 `;
 

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -18,7 +18,12 @@ export async function buildCustomSchema(ogm: OGM) {
         {
           searchVals,
           sampleContext,
-        }: { searchVals: string[]; sampleContext: SampleContext },
+          limit,
+        }: {
+          searchVals: string[];
+          sampleContext: SampleContext;
+          limit: number;
+        },
         { oncotreeCache }: ApolloServerContext
       ) {
         const addlOncotreeCodes = getAddlOtCodesMatchingCtOrCtdVals({
@@ -29,6 +34,7 @@ export async function buildCustomSchema(ogm: OGM) {
         return await queryDashboardSamples({
           searchVals,
           sampleContext,
+          limit,
           oncotreeCache,
           addlOncotreeCodes: Array.from(addlOncotreeCodes),
         });
@@ -133,10 +139,6 @@ export async function buildCustomSchema(ogm: OGM) {
       qcCompleteStatus: String
     }
 
-    type DashboardSampleCount {
-      count: Int
-    }
-
     input SampleContext {
       fieldName: String
       values: [String!]!
@@ -146,6 +148,7 @@ export async function buildCustomSchema(ogm: OGM) {
       dashboardSamples(
         searchVals: [String]
         sampleContext: SampleContext
+        limit: Int
       ): [DashboardSample!]!
       dashboardSampleCount(
         searchVals: [String]
@@ -231,11 +234,13 @@ export async function buildCustomSchema(ogm: OGM) {
 async function queryDashboardSamples({
   searchVals,
   sampleContext,
+  limit,
   oncotreeCache,
   addlOncotreeCodes,
 }: {
   searchVals: string[];
   sampleContext?: SampleContext;
+  limit: number;
   oncotreeCache: NodeCache;
   addlOncotreeCodes: string[];
 }) {
@@ -292,7 +297,7 @@ async function queryDashboardSamples({
     latestQC.status AS qcCompleteStatus
 
   ORDER BY importDate DESC
-  LIMIT 500
+  LIMIT ${limit}
   `;
 
   const session = neo4jDriver.session();

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -538,7 +538,7 @@ function getAddlOtCodesMatchingCtOrCtdVals({
   oncotreeCache: NodeCache;
 }) {
   let addlOncotreeCodes: Set<string> = new Set();
-  if (searchVals && searchVals.length > 0) {
+  if (searchVals?.length) {
     oncotreeCache.keys().forEach((code) => {
       const { name, mainType } = (oncotreeCache.get(
         code

--- a/graphql-server/src/schemas/neo4j.ts
+++ b/graphql-server/src/schemas/neo4j.ts
@@ -4,23 +4,10 @@ import { OGM } from "@neo4j/graphql-ogm";
 import { toGraphQLTypeDefs } from "@neo4j/introspector";
 import { createHttpLink } from "apollo-link-http";
 import { InMemoryCache, NormalizedCacheObject } from "apollo-cache-inmemory";
-import { props } from "../utils/constants";
-import {
-  SampleHasMetadataSampleMetadataUpdateFieldInput,
-  SampleHasTempoTemposUpdateFieldInput,
-  SampleMetadata,
-  SampleMetadataUpdateInput,
-  SampleUpdateInput,
-  SampleWhere,
-  SamplesDocument,
-  SortDirection,
-  Tempo,
-  UpdateSamplesMutationResponse,
-} from "../generated/graphql";
-import { connect, headers, StringCodec } from "nats";
+import { SortDirection } from "../generated/graphql";
 const fetch = require("node-fetch");
 const request = require("request-promise-native");
-import { ApolloClient, ApolloQueryResult } from "apollo-client";
+import { ApolloClient } from "apollo-client";
 import { gql } from "apollo-server";
 import {
   flattenedCohortFields,
@@ -102,84 +89,6 @@ function buildResolvers(
   apolloClient: ApolloClient<NormalizedCacheObject>
 ) {
   return {
-    Mutation: {
-      async updateSamples(
-        _source: any,
-        { where, update }: { where: SampleWhere; update: SampleUpdateInput }
-      ) {
-        // Grab data passed in from the frontend
-        const primaryId = where.hasMetadataSampleMetadata_SOME!.primaryId!;
-
-        const sampleKeyForUpdate = Object.keys(
-          update
-        )[0] as keyof SampleUpdateInput;
-
-        const changedFields = (
-          update[sampleKeyForUpdate] as Array<
-            | SampleHasMetadataSampleMetadataUpdateFieldInput
-            | SampleHasTempoTemposUpdateFieldInput
-          >
-        )[0].update!.node!;
-
-        // Get sample manifest from SMILE API /sampleById and update fields that were changed
-        const sampleManifest = await request(
-          props.smile_sample_endpoint + primaryId,
-          {
-            json: true,
-          }
-        );
-
-        Object.keys(changedFields).forEach((changedField) => {
-          const key = changedField as keyof SampleMetadataUpdateInput;
-          sampleManifest[key] =
-            changedFields[key as keyof typeof changedFields];
-        });
-
-        // Get the sample data from the database and update the fields that were changed
-        const updatedSamples: ApolloQueryResult<UpdateSamplesMutationResponse> =
-          await apolloClient.query({
-            query: SamplesDocument,
-            variables: {
-              where: {
-                smileSampleId: sampleManifest.smileSampleId,
-              },
-              hasMetadataSampleMetadataOptions2: {
-                sort: [{ importDate: SortDirection.Desc }],
-                limit: 1,
-              },
-            },
-          });
-
-        Object.keys(changedFields).forEach((key) => {
-          const sample = updatedSamples.data.samples[0][sampleKeyForUpdate] as
-            | SampleMetadata[]
-            | Tempo[];
-          if (Array.isArray(sample) && sample.length > 0) {
-            sample[0][key as keyof typeof sample[0]] =
-              changedFields[key as keyof typeof changedFields];
-          }
-        });
-
-        // Publish the data updates to NATS
-        if ("hasMetadataSampleMetadata" in update) {
-          await publishNatsMessageForSampleMetadataUpdates(sampleManifest, ogm);
-        } else if ("hasTempoTempos" in update) {
-          await publishNatsMessageForSampleBillingUpdates(
-            primaryId,
-            updatedSamples
-          );
-        } else {
-          throw new Error("Unknown update field");
-        }
-
-        // Return the updated samples data to enable optimistic UI updates.
-        // The shape of the data returned here doesn't fully match the shape of the data
-        // in the frontend, but it has all the fields being updated
-        return {
-          samples: updatedSamples.data.samples,
-        };
-      },
-    },
     Query: {
       async requests(_source: undefined, args: any) {
         const requests = await ogm.model("Request").find({
@@ -334,91 +243,4 @@ function buildResolvers(
     Patient: generateFieldResolvers(flattenedPatientFields, "Patient"),
     Cohort: generateFieldResolvers(flattenedCohortFields, "Cohort"),
   };
-}
-
-async function publishNatsMessageForSampleMetadataUpdates(
-  sampleManifest: any,
-  ogm: OGM
-) {
-  // remove 'status' from sample metadata to ensure validator and label
-  // generator use latest status data added during validation process
-  delete sampleManifest["status"];
-
-  // add isCmoSample to sample's 'additionalProperties' if not already present
-  // this is to ensure that cmo samples get sent to the label generator after validation
-  // since some of the older SMILE samples do not have this additionalProperty set
-  if (sampleManifest["additionalProperties"]["isCmoSample"] == null) {
-    const requestId = sampleManifest["additionalProperties"]["igoRequestId"];
-    let req = ogm.model("Request");
-    const rd = await req.find({
-      where: { igoRequestId: requestId },
-    });
-    sampleManifest["additionalProperties"]["isCmoSample"] =
-      rd[0]["isCmoRequest"].toString();
-  }
-
-  publishNatsMessage(
-    props.pub_validate_sample_update,
-    JSON.stringify(sampleManifest)
-  );
-
-  await ogm.model("Sample").update({
-    where: { smileSampleId: sampleManifest.smileSampleId },
-    update: { revisable: false },
-  });
-}
-
-async function publishNatsMessageForSampleBillingUpdates(
-  primaryId: string,
-  updatedSamples: ApolloQueryResult<UpdateSamplesMutationResponse>
-) {
-  const { billed, billedBy, costCenter, accessLevel, custodianInformation } =
-    updatedSamples.data.samples[0].hasTempoTempos[0];
-
-  const dataForTempoBillingUpdate = {
-    primaryId,
-    billed,
-    billedBy,
-    costCenter,
-    accessLevel,
-    custodianInformation,
-  };
-
-  publishNatsMessage(
-    props.pub_tempo_sample_billing,
-    JSON.stringify(dataForTempoBillingUpdate)
-  );
-}
-
-async function publishNatsMessage(topic: string, message: string) {
-  const sc = StringCodec();
-
-  const tlsOptions = {
-    keyFile: props.nats_key_pem,
-    certFile: props.nats_cert_pem,
-    caFile: props.nats_ca_pem,
-    rejectUnauthorized: false,
-  };
-
-  const natsConnProperties = {
-    servers: [props.nats_url],
-    user: props.nats_username,
-    pass: props.nats_password,
-    tls: tlsOptions,
-  };
-
-  try {
-    const natsConn = await connect(natsConnProperties);
-    console.log("Connected to server: ");
-    console.log(natsConn.getServer());
-    console.log("publishing message: ", message, "\nto topic", topic);
-    const h = headers();
-    h.append("Nats-Msg-Subject", topic);
-    natsConn.publish(topic, sc.encode(JSON.stringify(message)), { headers: h });
-  } catch (err) {
-    console.log(
-      `error connecting to ${JSON.stringify(natsConnProperties)}`,
-      err
-    );
-  }
 }

--- a/graphql-server/src/utils/servers.ts
+++ b/graphql-server/src/utils/servers.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import https from "https";
 import { props } from "./constants";
 import { buildNeo4jDbSchema } from "../schemas/neo4j";
+import { buildCustomSchema } from "../schemas/custom";
 import { mergeSchemas } from "@graphql-tools/schema";
 import { oracleDbSchema } from "../schemas/oracle";
 import { ApolloServer } from "apollo-server-express";
@@ -14,7 +15,6 @@ import { updateActiveUserSessions } from "./session";
 import { corsOptions } from "./constants";
 import NodeCache from "node-cache";
 import { fetchAndCacheOncotreeData } from "./oncotree";
-import { customSchema } from "../schemas/custom";
 import neo4j from "neo4j-driver";
 
 export function initializeHttpsServer(app: Express) {
@@ -48,6 +48,7 @@ export async function initializeApolloServer(
   app: Express
 ) {
   const { neo4jDbSchema, ogm } = await buildNeo4jDbSchema();
+  const customSchema = await buildCustomSchema(ogm);
   const mergedSchema = mergeSchemas({
     schemas: [neo4jDbSchema, oracleDbSchema, customSchema],
   });

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -17729,18 +17729,6 @@
         "description": null,
         "fields": [
           {
-            "name": "count",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "totalCount",
             "description": null,
             "args": [],
@@ -45439,6 +45427,18 @@
             "name": "dashboardSamples",
             "description": null,
             "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
               {
                 "name": "sampleContext",
                 "description": null,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -17751,6 +17751,497 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "DashboardSampleInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "accessLevel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "baitSet",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bamCompleteDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bamCompleteStatus",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billed",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billedBy",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerType",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cancerTypeDetailed",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoPatientId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cmoSampleName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "collectionYear",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costCenter",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custodianInformation",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "embargoDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "genePanel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "importDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initialPipelineRunDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorSampleId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mafCompleteDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mafCompleteNormalPrimaryId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mafCompleteStatus",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oncotreeCode",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "preservation",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "primaryId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcCompleteDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcCompleteReason",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcCompleteResult",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcCompleteStatus",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipe",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revisable",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sampleClass",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sampleOrigin",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sampleType",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sex",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "smileSampleId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "species",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tissueLocation",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tumorOrNormal",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validationReport",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validationStatus",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "DeleteInfo",
         "description": null,
@@ -22806,6 +23297,39 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "UpdateCohortsMutationResponse",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateDashboardSamples",
+            "description": null,
+            "args": [
+              {
+                "name": "newDashboardSamples",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "DashboardSampleInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DashboardSample",
                 "ofType": null
               }
             },

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -17711,7 +17711,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "String",
+              "name": "Boolean",
               "ofType": null
             },
             "isDeprecated": false,
@@ -18257,7 +18257,7 @@
             "description": null,
             "type": {
               "kind": "SCALAR",
-              "name": "String",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -45401,9 +45401,13 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
                   }
                 },
                 "defaultValue": null,
@@ -45431,9 +45435,13 @@
                 "name": "limit",
                 "description": null,
                 "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -45458,9 +45466,13 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
                   }
                 },
                 "defaultValue": null,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -17642,9 +17642,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -17847,6 +17851,30 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "changedFieldNames",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -18168,9 +18196,13 @@
             "name": "smileSampleId",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -17510,9 +17510,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -18064,9 +18068,13 @@
             "name": "primaryId",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -45416,9 +45424,13 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "DashboardSampleCount",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DashboardSampleCount",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -45457,12 +45469,20 @@
               }
             ],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "DashboardSample",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DashboardSample",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -140,76 +140,6 @@ fragment RequestParts on Request {
   smileRequestId
 }
 
-fragment SampleParts on Sample {
-  datasource
-  revisable
-  sampleCategory
-  sampleClass
-  smileSampleId
-}
-
-fragment SampleMetadataParts on SampleMetadata {
-  additionalProperties
-  baitSet
-  cfDNA2dBarcode
-  cmoInfoIgoId
-  cmoPatientId
-  cmoSampleIdFields
-  cmoSampleName
-  collectionYear
-  genePanel
-  igoComplete
-  igoRequestId
-  importDate
-  investigatorSampleId
-  libraries
-  oncotreeCode
-  preservation
-  primaryId
-  qcReports
-  sampleClass
-  sampleName
-  sampleOrigin
-  sampleType
-  sex
-  species
-  tissueLocation
-  tubeId
-  tumorOrNormal
-}
-
-fragment TempoParts on Tempo {
-  smileTempoId
-  billed
-  billedBy
-  costCenter
-  custodianInformation
-  accessLevel
-}
-
-query Samples(
-  $where: SampleWhere
-  $hasMetadataSampleMetadataWhere2: SampleMetadataWhere
-  $hasMetadataSampleMetadataOptions2: SampleMetadataOptions
-) {
-  samples(where: $where) {
-    smileSampleId
-    revisable
-    sampleCategory
-    sampleClass
-    datasource
-    hasMetadataSampleMetadata(
-      where: $hasMetadataSampleMetadataWhere2
-      options: $hasMetadataSampleMetadataOptions2
-    ) {
-      ...SampleMetadataParts
-    }
-    hasTempoTempos {
-      ...TempoParts
-    }
-  }
-}
-
 mutation UpdateDashboardSamples(
   $newDashboardSamples: [DashboardSampleInput!]!
 ) {
@@ -217,28 +147,6 @@ mutation UpdateDashboardSamples(
     ...DashboardSampleParts
     ...DashboardSampleMetadataParts
     ...DashboardTempoParts
-  }
-}
-
-mutation UpdateSamples(
-  $where: SampleWhere
-  $update: SampleUpdateInput
-  $connect: SampleConnectInput
-) {
-  updateSamples(where: $where, update: $update, connect: $connect) {
-    samples {
-      smileSampleId
-      revisable
-      datasource
-      sampleCategory
-      sampleClass
-      hasMetadataSampleMetadata {
-        ...SampleMetadataParts
-      }
-      hasTempoTempos {
-        ...TempoParts
-      }
-    }
   }
 }
 

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -46,11 +46,19 @@ query PatientsList($options: PatientOptions, $where: PatientWhere) {
   }
 }
 
-query DashboardSamples($searchVals: [String], $sampleContext: SampleContext) {
+query DashboardSamples(
+  $searchVals: [String]
+  $sampleContext: SampleContext
+  $limit: Int
+) {
   dashboardSampleCount(searchVals: $searchVals, sampleContext: $sampleContext) {
     totalCount
   }
-  dashboardSamples(searchVals: $searchVals, sampleContext: $sampleContext) {
+  dashboardSamples(
+    searchVals: $searchVals
+    sampleContext: $sampleContext
+    limit: $limit
+  ) {
     ...DashboardSampleParts
     ...DashboardSampleMetadataParts
     ...DashboardTempoParts

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -47,9 +47,9 @@ query PatientsList($options: PatientOptions, $where: PatientWhere) {
 }
 
 query DashboardSamples(
-  $searchVals: [String]
+  $searchVals: [String!]
   $sampleContext: SampleContext
-  $limit: Int
+  $limit: Int!
 ) {
   dashboardSampleCount(searchVals: $searchVals, sampleContext: $sampleContext) {
     totalCount

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -210,6 +210,16 @@ query Samples(
   }
 }
 
+mutation UpdateDashboardSamples(
+  $newDashboardSamples: [DashboardSampleInput!]!
+) {
+  updateDashboardSamples(newDashboardSamples: $newDashboardSamples) {
+    ...DashboardSampleParts
+    ...DashboardSampleMetadataParts
+    ...DashboardTempoParts
+  }
+}
+
 mutation UpdateSamples(
   $where: SampleWhere
   $update: SampleUpdateInput


### PR DESCRIPTION
For card [#1280](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1280). This PR also addresses the following bugs:
- [x] Re-enable users' ability to download >500 and <5,000 samples. Right now, users can either download up to 500 or not at all
- [x] Fix exported file to show only the non-hidden columns
- [x] Samples not showing TEMPO events ([#1287](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1287))

TODOs for a future PR:
- [ ] Resolve the duplicate tableElements.tsx files