### PR TITLE
Implement infinite scrolling for the Sample views

### DIFF
--- a/frontend/src/components/AlertModal.tsx
+++ b/frontend/src/components/AlertModal.tsx
@@ -5,7 +5,7 @@ import Modal from "react-bootstrap/Modal";
 export const AlertModal: FunctionComponent<{
   show: boolean;
   title: string;
-  content: string;
+  content: string | null;
   onHide: () => void;
 }> = ({ show, title, content, onHide }) => {
   return (

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -30,6 +30,8 @@ import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
 import { BreadCrumb } from "../shared/components/BreadCrumb";
 import { Title } from "../shared/components/Title";
 
+const CACHE_BLOCK_SIZE = 100;
+
 interface IRecordsListProps {
   colDefs: ColDef[];
   dataName: DataName;
@@ -101,7 +103,7 @@ export default function RecordsList({
     lazyRecordsQuery({
       variables: {
         options: {
-          limit: 20,
+          limit: CACHE_BLOCK_SIZE,
           offset: 0,
           sort: defaultSort,
         },
@@ -314,7 +316,7 @@ export default function RecordsList({
               columnDefs={colDefs}
               serverSideDatasource={datasource}
               serverSideInfiniteScroll={enableInfiniteScroll}
-              cacheBlockSize={20}
+              cacheBlockSize={CACHE_BLOCK_SIZE}
               debug={false}
               context={{
                 navigateFunction: navigate,

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -121,8 +121,10 @@ export default function SamplesList({
           .then((result) => {
             successCallback(
               result.data.dashboardSamples,
-              result.data.dashboardSampleCount.totalCount ?? 0
+              result.data.dashboardSampleCount.totalCount
             );
+
+            setSampleCount(result.data.dashboardSampleCount.totalCount);
           })
           .catch(() => {
             failCallback();

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -56,7 +56,6 @@ interface ISampleListProps {
 }
 
 // TODOs
-// - Replace usage of the old `samples` variable
 // - Fix random rows' height expanding when loading new rows
 // - Investigate console error "AG Grid: ImmutableService only works with ClientSideRowModel"
 // - Test
@@ -372,9 +371,6 @@ export default function SamplesList({
               rowModelType="serverSide"
               serverSideInfiniteScroll={true}
               cacheBlockSize={CACHE_BLOCK_SIZE}
-              getRowId={(params) => {
-                return params.data.primaryId;
-              }}
               rowClassRules={{
                 unlocked: function (params) {
                   return params.data?.revisable === true;
@@ -391,7 +387,6 @@ export default function SamplesList({
                 },
               }}
               columnDefs={columnDefs}
-              rowData={samples!}
               onCellEditRequest={onCellValueChanged}
               readOnlyEdit={true}
               defaultColDef={defaultColDef}

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -15,6 +15,7 @@ import { buildTsvString } from "../utils/stringBuilders";
 import {
   SampleChange,
   defaultColDef,
+  formatDate,
   isValidCostCenter,
 } from "../shared/helpers";
 import { AgGridReact } from "ag-grid-react";
@@ -260,7 +261,7 @@ export default function SamplesList({
         return {
           ...s,
           revisable: false,
-          importDate: new Date().toISOString().split("T")[0],
+          importDate: formatDate(new Date()) as string,
           ...changesByPrimaryId[s.primaryId],
         };
       }

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -81,6 +81,7 @@ export default function SamplesList({
         searchVals: [],
         sampleContext,
         limit: MAX_ROWS_TABLE,
+        offset: 0,
       },
       pollInterval: POLLING_INTERVAL,
     });

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -261,19 +261,20 @@ export default function SamplesList({
 
       {showDownloadModal && (
         <DownloadModal
-          loader={() => {
-            const allColumns = gridRef.current?.columnApi?.getAllGridColumns();
-            return sampleCount <= CACHE_BLOCK_SIZE
-              ? Promise.resolve(
-                  buildTsvString(samples!, columnDefs, allColumns)
-                )
-              : refetch({ limit: MAX_ROWS_EXPORT }).then((result) =>
-                  buildTsvString(
-                    result.data.dashboardSamples!,
-                    columnDefs,
-                    allColumns
-                  )
-                );
+          loader={async () => {
+            const { data } = await fetchMore({
+              variables: {
+                searchVals: parseUserSearchVal(userSearchVal),
+                sampleContext,
+                offset: 0,
+                limit: MAX_ROWS_EXPORT,
+              },
+            });
+            return buildTsvString(
+              data.dashboardSamples,
+              columnDefs,
+              gridRef.current?.columnApi?.getAllGridColumns()
+            );
           }}
           onComplete={() => {
             setShowDownloadModal(false);
@@ -374,7 +375,6 @@ export default function SamplesList({
               getRowId={(params) => {
                 return params.data.primaryId;
               }}
-              debug={true}
               rowClassRules={{
                 unlocked: function (params) {
                   return params.data?.revisable === true;

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -65,7 +65,6 @@ export default function SamplesList({
   customToolbarUI,
 }: ISampleListProps) {
   const [userSearchVal, setUserSearchVal] = useState<string>("");
-  const [sampleCount, setSampleCount] = useState(0);
   const [changes, setChanges] = useState<SampleChange[]>([]);
 
   const [showDownloadModal, setShowDownloadModal] = useState(false);
@@ -88,6 +87,7 @@ export default function SamplesList({
     });
 
   const samples = data?.dashboardSamples;
+  const sampleCount = data?.dashboardSampleCount.totalCount;
 
   const createDatasource = useCallback(
     ({ userSearchVal, sampleContext }) => {
@@ -109,7 +109,6 @@ export default function SamplesList({
 
           return thisFetch
             .then((result) => {
-              setSampleCount(result.data.dashboardSampleCount.totalCount);
               params.success({
                 rowData: result.data.dashboardSamples,
                 rowCount: result.data.dashboardSampleCount.totalCount,
@@ -341,7 +340,7 @@ export default function SamplesList({
           sampleCount ? sampleCount.toLocaleString() : "Loading"
         } matching samples`}
         handleDownload={() => {
-          if (sampleCount > MAX_ROWS_EXPORT) {
+          if (sampleCount && sampleCount > MAX_ROWS_EXPORT) {
             setAlertContent(MAX_ROWS_EXPORT_EXCEED_ALERT);
           } else {
             setShowDownloadModal(true);
@@ -434,9 +433,6 @@ export default function SamplesList({
               }}
               tooltipShowDelay={0}
               tooltipHideDelay={60000}
-              onFilterChanged={(params) => {
-                setSampleCount(params.api.getDisplayedRowCount());
-              }}
               onGridColumnsChanged={() => refreshData(userSearchVal)}
             />
           </div>

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -33,7 +33,7 @@ import { DataName } from "../shared/types";
 import { parseUserSearchVal } from "../utils/parseSearchQueries";
 
 const POLLING_INTERVAL = 5000; // 5s
-const CACHE_BLOCK_SIZE = 20; // number of rows to fetch at a time
+const CACHE_BLOCK_SIZE = 100; // number of rows to fetch at a time
 const MAX_ROWS_EXPORT = 5000;
 const MAX_ROWS_EXPORT_EXCEED_ALERT =
   "You can only download up to 5,000 rows of data at a time. Please refine your search and try again. If you need the full dataset, contact the SMILE team at cmosmile@mskcc.org.";
@@ -54,11 +54,6 @@ interface ISampleListProps {
   setUserEmail?: Dispatch<SetStateAction<string | null>>;
   customToolbarUI?: JSX.Element;
 }
-
-// TODOs
-// - Fix random rows' height expanding when loading new rows
-// - Investigate console error "AG Grid: ImmutableService only works with ClientSideRowModel"
-// - Test
 
 export default function SamplesList({
   columnDefs,

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -261,6 +261,7 @@ export default function SamplesList({
       {showDownloadModal && (
         <DownloadModal
           loader={async () => {
+            // Using fetchMore instead of refetch to avoid overriding the cached variables
             const { data } = await fetchMore({
               variables: {
                 searchVals: parseUserSearchVal(userSearchVal),
@@ -275,12 +276,7 @@ export default function SamplesList({
               gridRef.current?.columnApi?.getAllGridColumns()
             );
           }}
-          onComplete={() => {
-            setShowDownloadModal(false);
-            // Reset the limit back to the default value of MAX_ROWS_TABLE.
-            // Otherwise, polling will use the most recent value MAX_ROWS_EXPORT
-            refetch({ limit: CACHE_BLOCK_SIZE });
-          }}
+          onComplete={() => setShowDownloadModal(false)}
           exportFileName={[
             parentDataName?.slice(0, -1),
             Object.values(params)?.[0],

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -230,6 +230,11 @@ export default function SamplesList({
   }
 
   const handleDiscardChanges = () => {
+    // Remove cell styles associated with having been edited
+    gridRef.current?.api?.redrawRows({
+      rowNodes: changes.map((c) => c.rowNode),
+    });
+
     setEditMode(false);
 
     setTimeout(() => {

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -226,6 +226,10 @@ export default function SamplesList({
   }
 
   async function handleConfirmUpdates() {
+    // Manually handle optimistic updates
+    // (We can't use GraphQL's optimistic response because it isn't a good fit for
+    // AG Grid's Server-Side data model. e.g. GraphQL's optimistic response only returns
+    // the updated data, while AG Grid expects the datasource == the entire dataset.)
     const changesByPrimaryId = groupChangesByPrimaryId(changes);
     const optimisticSamples = samples?.map((s) => {
       if (s.primaryId in changesByPrimaryId) {

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -99,7 +99,7 @@ export default function SamplesList({
   const samples = data?.dashboardSamples;
   const sampleCount = data?.dashboardSampleCount.totalCount;
 
-  const createDatasource = useCallback(
+  const getServerSideDatasource = useCallback(
     ({ userSearchVal, sampleContext }) => {
       return {
         getRows: async (params: IServerSideGetRowsParams) => {
@@ -138,7 +138,7 @@ export default function SamplesList({
   );
 
   async function refreshData(userSearchVal: string) {
-    const newDatasource = createDatasource({
+    const newDatasource = getServerSideDatasource({
       userSearchVal,
       sampleContext,
     });

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -1,6 +1,5 @@
 import {
   AgGridSortDirection,
-  DashboardSample,
   DashboardSampleFilter,
   DashboardSampleSort,
   QueryDashboardSamplesArgs,

--- a/frontend/src/components/UpdateModal.tsx
+++ b/frontend/src/components/UpdateModal.tsx
@@ -73,9 +73,6 @@ export function UpdateModal({
 
     updateDashboardSamplesMutation({
       variables: { newDashboardSamples },
-      optimisticResponse: {
-        updateDashboardSamples: newDashboardSamples,
-      },
     });
 
     onSuccess();

--- a/frontend/src/components/UpdateModal.tsx
+++ b/frontend/src/components/UpdateModal.tsx
@@ -49,14 +49,7 @@ export function UpdateModal({
   const [updateDashboardSamplesMutation] = useUpdateDashboardSamplesMutation();
 
   async function handleSubmitUpdates() {
-    const changesByPrimaryId: ChangesByPrimaryId = {};
-    for (const { primaryId, fieldName, newValue } of changes) {
-      if (changesByPrimaryId[primaryId]) {
-        changesByPrimaryId[primaryId][fieldName] = newValue;
-      } else {
-        changesByPrimaryId[primaryId] = { [fieldName]: newValue };
-      }
-    }
+    const changesByPrimaryId = groupChangesByPrimaryId(changes);
 
     let newDashboardSamples: DashboardSampleInput[] = [];
     samples.forEach((s) => {
@@ -133,4 +126,16 @@ export function UpdateModal({
       </Modal.Footer>
     </Modal>
   );
+}
+
+export function groupChangesByPrimaryId(changes: SampleChange[]) {
+  const changesByPrimaryId: ChangesByPrimaryId = {};
+  for (const { primaryId, fieldName, newValue } of changes) {
+    if (changesByPrimaryId[primaryId]) {
+      changesByPrimaryId[primaryId][fieldName] = newValue;
+    } else {
+      changesByPrimaryId[primaryId] = { [fieldName]: newValue };
+    }
+  }
+  return changesByPrimaryId;
 }

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1786,7 +1786,7 @@ export type DashboardSample = {
 
 export type DashboardSampleCount = {
   __typename?: "DashboardSampleCount";
-  totalCount?: Maybe<Scalars["Int"]>;
+  totalCount: Scalars["Int"];
 };
 
 export type DashboardSampleInput = {
@@ -12472,7 +12472,7 @@ export type DashboardSamplesQuery = {
   __typename?: "Query";
   dashboardSampleCount: {
     __typename?: "DashboardSampleCount";
-    totalCount?: number | null;
+    totalCount: number;
   };
   dashboardSamples: Array<{
     __typename?: "DashboardSample";

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1799,6 +1799,11 @@ export type DashboardSampleCount = {
   totalCount: Scalars["Int"];
 };
 
+export type DashboardSampleFilter = {
+  field: Scalars["String"];
+  values: Array<Scalars["String"]>;
+};
+
 export type DashboardSampleInput = {
   accessLevel?: InputMaybe<Scalars["String"]>;
   baitSet?: InputMaybe<Scalars["String"]>;
@@ -4622,11 +4627,13 @@ export type QueryCohortsConnectionArgs = {
 };
 
 export type QueryDashboardSampleCountArgs = {
+  filter?: InputMaybe<DashboardSampleFilter>;
   sampleContext?: InputMaybe<DashboardSampleContext>;
   searchVals?: InputMaybe<Array<Scalars["String"]>>;
 };
 
 export type QueryDashboardSamplesArgs = {
+  filter?: InputMaybe<DashboardSampleFilter>;
   limit: Scalars["Int"];
   offset: Scalars["Int"];
   sampleContext?: InputMaybe<DashboardSampleContext>;
@@ -12476,6 +12483,7 @@ export type DashboardSamplesQueryVariables = Exact<{
   searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
   sampleContext?: InputMaybe<DashboardSampleContext>;
   sort: DashboardSampleSort;
+  filter?: InputMaybe<DashboardSampleFilter>;
   limit: Scalars["Int"];
   offset: Scalars["Int"];
 }>;
@@ -12952,12 +12960,14 @@ export const DashboardSamplesDocument = gql`
     $searchVals: [String!]
     $sampleContext: DashboardSampleContext
     $sort: DashboardSampleSort!
+    $filter: DashboardSampleFilter
     $limit: Int!
     $offset: Int!
   ) {
     dashboardSampleCount(
       searchVals: $searchVals
       sampleContext: $sampleContext
+      filter: $filter
     ) {
       totalCount
     }
@@ -12965,6 +12975,7 @@ export const DashboardSamplesDocument = gql`
       searchVals: $searchVals
       sampleContext: $sampleContext
       sort: $sort
+      filter: $filter
       limit: $limit
       offset: $offset
     ) {
@@ -12993,6 +13004,7 @@ export const DashboardSamplesDocument = gql`
  *      searchVals: // value for 'searchVals'
  *      sampleContext: // value for 'sampleContext'
  *      sort: // value for 'sort'
+ *      filter: // value for 'filter'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *   },

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -4613,6 +4613,7 @@ export type QueryDashboardSampleCountArgs = {
 
 export type QueryDashboardSamplesArgs = {
   limit: Scalars["Int"];
+  offset: Scalars["Int"];
   sampleContext?: InputMaybe<SampleContext>;
   searchVals?: InputMaybe<Array<Scalars["String"]>>;
 };
@@ -12464,6 +12465,7 @@ export type DashboardSamplesQueryVariables = Exact<{
   searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
   sampleContext?: InputMaybe<SampleContext>;
   limit: Scalars["Int"];
+  offset: Scalars["Int"];
 }>;
 
 export type DashboardSamplesQuery = {
@@ -12938,6 +12940,7 @@ export const DashboardSamplesDocument = gql`
     $searchVals: [String!]
     $sampleContext: SampleContext
     $limit: Int!
+    $offset: Int!
   ) {
     dashboardSampleCount(
       searchVals: $searchVals
@@ -12949,6 +12952,7 @@ export const DashboardSamplesDocument = gql`
       searchVals: $searchVals
       sampleContext: $sampleContext
       limit: $limit
+      offset: $offset
     ) {
       ...DashboardSampleParts
       ...DashboardSampleMetadataParts
@@ -12975,6 +12979,7 @@ export const DashboardSamplesDocument = gql`
  *      searchVals: // value for 'searchVals'
  *      sampleContext: // value for 'sampleContext'
  *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
  *   },
  * });
  */

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -21,6 +21,11 @@ export type Scalars = {
   Float: number;
 };
 
+export enum AgGridSortDirection {
+  Asc = "asc",
+  Desc = "desc",
+}
+
 export type BamComplete = {
   __typename?: "BamComplete";
   date: Scalars["String"];
@@ -1784,6 +1789,11 @@ export type DashboardSample = {
   validationStatus?: Maybe<Scalars["Boolean"]>;
 };
 
+export type DashboardSampleContext = {
+  fieldName?: InputMaybe<Scalars["String"]>;
+  values: Array<Scalars["String"]>;
+};
+
 export type DashboardSampleCount = {
   __typename?: "DashboardSampleCount";
   totalCount: Scalars["Int"];
@@ -1831,6 +1841,11 @@ export type DashboardSampleInput = {
   tumorOrNormal?: InputMaybe<Scalars["String"]>;
   validationReport?: InputMaybe<Scalars["String"]>;
   validationStatus?: InputMaybe<Scalars["Boolean"]>;
+};
+
+export type DashboardSampleSort = {
+  colId: Scalars["String"];
+  sort: AgGridSortDirection;
 };
 
 export type DeleteInfo = {
@@ -4607,15 +4622,16 @@ export type QueryCohortsConnectionArgs = {
 };
 
 export type QueryDashboardSampleCountArgs = {
-  sampleContext?: InputMaybe<SampleContext>;
+  sampleContext?: InputMaybe<DashboardSampleContext>;
   searchVals?: InputMaybe<Array<Scalars["String"]>>;
 };
 
 export type QueryDashboardSamplesArgs = {
   limit: Scalars["Int"];
   offset: Scalars["Int"];
-  sampleContext?: InputMaybe<SampleContext>;
+  sampleContext?: InputMaybe<DashboardSampleContext>;
   searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  sort: DashboardSampleSort;
 };
 
 export type QueryMafCompletesArgs = {
@@ -7476,11 +7492,6 @@ export type SampleConnectInput = {
 
 export type SampleConnectWhere = {
   node: SampleWhere;
-};
-
-export type SampleContext = {
-  fieldName?: InputMaybe<Scalars["String"]>;
-  values: Array<Scalars["String"]>;
 };
 
 export type SampleCreateInput = {
@@ -12463,7 +12474,8 @@ export type PatientsListQuery = {
 
 export type DashboardSamplesQueryVariables = Exact<{
   searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
-  sampleContext?: InputMaybe<SampleContext>;
+  sampleContext?: InputMaybe<DashboardSampleContext>;
+  sort: DashboardSampleSort;
   limit: Scalars["Int"];
   offset: Scalars["Int"];
 }>;
@@ -12938,7 +12950,8 @@ export type PatientsListQueryResult = Apollo.QueryResult<
 export const DashboardSamplesDocument = gql`
   query DashboardSamples(
     $searchVals: [String!]
-    $sampleContext: SampleContext
+    $sampleContext: DashboardSampleContext
+    $sort: DashboardSampleSort!
     $limit: Int!
     $offset: Int!
   ) {
@@ -12951,6 +12964,7 @@ export const DashboardSamplesDocument = gql`
     dashboardSamples(
       searchVals: $searchVals
       sampleContext: $sampleContext
+      sort: $sort
       limit: $limit
       offset: $offset
     ) {
@@ -12978,6 +12992,7 @@ export const DashboardSamplesDocument = gql`
  *   variables: {
  *      searchVals: // value for 'searchVals'
  *      sampleContext: // value for 'sampleContext'
+ *      sort: // value for 'sort'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *   },

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1762,7 +1762,7 @@ export type DashboardSample = {
   custodianInformation?: Maybe<Scalars["String"]>;
   embargoDate?: Maybe<Scalars["String"]>;
   genePanel?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
+  importDate: Scalars["String"];
   initialPipelineRunDate?: Maybe<Scalars["String"]>;
   investigatorSampleId?: Maybe<Scalars["String"]>;
   mafCompleteDate?: Maybe<Scalars["String"]>;
@@ -1821,7 +1821,7 @@ export type DashboardSampleInput = {
   custodianInformation?: InputMaybe<Scalars["String"]>;
   embargoDate?: InputMaybe<Scalars["String"]>;
   genePanel?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["String"]>;
+  importDate: Scalars["String"];
   initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
   investigatorSampleId?: InputMaybe<Scalars["String"]>;
   mafCompleteDate?: InputMaybe<Scalars["String"]>;
@@ -12500,7 +12500,7 @@ export type DashboardSamplesQuery = {
     revisable?: boolean | null;
     primaryId: string;
     cmoSampleName?: string | null;
-    importDate?: string | null;
+    importDate: string;
     cmoPatientId?: string | null;
     investigatorSampleId?: string | null;
     sampleType?: string | null;
@@ -12549,7 +12549,7 @@ export type DashboardSampleMetadataPartsFragment = {
   __typename?: "DashboardSample";
   primaryId: string;
   cmoSampleName?: string | null;
-  importDate?: string | null;
+  importDate: string;
   cmoPatientId?: string | null;
   investigatorSampleId?: string | null;
   sampleType?: string | null;
@@ -12625,7 +12625,7 @@ export type UpdateDashboardSamplesMutation = {
     revisable?: boolean | null;
     primaryId: string;
     cmoSampleName?: string | null;
-    importDate?: string | null;
+    importDate: string;
     cmoPatientId?: string | null;
     investigatorSampleId?: string | null;
     sampleType?: string | null;

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -833,7 +833,7 @@ export function handleSearch(
   setParsedSearchVals(parsedSearchVals);
 }
 
-function formatDate(date: moment.MomentInput) {
+export function formatDate(date: moment.MomentInput) {
   return date ? moment(date).format("YYYY-MM-DD") : null;
 }
 

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -703,10 +703,9 @@ export const WesSampleDetailsColumns: ColDef[] = [
           return "";
       }
     },
-    filter: true,
+    filter: "agSetColumnFilter",
     filterParams: {
-      valueFormatter: (params: ValueFormatterParams) =>
-        params.value === "true" ? "Yes" : "No",
+      values: ["Yes", "No"],
       suppressMiniFilter: true,
     },
   },

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -203,6 +203,12 @@ const ONCOTREE_CODE_NA_TOOLTIP =
 
 export const SampleMetadataDetailsColumns: ColDef[] = [
   {
+    headerName: "Row",
+    valueGetter: (params) => {
+      return params.node?.rowIndex!;
+    },
+  },
+  {
     field: "primaryId",
     headerName: "Primary ID",
   },
@@ -461,7 +467,7 @@ function setupEditableSampleFields(samplesColDefs: ColDef[]) {
         if (changedValue) {
           return changedValue.newValue;
         } else {
-          if (params?.colDef?.field! in params.data!) {
+          if (params.data && params?.colDef?.field! in params.data!) {
             return params.data?.[params.colDef?.field!];
           } else {
             return "N/A";

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -204,16 +204,6 @@ export const SampleMetadataDetailsColumns: ColDef[] = [
   {
     field: "primaryId",
     headerName: "Primary ID",
-    cellRenderer: (params: ICellRendererParams) => {
-      if (params.value === undefined) {
-        return (
-          <>
-            <LoadingIcon /> Loading...
-          </>
-        );
-      }
-      return params.value;
-    },
   },
   {
     field: "revisable",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -4,7 +4,6 @@ import {
   IHeaderParams,
   RowNode,
   ITooltipParams,
-  ValueFormatterParams,
   IServerSideGetRowsRequest,
   CellClassParams,
 } from "ag-grid-community";
@@ -343,6 +342,7 @@ export const SampleMetadataDetailsColumns: ColDef[] = [
         return ONCOTREE_CODE_NA_TOOLTIP;
       }
     },
+    sortable: false,
   },
   {
     field: "cancerTypeDetailed",
@@ -360,6 +360,7 @@ export const SampleMetadataDetailsColumns: ColDef[] = [
         return ONCOTREE_CODE_NA_TOOLTIP;
       }
     },
+    sortable: false,
   },
   {
     field: "collectionYear",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -203,28 +203,34 @@ const ONCOTREE_CODE_NA_TOOLTIP =
 
 export const SampleMetadataDetailsColumns: ColDef[] = [
   {
-    headerName: "Row",
-    valueGetter: (params) => {
-      return params.node?.rowIndex!;
-    },
-  },
-  {
     field: "primaryId",
     headerName: "Primary ID",
+    cellRenderer: (params: ICellRendererParams) => {
+      if (params.value === undefined) {
+        return (
+          <>
+            <LoadingIcon /> Loading...
+          </>
+        );
+      }
+      return params.value;
+    },
   },
   {
     field: "revisable",
     headerName: "Status",
     cellRenderer: (params: ICellRendererParams) => {
-      if (params.data?.revisable) {
+      if (params.data?.revisable === true) {
         return params.data?.validationStatus === false ? (
           <WarningIcon />
         ) : (
           <CheckIcon />
         );
-      } else {
+      }
+      if (params.data?.revisable === false) {
         return <LoadingIcon />;
       }
+      return null;
     },
     tooltipComponent: StatusTooltip,
     // This prop is required for tooltip to appear even though we're not using it
@@ -457,20 +463,22 @@ function setupEditableSampleFields(samplesColDefs: ColDef[]) {
 
     if (colDef.valueGetter === undefined) {
       colDef.valueGetter = (params) => {
-        const changes: SampleChange[] = params.context?.getChanges();
-        const changedValue = changes?.find((change) => {
-          return (
-            change.fieldName === params.colDef.field &&
-            change.primaryId === params.data?.primaryId
-          );
-        });
-        if (changedValue) {
-          return changedValue.newValue;
-        } else {
-          if (params.data && params?.colDef?.field! in params.data!) {
-            return params.data?.[params.colDef?.field!];
+        if (params.data && params.colDef.field) {
+          const changes: SampleChange[] = params.context.getChanges();
+          const changedValue = changes.find((change) => {
+            return (
+              change.fieldName === params.colDef.field &&
+              change.primaryId === params.data.primaryId
+            );
+          });
+          if (changedValue) {
+            return changedValue.newValue;
           } else {
-            return "N/A";
+            if (params.colDef.field in params.data) {
+              return params.data[params.colDef.field];
+            } else {
+              return "N/A";
+            }
           }
         }
       };

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -442,7 +442,7 @@ function setupEditableSampleFields(samplesColDefs: ColDef[]) {
   samplesColDefs.forEach((colDef) => {
     const newClassRule = {
       unsubmittedChange: (params: CellClassParams) => {
-        const changes: SampleChange[] = params.context.getChanges();
+        const changes: SampleChange[] = params.context?.getChanges();
         const changedValue = changes?.find((change) => {
           return (
             change.fieldName === params.colDef.field &&
@@ -464,8 +464,8 @@ function setupEditableSampleFields(samplesColDefs: ColDef[]) {
     if (colDef.valueGetter === undefined) {
       colDef.valueGetter = (params) => {
         if (params.data && params.colDef.field) {
-          const changes: SampleChange[] = params.context.getChanges();
-          const changedValue = changes.find((change) => {
+          const changes: SampleChange[] = params.context?.getChanges();
+          const changedValue = changes?.find((change) => {
             return (
               change.fieldName === params.colDef.field &&
               change.primaryId === params.data.primaryId

--- a/frontend/src/shared/tableElements.tsx
+++ b/frontend/src/shared/tableElements.tsx
@@ -26,7 +26,7 @@ interface IToolbarProps {
   dataName: DataName;
   userSearchVal: string;
   setUserSearchVal: Dispatch<SetStateAction<string>>;
-  handleSearch: (userSearchVal: string) => void;
+  refreshData: (userSearchVal: string) => void;
   matchingResultsCount: string;
   handleDownload: () => void;
   customUILeft?: JSX.Element;
@@ -37,7 +37,7 @@ export function Toolbar({
   dataName,
   userSearchVal,
   setUserSearchVal,
-  handleSearch,
+  refreshData,
   matchingResultsCount,
   handleDownload,
   customUILeft,
@@ -57,15 +57,15 @@ export function Toolbar({
           value={userSearchVal}
           onKeyDown={(event) => {
             if (event.key === "Enter") {
-              handleSearch(userSearchVal);
+              refreshData(userSearchVal);
             }
           }}
           onInput={(event) => {
             const userSearchVal = event.currentTarget.value;
-            if (userSearchVal === "") {
-              handleSearch(userSearchVal);
-            }
             setUserSearchVal(userSearchVal);
+            if (userSearchVal === "") {
+              refreshData("");
+            }
           }}
         />
       </Col>
@@ -82,7 +82,7 @@ export function Toolbar({
 
       <Col md="auto" style={{ marginLeft: -15 }}>
         <Button
-          onClick={() => handleSearch(userSearchVal)}
+          onClick={() => refreshData(userSearchVal)}
           className={"btn btn-secondary"}
           size={"sm"}
         >

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -20,6 +20,11 @@ export type Scalars = {
   Float: number;
 };
 
+export enum AgGridSortDirection {
+  Asc = "asc",
+  Desc = "desc",
+}
+
 export type BamComplete = {
   __typename?: "BamComplete";
   date: Scalars["String"];
@@ -1783,6 +1788,11 @@ export type DashboardSample = {
   validationStatus?: Maybe<Scalars["Boolean"]>;
 };
 
+export type DashboardSampleContext = {
+  fieldName?: InputMaybe<Scalars["String"]>;
+  values: Array<Scalars["String"]>;
+};
+
 export type DashboardSampleCount = {
   __typename?: "DashboardSampleCount";
   totalCount: Scalars["Int"];
@@ -1830,6 +1840,11 @@ export type DashboardSampleInput = {
   tumorOrNormal?: InputMaybe<Scalars["String"]>;
   validationReport?: InputMaybe<Scalars["String"]>;
   validationStatus?: InputMaybe<Scalars["Boolean"]>;
+};
+
+export type DashboardSampleSort = {
+  colId: Scalars["String"];
+  sort: AgGridSortDirection;
 };
 
 export type DeleteInfo = {
@@ -4606,15 +4621,16 @@ export type QueryCohortsConnectionArgs = {
 };
 
 export type QueryDashboardSampleCountArgs = {
-  sampleContext?: InputMaybe<SampleContext>;
+  sampleContext?: InputMaybe<DashboardSampleContext>;
   searchVals?: InputMaybe<Array<Scalars["String"]>>;
 };
 
 export type QueryDashboardSamplesArgs = {
   limit: Scalars["Int"];
   offset: Scalars["Int"];
-  sampleContext?: InputMaybe<SampleContext>;
+  sampleContext?: InputMaybe<DashboardSampleContext>;
   searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  sort: DashboardSampleSort;
 };
 
 export type QueryMafCompletesArgs = {
@@ -7475,11 +7491,6 @@ export type SampleConnectInput = {
 
 export type SampleConnectWhere = {
   node: SampleWhere;
-};
-
-export type SampleContext = {
-  fieldName?: InputMaybe<Scalars["String"]>;
-  values: Array<Scalars["String"]>;
 };
 
 export type SampleCreateInput = {
@@ -12462,7 +12473,8 @@ export type PatientsListQuery = {
 
 export type DashboardSamplesQueryVariables = Exact<{
   searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
-  sampleContext?: InputMaybe<SampleContext>;
+  sampleContext?: InputMaybe<DashboardSampleContext>;
+  sort: DashboardSampleSort;
   limit: Scalars["Int"];
   offset: Scalars["Int"];
 }>;
@@ -12841,7 +12853,8 @@ export type PatientsListQueryResult = Apollo.QueryResult<
 export const DashboardSamplesDocument = gql`
   query DashboardSamples(
     $searchVals: [String!]
-    $sampleContext: SampleContext
+    $sampleContext: DashboardSampleContext
+    $sort: DashboardSampleSort!
     $limit: Int!
     $offset: Int!
   ) {
@@ -12854,6 +12867,7 @@ export const DashboardSamplesDocument = gql`
     dashboardSamples(
       searchVals: $searchVals
       sampleContext: $sampleContext
+      sort: $sort
       limit: $limit
       offset: $offset
     ) {

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1785,7 +1785,7 @@ export type DashboardSample = {
 
 export type DashboardSampleCount = {
   __typename?: "DashboardSampleCount";
-  totalCount?: Maybe<Scalars["Int"]>;
+  totalCount: Scalars["Int"];
 };
 
 export type DashboardSampleInput = {
@@ -12471,7 +12471,7 @@ export type DashboardSamplesQuery = {
   __typename?: "Query";
   dashboardSampleCount: {
     __typename?: "DashboardSampleCount";
-    totalCount?: number | null;
+    totalCount: number;
   };
   dashboardSamples: Array<{
     __typename?: "DashboardSample";

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1761,7 +1761,7 @@ export type DashboardSample = {
   custodianInformation?: Maybe<Scalars["String"]>;
   embargoDate?: Maybe<Scalars["String"]>;
   genePanel?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
+  importDate: Scalars["String"];
   initialPipelineRunDate?: Maybe<Scalars["String"]>;
   investigatorSampleId?: Maybe<Scalars["String"]>;
   mafCompleteDate?: Maybe<Scalars["String"]>;
@@ -1820,7 +1820,7 @@ export type DashboardSampleInput = {
   custodianInformation?: InputMaybe<Scalars["String"]>;
   embargoDate?: InputMaybe<Scalars["String"]>;
   genePanel?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["String"]>;
+  importDate: Scalars["String"];
   initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
   investigatorSampleId?: InputMaybe<Scalars["String"]>;
   mafCompleteDate?: InputMaybe<Scalars["String"]>;
@@ -12499,7 +12499,7 @@ export type DashboardSamplesQuery = {
     revisable?: boolean | null;
     primaryId: string;
     cmoSampleName?: string | null;
-    importDate?: string | null;
+    importDate: string;
     cmoPatientId?: string | null;
     investigatorSampleId?: string | null;
     sampleType?: string | null;
@@ -12548,7 +12548,7 @@ export type DashboardSampleMetadataPartsFragment = {
   __typename?: "DashboardSample";
   primaryId: string;
   cmoSampleName?: string | null;
-  importDate?: string | null;
+  importDate: string;
   cmoPatientId?: string | null;
   investigatorSampleId?: string | null;
   sampleType?: string | null;
@@ -12624,7 +12624,7 @@ export type UpdateDashboardSamplesMutation = {
     revisable?: boolean | null;
     primaryId: string;
     cmoSampleName?: string | null;
-    importDate?: string | null;
+    importDate: string;
     cmoPatientId?: string | null;
     investigatorSampleId?: string | null;
     sampleType?: string | null;

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1798,6 +1798,11 @@ export type DashboardSampleCount = {
   totalCount: Scalars["Int"];
 };
 
+export type DashboardSampleFilter = {
+  field: Scalars["String"];
+  values: Array<Scalars["String"]>;
+};
+
 export type DashboardSampleInput = {
   accessLevel?: InputMaybe<Scalars["String"]>;
   baitSet?: InputMaybe<Scalars["String"]>;
@@ -4621,11 +4626,13 @@ export type QueryCohortsConnectionArgs = {
 };
 
 export type QueryDashboardSampleCountArgs = {
+  filter?: InputMaybe<DashboardSampleFilter>;
   sampleContext?: InputMaybe<DashboardSampleContext>;
   searchVals?: InputMaybe<Array<Scalars["String"]>>;
 };
 
 export type QueryDashboardSamplesArgs = {
+  filter?: InputMaybe<DashboardSampleFilter>;
   limit: Scalars["Int"];
   offset: Scalars["Int"];
   sampleContext?: InputMaybe<DashboardSampleContext>;
@@ -12475,6 +12482,7 @@ export type DashboardSamplesQueryVariables = Exact<{
   searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
   sampleContext?: InputMaybe<DashboardSampleContext>;
   sort: DashboardSampleSort;
+  filter?: InputMaybe<DashboardSampleFilter>;
   limit: Scalars["Int"];
   offset: Scalars["Int"];
 }>;
@@ -12855,12 +12863,14 @@ export const DashboardSamplesDocument = gql`
     $searchVals: [String!]
     $sampleContext: DashboardSampleContext
     $sort: DashboardSampleSort!
+    $filter: DashboardSampleFilter
     $limit: Int!
     $offset: Int!
   ) {
     dashboardSampleCount(
       searchVals: $searchVals
       sampleContext: $sampleContext
+      filter: $filter
     ) {
       totalCount
     }
@@ -12868,6 +12878,7 @@ export const DashboardSamplesDocument = gql`
       searchVals: $searchVals
       sampleContext: $sampleContext
       sort: $sort
+      filter: $filter
       limit: $limit
       offset: $offset
     ) {

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -4612,6 +4612,7 @@ export type QueryDashboardSampleCountArgs = {
 
 export type QueryDashboardSamplesArgs = {
   limit: Scalars["Int"];
+  offset: Scalars["Int"];
   sampleContext?: InputMaybe<SampleContext>;
   searchVals?: InputMaybe<Array<Scalars["String"]>>;
 };
@@ -12463,6 +12464,7 @@ export type DashboardSamplesQueryVariables = Exact<{
   searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
   sampleContext?: InputMaybe<SampleContext>;
   limit: Scalars["Int"];
+  offset: Scalars["Int"];
 }>;
 
 export type DashboardSamplesQuery = {
@@ -12841,6 +12843,7 @@ export const DashboardSamplesDocument = gql`
     $searchVals: [String!]
     $sampleContext: SampleContext
     $limit: Int!
+    $offset: Int!
   ) {
     dashboardSampleCount(
       searchVals: $searchVals
@@ -12852,6 +12855,7 @@ export const DashboardSamplesDocument = gql`
       searchVals: $searchVals
       sampleContext: $sampleContext
       limit: $limit
+      offset: $offset
     ) {
       ...DashboardSampleParts
       ...DashboardSampleMetadataParts

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -102,7 +102,7 @@ export async function buildCustomSchema(ogm: OGM) {
       ## Root-level fields
       primaryId: String!
       cmoSampleName: String
-      importDate: String
+      importDate: String!
       cmoPatientId: String
       investigatorSampleId: String
       sampleType: String
@@ -201,7 +201,7 @@ export async function buildCustomSchema(ogm: OGM) {
       ## Root-level fields
       primaryId: String!
       cmoSampleName: String
-      importDate: String
+      importDate: String!
       cmoPatientId: String
       investigatorSampleId: String
       sampleType: String

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -302,6 +302,7 @@ async function queryDashboardSamples({
       apoc.convert.fromJsonMap(latestSm.cmoSampleIdFields).recipe as recipe,
 
       oldestCCDate AS initialPipelineRunDate,
+      toString(datetime(replace(oldestCCDate, ' ', 'T')) + duration({ months: 18 })) AS embargoDate,
 
       t.smileTempoId AS smileTempoId,
       t.billed AS billed,
@@ -339,14 +340,6 @@ async function queryDashboardSamples({
 
       return {
         ...recordObject,
-        // TODO: handle sorting for these custom fields or disable them from being sortable
-        embargoDate: recordObject.initialPipelineRunDate
-          ? new Date(
-              new Date(recordObject.initialPipelineRunDate).setMonth(
-                new Date(recordObject.initialPipelineRunDate).getMonth() + 18
-              )
-            ).toISOString()
-          : null,
         cancerType: otCache?.mainType,
         cancerTypeDetailed: otCache?.name,
       };

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -19,7 +19,7 @@ export async function buildCustomSchema(ogm: OGM) {
     Query: {
       async dashboardSamples(
         _source: undefined,
-        { searchVals, sampleContext, limit }: QueryDashboardSamplesArgs,
+        { searchVals, sampleContext, limit, offset }: QueryDashboardSamplesArgs,
         { oncotreeCache }: ApolloServerContext
       ) {
         const addlOncotreeCodes = getAddlOtCodesMatchingCtOrCtdVals({
@@ -36,6 +36,7 @@ export async function buildCustomSchema(ogm: OGM) {
         return await queryDashboardSamples({
           partialCypherQuery,
           limit,
+          offset,
           oncotreeCache,
         });
       },
@@ -237,9 +238,11 @@ async function queryDashboardSamples({
   partialCypherQuery,
   limit,
   oncotreeCache,
+  offset, // Add offset parameter
 }: {
   partialCypherQuery: string;
   limit: QueryDashboardSamplesArgs["limit"];
+  offset: number; // Add offset parameter
   oncotreeCache: NodeCache;
 }) {
   const cypherQuery = `
@@ -289,6 +292,7 @@ async function queryDashboardSamples({
       latestQC.status AS qcCompleteStatus
 
     ORDER BY importDate DESC
+    SKIP ${offset}
     LIMIT ${limit}
   `;
 

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -150,6 +150,7 @@ export async function buildCustomSchema(ogm: OGM) {
         searchVals: [String!]
         sampleContext: SampleContext
         limit: Int!
+        offset: Int!
       ): [DashboardSample!]!
       dashboardSampleCount(
         searchVals: [String!]

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -80,7 +80,7 @@ export async function buildCustomSchema(ogm: OGM) {
 
   const typeDefs = gql`
     type DashboardSampleCount {
-      totalCount: Int
+      totalCount: Int!
     }
 
     type DashboardSample {

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -299,7 +299,7 @@ async function queryDashboardSamples({
       latestSm.sampleOrigin AS sampleOrigin,
       latestSm.tissueLocation AS tissueLocation,
       latestSm.sex AS sex,
-      latestSm.cmoSampleIdFields AS cmoSampleIdFields,
+      apoc.convert.fromJsonMap(latestSm.cmoSampleIdFields).recipe as recipe,
 
       oldestCCDate AS initialPipelineRunDate,
 
@@ -340,7 +340,6 @@ async function queryDashboardSamples({
       return {
         ...recordObject,
         // TODO: handle sorting for these custom fields or disable them from being sortable
-        recipe: parseJsonSafely(recordObject.cmoSampleIdFields)?.recipe,
         embargoDate: recordObject.initialPipelineRunDate
           ? new Date(
               new Date(recordObject.initialPipelineRunDate).setMonth(

--- a/graphql-server/src/schemas/oracle.ts
+++ b/graphql-server/src/schemas/oracle.ts
@@ -5,91 +5,92 @@ import { props } from "../utils/constants";
 import { applyMiddleware } from "graphql-middleware";
 import { IMiddlewareResolver } from "graphql-middleware/dist/types";
 
-// The CRDB implements case insensitive logon, a setting that requires node-oracledb's Thick mode
-// and the Oracle Instant Client, which is unavailable for M1 Macs
-let oracledb: any = null;
-if (os.arch() !== "arm64") {
-  oracledb = require("oracledb");
-  oracledb.initOracleClient({ libDir: process.env.LD_LIBRARY_PATH });
-  oracledb.outFormat = oracledb.OUT_FORMAT_OBJECT; // returns each row as a JS object
-}
+export async function buildOracleDbSchema() {
+  // The CRDB implements case insensitive logon, a setting that requires node-oracledb's Thick mode
+  // and the Oracle Instant Client, which is unavailable for M1 Macs
+  let oracledb: any = null;
+  if (os.arch() !== "arm64") {
+    oracledb = require("oracledb");
+    oracledb.initOracleClient({ libDir: process.env.LD_LIBRARY_PATH });
+    oracledb.outFormat = oracledb.OUT_FORMAT_OBJECT; // returns each row as a JS object
+  }
 
-const authenticationMiddleware: {
-  Query: {
-    patientIdsTriplets: IMiddlewareResolver;
-  };
-} = {
-  Query: {
-    patientIdsTriplets: async (resolve, parent, args, context, info) => {
-      const req = context.req;
+  const authenticationMiddleware: {
+    Query: {
+      patientIdsTriplets: IMiddlewareResolver;
+    };
+  } = {
+    Query: {
+      patientIdsTriplets: async (resolve, parent, args, context, info) => {
+        const req = context.req;
 
-      if (req.isAuthenticated()) {
-        // continues to the next middleware or resolver
-        const result = await resolve(parent, args, context, info);
-        return result;
-      } else {
-        throw new AuthenticationError("401");
-      }
-    },
-  },
-};
-
-const authorizationMiddleware: {
-  Query: {
-    patientIdsTriplets: IMiddlewareResolver;
-  };
-} = {
-  Query: {
-    patientIdsTriplets: async (resolve, parent, args, context, info) => {
-      const req = context.req;
-
-      if (req.user.groups.includes("mrn-search")) {
-        // continues to the next middleware or resolver
-        const result = await resolve(parent, args, context, info);
-        return result;
-      } else {
-        throw new ForbiddenError("403");
-      }
-    },
-  },
-};
-
-const resolvers = {
-  Query: {
-    patientIdsTriplets: async (_: any, { patientIds }: any) => {
-      const patientIdsTriplets = [];
-
-      if (os.arch() !== "arm64" && oracledb !== null) {
-        try {
-          const connection = await oracledb.getConnection({
-            user: props.oracle_user,
-            password: props.oracle_password,
-            connectString: props.oracle_connect_string,
-          });
-
-          const promises = patientIds.map(async (patientId: string) => {
-            const result = await connection.execute(
-              "SELECT CMO_ID, DMP_ID, PT_MRN FROM CRDB_CMO_LOJ_DMP_MAP WHERE :patientId IN (DMP_ID, PT_MRN, CMO_ID)",
-              { patientId }
-            );
-            if (result.rows.length > 0) {
-              return result.rows[0];
-            }
-          });
-
-          patientIdsTriplets.push(...(await Promise.all(promises)));
-          await connection.close();
-        } catch (error) {
-          console.error("Error in OracleDB connection: ", error);
+        if (req.isAuthenticated()) {
+          // continues to the next middleware or resolver
+          const result = await resolve(parent, args, context, info);
+          return result;
+        } else {
+          throw new AuthenticationError("401");
         }
-      }
-
-      return patientIdsTriplets;
+      },
     },
-  },
-};
+  };
 
-const typeDefs = `
+  const authorizationMiddleware: {
+    Query: {
+      patientIdsTriplets: IMiddlewareResolver;
+    };
+  } = {
+    Query: {
+      patientIdsTriplets: async (resolve, parent, args, context, info) => {
+        const req = context.req;
+
+        if (req.user.groups.includes("mrn-search")) {
+          // continues to the next middleware or resolver
+          const result = await resolve(parent, args, context, info);
+          return result;
+        } else {
+          throw new ForbiddenError("403");
+        }
+      },
+    },
+  };
+
+  const resolvers = {
+    Query: {
+      patientIdsTriplets: async (_: any, { patientIds }: any) => {
+        const patientIdsTriplets = [];
+
+        if (os.arch() !== "arm64" && oracledb !== null) {
+          try {
+            const connection = await oracledb.getConnection({
+              user: props.oracle_user,
+              password: props.oracle_password,
+              connectString: props.oracle_connect_string,
+            });
+
+            const promises = patientIds.map(async (patientId: string) => {
+              const result = await connection.execute(
+                "SELECT CMO_ID, DMP_ID, PT_MRN FROM CRDB_CMO_LOJ_DMP_MAP WHERE :patientId IN (DMP_ID, PT_MRN, CMO_ID)",
+                { patientId }
+              );
+              if (result.rows.length > 0) {
+                return result.rows[0];
+              }
+            });
+
+            patientIdsTriplets.push(...(await Promise.all(promises)));
+            await connection.close();
+          } catch (error) {
+            console.error("Error in OracleDB connection: ", error);
+          }
+        }
+
+        return patientIdsTriplets;
+      },
+    },
+  };
+
+  const typeDefs = `
   type PatientIdsTriplet {
     CMO_ID: String
     DMP_ID: String
@@ -101,13 +102,14 @@ const typeDefs = `
   }
 `;
 
-const schema = makeExecutableSchema({
-  typeDefs: typeDefs,
-  resolvers: resolvers,
-});
+  const schema = makeExecutableSchema({
+    typeDefs: typeDefs,
+    resolvers: resolvers,
+  });
 
-export const oracleDbSchema = applyMiddleware(
-  schema,
-  authenticationMiddleware,
-  authorizationMiddleware
-);
+  return applyMiddleware(
+    schema,
+    authenticationMiddleware,
+    authorizationMiddleware
+  );
+}

--- a/graphql-server/src/utils/servers.ts
+++ b/graphql-server/src/utils/servers.ts
@@ -47,16 +47,19 @@ export async function initializeApolloServer(
   httpsServer: https.Server,
   app: Express
 ) {
+  console.log("Building schemas...");
   const { neo4jDbSchema, ogm } = await buildNeo4jDbSchema();
   const customSchema = await buildCustomSchema(ogm);
   const mergedSchema = mergeSchemas({
     schemas: [neo4jDbSchema, oracleDbSchema, customSchema],
   });
 
+  console.log("Fetching Oncotree data and caching...");
   const oncotreeCache = new NodeCache({ stdTTL: 86400 }); // 1 day
   await fetchAndCacheOncotreeData(oncotreeCache);
   oncotreeCache.on("expired", fetchAndCacheOncotreeData);
 
+  console.log("Initializing Apollo Server...");
   const apolloServer = new ApolloServer<ApolloServerContext>({
     schema: mergedSchema,
     context: async ({ req }: { req: any }) => {

--- a/graphql-server/src/utils/servers.ts
+++ b/graphql-server/src/utils/servers.ts
@@ -5,7 +5,7 @@ import { props } from "./constants";
 import { buildNeo4jDbSchema } from "../schemas/neo4j";
 import { buildCustomSchema } from "../schemas/custom";
 import { mergeSchemas } from "@graphql-tools/schema";
-import { oracleDbSchema } from "../schemas/oracle";
+import { buildOracleDbSchema } from "../schemas/oracle";
 import { ApolloServer } from "apollo-server-express";
 import {
   ApolloServerPluginDrainHttpServer,
@@ -47,19 +47,17 @@ export async function initializeApolloServer(
   httpsServer: https.Server,
   app: Express
 ) {
-  console.log("Building schemas...");
   const { neo4jDbSchema, ogm } = await buildNeo4jDbSchema();
   const customSchema = await buildCustomSchema(ogm);
+  const oracleDbSchema = await buildOracleDbSchema();
   const mergedSchema = mergeSchemas({
     schemas: [neo4jDbSchema, oracleDbSchema, customSchema],
   });
 
-  console.log("Fetching Oncotree data and caching...");
   const oncotreeCache = new NodeCache({ stdTTL: 86400 }); // 1 day
   await fetchAndCacheOncotreeData(oncotreeCache);
   oncotreeCache.on("expired", fetchAndCacheOncotreeData);
 
-  console.log("Initializing Apollo Server...");
   const apolloServer = new ApolloServer<ApolloServerContext>({
     schema: mergedSchema,
     context: async ({ req }: { req: any }) => {

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -17822,6 +17822,57 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "DashboardSampleFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "values",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "DashboardSampleInput",
         "description": null,
         "fields": null,
@@ -45500,6 +45551,18 @@
             "description": null,
             "args": [
               {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DashboardSampleFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "sampleContext",
                 "description": null,
                 "type": {
@@ -45548,6 +45611,18 @@
             "name": "dashboardSamples",
             "description": null,
             "args": [
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DashboardSampleFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
               {
                 "name": "limit",
                 "description": null,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -45448,6 +45448,22 @@
                 "deprecationReason": null
               },
               {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "sampleContext",
                 "description": null,
                 "type": {

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -17437,9 +17437,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -18085,9 +18089,13 @@
             "name": "importDate",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -9,6 +9,29 @@
     "subscriptionType": null,
     "types": [
       {
+        "kind": "ENUM",
+        "name": "AgGridSortDirection",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "asc",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "desc",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "BamComplete",
         "description": null,
@@ -17724,6 +17747,53 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "DashboardSampleContext",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "fieldName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "values",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "DashboardSampleCount",
         "description": null,
@@ -18263,6 +18333,49 @@
               "kind": "SCALAR",
               "name": "Boolean",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "DashboardSampleSort",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "colId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sort",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AgGridSortDirection",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -45391,7 +45504,7 @@
                 "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "SampleContext",
+                  "name": "DashboardSampleContext",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -45472,7 +45585,7 @@
                 "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "SampleContext",
+                  "name": "DashboardSampleContext",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -45493,6 +45606,22 @@
                       "name": "String",
                       "ofType": null
                     }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "DashboardSampleSort",
+                    "ofType": null
                   }
                 },
                 "defaultValue": null,
@@ -74853,53 +74982,6 @@
                 "kind": "INPUT_OBJECT",
                 "name": "SampleWhere",
                 "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "SampleContext",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "fieldName",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "values",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
               }
             },
             "defaultValue": null,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -17733,9 +17733,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -50,6 +50,7 @@ query DashboardSamples(
   $searchVals: [String!]
   $sampleContext: SampleContext
   $limit: Int!
+  $offset: Int!
 ) {
   dashboardSampleCount(searchVals: $searchVals, sampleContext: $sampleContext) {
     totalCount
@@ -58,6 +59,7 @@ query DashboardSamples(
     searchVals: $searchVals
     sampleContext: $sampleContext
     limit: $limit
+    offset: $offset
   ) {
     ...DashboardSampleParts
     ...DashboardSampleMetadataParts

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -48,7 +48,8 @@ query PatientsList($options: PatientOptions, $where: PatientWhere) {
 
 query DashboardSamples(
   $searchVals: [String!]
-  $sampleContext: SampleContext
+  $sampleContext: DashboardSampleContext
+  $sort: DashboardSampleSort!
   $limit: Int!
   $offset: Int!
 ) {
@@ -58,6 +59,7 @@ query DashboardSamples(
   dashboardSamples(
     searchVals: $searchVals
     sampleContext: $sampleContext
+    sort: $sort
     limit: $limit
     offset: $offset
   ) {

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -50,16 +50,22 @@ query DashboardSamples(
   $searchVals: [String!]
   $sampleContext: DashboardSampleContext
   $sort: DashboardSampleSort!
+  $filter: DashboardSampleFilter
   $limit: Int!
   $offset: Int!
 ) {
-  dashboardSampleCount(searchVals: $searchVals, sampleContext: $sampleContext) {
+  dashboardSampleCount(
+    searchVals: $searchVals
+    sampleContext: $sampleContext
+    filter: $filter
+  ) {
     totalCount
   }
   dashboardSamples(
     searchVals: $searchVals
     sampleContext: $sampleContext
     sort: $sort
+    filter: $filter
     limit: $limit
     offset: $offset
   ) {


### PR DESCRIPTION
This PR transitions the Sample views' AG Grid [row model](https://www.ag-grid.com/javascript-data-grid/row-models/) from Client-Side to Server-Side, allowing the grid to lazy-load the data as the user scrolls down.

[#1291](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1291)