### PR TITLE
Enable column filters for all date and boolean columns

### DIFF
--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -5,6 +5,7 @@ import {
   RowNode,
   ITooltipParams,
   CellClassParams,
+  IFilterDef,
 } from "ag-grid-community";
 import { Button } from "react-bootstrap";
 import "ag-grid-enterprise";
@@ -21,6 +22,52 @@ export type SampleChange = {
   newValue: string;
   rowNode: RowNode;
 };
+
+const agGridDateFilterConfigs: IFilterDef = {
+  filter: "agDateColumnFilter",
+  filterParams: {
+    buttons: ["apply", "reset"],
+    filterOptions: ["inRange"],
+    inRangeInclusive: true,
+    minValidYear: 2016,
+    maxValidYear: new Date().getFullYear(),
+    suppressAndOrCondition: true,
+  },
+};
+
+function getAgGridBooleanFilterConfigs({
+  showBlanksFilterOption = false,
+}: { showBlanksFilterOption?: Boolean } = {}): IFilterDef {
+  return {
+    filter: true,
+    filterParams: {
+      values: !showBlanksFilterOption ? ["Yes", "No"] : ["Yes", "No", ""],
+      suppressMiniFilter: true,
+    },
+  };
+}
+
+function getAgGridBooleanValueFormatter({
+  trueVal,
+  falseVal,
+}: {
+  // The true/false values that appear in the database for the given field
+  trueVal: String | Boolean;
+  falseVal: String | Boolean;
+}): ColDef {
+  return {
+    valueFormatter: (params) => {
+      switch (params.value) {
+        case trueVal:
+          return "Yes";
+        case falseVal:
+          return "No";
+        default:
+          return "";
+      }
+    },
+  };
+}
 
 export const RequestsListColumns: ColDef[] = [
   {
@@ -55,15 +102,7 @@ export const RequestsListColumns: ColDef[] = [
   {
     field: "importDate",
     headerName: "Import Date",
-    filter: "agDateColumnFilter",
-    filterParams: {
-      buttons: ["apply", "reset"],
-      filterOptions: ["inRange"],
-      inRangeInclusive: true,
-      minValidYear: 2016,
-      maxValidYear: new Date().getFullYear(),
-      suppressAndOrCondition: true,
-    },
+    ...agGridDateFilterConfigs,
   },
   {
     field: "totalSampleCount",
@@ -122,40 +161,20 @@ export const RequestsListColumns: ColDef[] = [
   {
     field: "bicAnalysis",
     headerName: "BIC Analysis",
-    filter: true,
-    filterParams: {
-      values: ["Yes", "No"],
-      suppressMiniFilter: true,
-    },
-    valueFormatter: (params) => {
-      switch (params.value) {
-        case true:
-          return "Yes";
-        case false:
-          return "No";
-        default:
-          return "";
-      }
-    },
+    ...getAgGridBooleanFilterConfigs(),
+    ...getAgGridBooleanValueFormatter({
+      trueVal: true,
+      falseVal: false,
+    }),
   },
   {
     field: "isCmoRequest",
     headerName: "CMO Request?",
-    filter: true,
-    filterParams: {
-      values: ["Yes", "No"],
-      suppressMiniFilter: true,
-    },
-    valueFormatter: (params) => {
-      switch (params.value) {
-        case true:
-          return "Yes";
-        case false:
-          return "No";
-        default:
-          return "";
-      }
-    },
+    ...getAgGridBooleanFilterConfigs(),
+    ...getAgGridBooleanValueFormatter({
+      trueVal: true,
+      falseVal: false,
+    }),
   },
   {
     field: "otherContactEmails",
@@ -201,40 +220,24 @@ export const PatientsListColumns: ColDef[] = [
   {
     field: "consentPartA",
     headerName: "12-245 Part A",
-    filter: true,
-    filterParams: {
-      values: ["Yes", "No"],
-      suppressMiniFilter: true,
-    },
-    valueFormatter: (params) => {
-      switch (params.value) {
-        case "YES":
-          return "Yes";
-        case "NO":
-          return "No";
-        default:
-          return "";
-      }
-    },
+    ...getAgGridBooleanFilterConfigs({
+      showBlanksFilterOption: true,
+    }),
+    ...getAgGridBooleanValueFormatter({
+      trueVal: "YES",
+      falseVal: "NO",
+    }),
   },
   {
     field: "consentPartC",
     headerName: "12-245 Part C",
-    filter: true,
-    filterParams: {
-      values: ["Yes", "No"],
-      suppressMiniFilter: true,
-    },
-    valueFormatter: (params) => {
-      switch (params.value) {
-        case "YES":
-          return "Yes";
-        case "NO":
-          return "No";
-        default:
-          return "";
-      }
-    },
+    ...getAgGridBooleanFilterConfigs({
+      showBlanksFilterOption: true,
+    }),
+    ...getAgGridBooleanValueFormatter({
+      trueVal: "YES",
+      falseVal: "NO",
+    }),
   },
   {
     field: "totalSampleCount",
@@ -298,16 +301,7 @@ export const SampleMetadataDetailsColumns: ColDef[] = [
   {
     field: "importDate",
     headerName: "Last Updated",
-    // TODO: standardize common filter settings like date into a function or object
-    filter: "agDateColumnFilter",
-    filterParams: {
-      buttons: ["apply", "reset"],
-      filterOptions: ["inRange"],
-      inRangeInclusive: true,
-      minValidYear: 2016,
-      maxValidYear: new Date().getFullYear(),
-      suppressAndOrCondition: true,
-    },
+    ...agGridDateFilterConfigs,
   },
   {
     field: "cmoPatientId",
@@ -599,25 +593,13 @@ export const CohortsListColumns: ColDef[] = [
   {
     field: "billed",
     headerName: "Billed",
-    filter: true,
-    filterParams: {
-      values: ["Yes", "No"],
-      suppressMiniFilter: true,
-    },
+    ...getAgGridBooleanFilterConfigs(),
   },
   {
     field: "initialCohortDeliveryDate",
     headerName: "Initial Cohort Delivery Date",
-    filter: "agDateColumnFilter",
-    filterParams: {
-      buttons: ["apply", "reset"],
-      filterOptions: ["inRange"],
-      inRangeInclusive: true,
-      minValidYear: 2016,
-      maxValidYear: new Date().getFullYear(),
-      suppressAndOrCondition: true,
-    },
     valueFormatter: (params) => formatDate(params.value) ?? "",
+    ...agGridDateFilterConfigs,
   },
   {
     field: "endUsers",
@@ -677,21 +659,11 @@ export const WesSampleDetailsColumns: ColDef[] = [
     cellEditorParams: {
       values: [true, false],
     },
-    valueFormatter: (params) => {
-      switch (params.value) {
-        case true:
-          return "Yes";
-        case false:
-          return "No";
-        default:
-          return "";
-      }
-    },
-    filter: "agSetColumnFilter",
-    filterParams: {
-      values: ["Yes", "No"],
-      suppressMiniFilter: true,
-    },
+    ...getAgGridBooleanFilterConfigs(),
+    ...getAgGridBooleanValueFormatter({
+      trueVal: true,
+      falseVal: false,
+    }),
   },
   {
     field: "costCenter",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -201,10 +201,40 @@ export const PatientsListColumns: ColDef[] = [
   {
     field: "consentPartA",
     headerName: "12-245 Part A",
+    filter: true,
+    filterParams: {
+      values: ["Yes", "No"],
+      suppressMiniFilter: true,
+    },
+    valueFormatter: (params) => {
+      switch (params.value) {
+        case "YES":
+          return "Yes";
+        case "NO":
+          return "No";
+        default:
+          return "";
+      }
+    },
   },
   {
     field: "consentPartC",
     headerName: "12-245 Part C",
+    filter: true,
+    filterParams: {
+      values: ["Yes", "No"],
+      suppressMiniFilter: true,
+    },
+    valueFormatter: (params) => {
+      switch (params.value) {
+        case "YES":
+          return "Yes";
+        case "NO":
+          return "No";
+        default:
+          return "";
+      }
+    },
   },
   {
     field: "totalSampleCount",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -644,11 +644,13 @@ export const WesSampleDetailsColumns: ColDef[] = [
     field: "initialPipelineRunDate",
     headerName: "Initial Pipeline Run Date",
     valueFormatter: (params) => formatDate(params.value) ?? "",
+    ...agGridDateFilterConfigs,
   },
   {
     field: "embargoDate",
     headerName: "Embargo Date",
     valueFormatter: (params) => formatDate(params.value) ?? "",
+    ...agGridDateFilterConfigs,
   },
   {
     field: "billed",
@@ -695,6 +697,7 @@ export const WesSampleDetailsColumns: ColDef[] = [
     field: "bamCompleteDate",
     headerName: "Latest BAM Complete Date",
     valueFormatter: (params) => formatDate(params.value) ?? "",
+    ...agGridDateFilterConfigs,
   },
   {
     field: "bamCompleteStatus",
@@ -704,6 +707,7 @@ export const WesSampleDetailsColumns: ColDef[] = [
     field: "mafCompleteDate",
     headerName: "Latest MAF Complete Date",
     valueFormatter: (params) => formatDate(params.value) ?? "",
+    ...agGridDateFilterConfigs,
   },
   {
     field: "mafCompleteNormalPrimaryId",
@@ -717,6 +721,7 @@ export const WesSampleDetailsColumns: ColDef[] = [
     field: "qcCompleteDate",
     headerName: "Latest QC Complete Date",
     valueFormatter: (params) => formatDate(params.value) ?? "",
+    ...agGridDateFilterConfigs,
   },
   {
     field: "qcCompleteResult",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -122,6 +122,11 @@ export const RequestsListColumns: ColDef[] = [
   {
     field: "bicAnalysis",
     headerName: "BIC Analysis",
+    filter: true,
+    filterParams: {
+      values: ["true", "false"],
+      suppressMiniFilter: true,
+    },
   },
   {
     field: "isCmoRequest",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -124,13 +124,38 @@ export const RequestsListColumns: ColDef[] = [
     headerName: "BIC Analysis",
     filter: true,
     filterParams: {
-      values: ["true", "false"],
+      values: ["Yes", "No"],
       suppressMiniFilter: true,
+    },
+    valueFormatter: (params) => {
+      switch (params.value) {
+        case true:
+          return "Yes";
+        case false:
+          return "No";
+        default:
+          return "";
+      }
     },
   },
   {
     field: "isCmoRequest",
     headerName: "CMO Request?",
+    filter: true,
+    filterParams: {
+      values: ["Yes", "No"],
+      suppressMiniFilter: true,
+    },
+    valueFormatter: (params) => {
+      switch (params.value) {
+        case true:
+          return "Yes";
+        case false:
+          return "No";
+        default:
+          return "";
+      }
+    },
   },
   {
     field: "otherContactEmails",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -23,17 +23,21 @@ export type SampleChange = {
   rowNode: RowNode;
 };
 
-const agGridDateFilterConfigs: IFilterDef = {
-  filter: "agDateColumnFilter",
-  filterParams: {
-    buttons: ["apply", "reset"],
-    filterOptions: ["inRange"],
-    inRangeInclusive: true,
-    minValidYear: 2016,
-    maxValidYear: new Date().getFullYear(),
-    suppressAndOrCondition: true,
-  },
-};
+function getAgGridDateFilterConfigs({
+  maxValidYear = new Date().getFullYear(),
+}: { maxValidYear?: number } = {}): IFilterDef {
+  return {
+    filter: "agDateColumnFilter",
+    filterParams: {
+      buttons: ["apply", "reset"],
+      filterOptions: ["inRange"],
+      inRangeInclusive: true,
+      minValidYear: 2016,
+      maxValidYear: maxValidYear,
+      suppressAndOrCondition: true,
+    },
+  };
+}
 
 function getAgGridBooleanFilterConfigs({
   showBlanksFilterOption = false,
@@ -102,7 +106,7 @@ export const RequestsListColumns: ColDef[] = [
   {
     field: "importDate",
     headerName: "Import Date",
-    ...agGridDateFilterConfigs,
+    ...getAgGridDateFilterConfigs(),
   },
   {
     field: "totalSampleCount",
@@ -301,7 +305,7 @@ export const SampleMetadataDetailsColumns: ColDef[] = [
   {
     field: "importDate",
     headerName: "Last Updated",
-    ...agGridDateFilterConfigs,
+    ...getAgGridDateFilterConfigs(),
   },
   {
     field: "cmoPatientId",
@@ -599,7 +603,7 @@ export const CohortsListColumns: ColDef[] = [
     field: "initialCohortDeliveryDate",
     headerName: "Initial Cohort Delivery Date",
     valueFormatter: (params) => formatDate(params.value) ?? "",
-    ...agGridDateFilterConfigs,
+    ...getAgGridDateFilterConfigs(),
   },
   {
     field: "endUsers",
@@ -644,13 +648,16 @@ export const WesSampleDetailsColumns: ColDef[] = [
     field: "initialPipelineRunDate",
     headerName: "Initial Pipeline Run Date",
     valueFormatter: (params) => formatDate(params.value) ?? "",
-    ...agGridDateFilterConfigs,
+    ...getAgGridDateFilterConfigs(),
   },
   {
     field: "embargoDate",
     headerName: "Embargo Date",
     valueFormatter: (params) => formatDate(params.value) ?? "",
-    ...agGridDateFilterConfigs,
+    ...getAgGridDateFilterConfigs({
+      // embargoDate is 18 months ahead of initialPipelineRunDate
+      maxValidYear: new Date().getFullYear() + 2,
+    }),
   },
   {
     field: "billed",
@@ -697,7 +704,7 @@ export const WesSampleDetailsColumns: ColDef[] = [
     field: "bamCompleteDate",
     headerName: "Latest BAM Complete Date",
     valueFormatter: (params) => formatDate(params.value) ?? "",
-    ...agGridDateFilterConfigs,
+    ...getAgGridDateFilterConfigs(),
   },
   {
     field: "bamCompleteStatus",
@@ -707,7 +714,7 @@ export const WesSampleDetailsColumns: ColDef[] = [
     field: "mafCompleteDate",
     headerName: "Latest MAF Complete Date",
     valueFormatter: (params) => formatDate(params.value) ?? "",
-    ...agGridDateFilterConfigs,
+    ...getAgGridDateFilterConfigs(),
   },
   {
     field: "mafCompleteNormalPrimaryId",
@@ -721,7 +728,7 @@ export const WesSampleDetailsColumns: ColDef[] = [
     field: "qcCompleteDate",
     headerName: "Latest QC Complete Date",
     valueFormatter: (params) => formatDate(params.value) ?? "",
-    ...agGridDateFilterConfigs,
+    ...getAgGridDateFilterConfigs(),
   },
   {
     field: "qcCompleteResult",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -55,6 +55,15 @@ export const RequestsListColumns: ColDef[] = [
   {
     field: "importDate",
     headerName: "Import Date",
+    filter: "agDateColumnFilter",
+    filterParams: {
+      buttons: ["apply", "reset"],
+      filterOptions: ["inRange"],
+      inRangeInclusive: true,
+      minValidYear: 2016,
+      maxValidYear: new Date().getFullYear(),
+      suppressAndOrCondition: true,
+    },
   },
   {
     field: "totalSampleCount",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -298,6 +298,16 @@ export const SampleMetadataDetailsColumns: ColDef[] = [
   {
     field: "importDate",
     headerName: "Last Updated",
+    // TODO: standardize common filter settings like date into a function or object
+    filter: "agDateColumnFilter",
+    filterParams: {
+      buttons: ["apply", "reset"],
+      filterOptions: ["inRange"],
+      inRangeInclusive: true,
+      minValidYear: 2016,
+      maxValidYear: new Date().getFullYear(),
+      suppressAndOrCondition: true,
+    },
   },
   {
     field: "cmoPatientId",

--- a/frontend/src/utils/stringBuilders.ts
+++ b/frontend/src/utils/stringBuilders.ts
@@ -28,6 +28,14 @@ export function buildTsvString(
           });
         }
         if (colDef.field) {
+          if (colDef.valueFormatter) {
+            // @ts-ignore
+            return colDef.valueFormatter({
+              colDef,
+              data: row,
+              value: row[colDef.field],
+            });
+          }
           return row[colDef.field];
         }
         return " ";

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -420,6 +420,7 @@ function buildRequestsQueryBody({
   filters?: QueryDashboardRequestsArgs["filters"];
 }) {
   // TODO: make other queries' filter builder consistent with the below setup
+  // TODO: create resuable functions from repetitive filtering logic (e.g. boolean filter)
 
   const queryFilters = [];
 
@@ -458,6 +459,22 @@ function buildRequestsQueryBody({
       let importDateFilter = `(apoc.date.parse(importDate, 'ms', 'yyyy-MM-dd') >= apoc.date.parse('${filter.dateFrom}', 'ms', 'yyyy-MM-dd HH:mm:ss')`;
       importDateFilter += `AND apoc.date.parse(importDate, 'ms', 'yyyy-MM-dd') <= apoc.date.parse('${filter.dateTo}', 'ms', 'yyyy-MM-dd HH:mm:ss'))`;
       queryFilters.push(importDateFilter);
+    }
+
+    const bicAnalysisFilterObj = filters?.find(
+      (filter) => filter.field === "bicAnalysis"
+    );
+    if (bicAnalysisFilterObj) {
+      const filter = JSON.parse(bicAnalysisFilterObj.filter);
+      let bicAnalysisFilter;
+      if (filter.values[0] === "true") {
+        bicAnalysisFilter = "bicAnalysis = true";
+      } else if (filter.values[0] === "false") {
+        bicAnalysisFilter = "bicAnalysis = false OR bicAnalysis IS NULL";
+      } else if (filter.values.length === 0) {
+        bicAnalysisFilter = "bicAnalysis <> true AND bicAnalysis <> false";
+      }
+      queryFilters.push(bicAnalysisFilter);
     }
   }
 

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -633,36 +633,52 @@ function buildPatientsQueryBody({
   }
 
   if (filters) {
+    // Unlike other Boolean filters, for consentPartA and consentPartB columns we're giving users an option
+    // to filter by null (blanks). This is because there is a distinction between patients who explicitly
+    // did not consent to 12-245 and those who were not asked to consent
+
     const consentPartAFilterObj = filters?.find(
       (filter) => filter.field === "consentPartA"
     );
     if (consentPartAFilterObj) {
-      const filter = JSON.parse(consentPartAFilterObj.filter);
-      let consentPartAFilter;
-      if (filter.values[0] === "Yes") {
-        consentPartAFilter = "consentPartA = 'YES'";
-      } else if (filter.values[0] === "No") {
-        consentPartAFilter = "consentPartA = 'NO' OR consentPartA IS NULL";
-      } else if (filter.values.length === 0) {
-        consentPartAFilter = "consentPartA <> 'YES' AND consentPartA <> 'NO'";
+      const filterValues = JSON.parse(consentPartAFilterObj.filter).values;
+      if (filterValues?.length > 0) {
+        const consentPartAFilters = [];
+        for (const value of filterValues) {
+          if (value === "Yes") {
+            consentPartAFilters.push("consentPartA = 'YES'");
+          } else if (value === "No") {
+            consentPartAFilters.push("consentPartA = 'NO'");
+          } else if (value === null) {
+            consentPartAFilters.push("consentPartA IS NULL");
+          }
+        }
+        queryFilters.push(consentPartAFilters.join(" OR "));
+      } else {
+        queryFilters.push("consentPartA <> 'YES' AND consentPartA <> 'NO'");
       }
-      queryFilters.push(consentPartAFilter);
     }
 
     const consentPartCFilterObj = filters?.find(
       (filter) => filter.field === "consentPartC"
     );
     if (consentPartCFilterObj) {
-      const filter = JSON.parse(consentPartCFilterObj.filter);
-      let consentPartCFilter;
-      if (filter.values[0] === "Yes") {
-        consentPartCFilter = "consentPartC = 'YES'";
-      } else if (filter.values[0] === "No") {
-        consentPartCFilter = "consentPartC = 'NO' OR consentPartC IS NULL";
-      } else if (filter.values.length === 0) {
-        consentPartCFilter = "consentPartC <> 'YES' AND consentPartC <> 'NO'";
+      const filterValues = JSON.parse(consentPartCFilterObj.filter).values;
+      if (filterValues?.length > 0) {
+        const consentPartCFilters = [];
+        for (const value of filterValues) {
+          if (value === "Yes") {
+            consentPartCFilters.push("consentPartC = 'YES'");
+          } else if (value === "No") {
+            consentPartCFilters.push("consentPartC = 'NO'");
+          } else if (value === null) {
+            consentPartCFilters.push("consentPartC IS NULL");
+          }
+        }
+        queryFilters.push(consentPartCFilters.join(" OR "));
+      } else {
+        queryFilters.push("consentPartC <> 'YES' AND consentPartC <> 'NO'");
       }
-      queryFilters.push(consentPartCFilter);
     }
   }
 

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -493,33 +493,33 @@ function buildRequestsQueryBody({
     OPTIONAL MATCH (r)-[:HAS_SAMPLE]->(s:Sample)-[:HAS_METADATA]->(sm:SampleMetadata)
     WITH
       r,
-      collect(s) as samples,
+      collect(s) AS samples,
       collect(sm) AS allSampleMetadata,
       max(sm.importDate) AS latestImportDate
     WITH
       r,
-      size(samples) as totalSampleCount,
+      size(samples) AS totalSampleCount,
       [sm IN allSampleMetadata WHERE sm.importDate = latestImportDate][0] AS latestSm
 
     WITH
-      r.igoRequestId as igoRequestId,
-      r.igoProjectId as igoProjectId,
-      latestSm.importDate as importDate,
+      r.igoRequestId AS igoRequestId,
+      r.igoProjectId AS igoProjectId,
+      latestSm.importDate AS importDate,
       totalSampleCount,
-      r.projectManagerName as projectManagerName,
-      r.investigatorName as investigatorName,
-      r.investigatorEmail as investigatorEmail,
-      r.piEmail as piEmail,
-      r.dataAnalystName as dataAnalystName,
-      r.dataAnalystEmail as dataAnalystEmail,
-      r.genePanel as genePanel,
-      r.labHeadName as labHeadName,
-      r.labHeadEmail as labHeadEmail,
-      r.qcAccessEmails as qcAccessEmails,
-      r.dataAccessEmails as dataAccessEmails,
-      r.bicAnalysis as bicAnalysis,
-      r.isCmoRequest as isCmoRequest,
-      r.otherContactEmails as otherContactEmails
+      r.projectManagerName AS projectManagerName,
+      r.investigatorName AS investigatorName,
+      r.investigatorEmail AS investigatorEmail,
+      r.piEmail AS piEmail,
+      r.dataAnalystName AS dataAnalystName,
+      r.dataAnalystEmail AS dataAnalystEmail,
+      r.genePanel AS genePanel,
+      r.labHeadName AS labHeadName,
+      r.labHeadEmail AS labHeadEmail,
+      r.qcAccessEmails AS qcAccessEmails,
+      r.dataAccessEmails AS dataAccessEmails,
+      r.bicAnalysis AS bicAnalysis,
+      r.isCmoRequest AS isCmoRequest,
+      r.otherContactEmails AS otherContactEmails
 
     ${filtersAsCypher}
   `;
@@ -688,21 +688,21 @@ function buildPatientsQueryBody({
       p,
       cmoPa,
       dmpPa,
-      latestImportDate,
-      collect(s) as samples,
+      max(latestImportDate) AS latestImportDate,
+      collect(s) AS samples,
       collect(cmoSampleId) AS cmoSampleIds,
-      collect(latestSmAddlPropsJson.\`consent-parta\`) as consentPartAs,
-      collect(latestSmAddlPropsJson.\`consent-partc\`) as consentPartCs
+      collect(latestSmAddlPropsJson.\`consent-parta\`) AS consentPartAs,
+      collect(latestSmAddlPropsJson.\`consent-partc\`) AS consentPartCs
 
     WITH
       p.smilePatientId AS smilePatientId,
       cmoPa.value AS cmoPatientId,
       dmpPa.value AS dmpPatientId,
       latestImportDate,
-      size(samples) as totalSampleCount,
+      size(samples) AS totalSampleCount,
       apoc.text.join([id IN cmoSampleIds WHERE id <> ''], ', ') AS cmoSampleIds,
-      consentPartAs[0] as consentPartA,
-      consentPartCs[0] as consentPartC
+      consentPartAs[0] AS consentPartA,
+      consentPartCs[0] AS consentPartC
 
     ${filtersAsCypher}
   `;

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -419,9 +419,6 @@ function buildRequestsQueryBody({
   searchVals: QueryDashboardRequestsArgs["searchVals"];
   filters?: QueryDashboardRequestsArgs["filters"];
 }) {
-  // TODO: make other queries' filter builder consistent with the below setup
-  // TODO: create resuable functions from repetitive filtering logic (e.g. boolean filter)
-
   const queryFilters = [];
 
   if (searchVals?.length) {

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -467,14 +467,30 @@ function buildRequestsQueryBody({
     if (bicAnalysisFilterObj) {
       const filter = JSON.parse(bicAnalysisFilterObj.filter);
       let bicAnalysisFilter;
-      if (filter.values[0] === "true") {
+      if (filter.values[0] === "Yes") {
         bicAnalysisFilter = "bicAnalysis = true";
-      } else if (filter.values[0] === "false") {
+      } else if (filter.values[0] === "No") {
         bicAnalysisFilter = "bicAnalysis = false OR bicAnalysis IS NULL";
       } else if (filter.values.length === 0) {
         bicAnalysisFilter = "bicAnalysis <> true AND bicAnalysis <> false";
       }
       queryFilters.push(bicAnalysisFilter);
+    }
+
+    const cmoRequestFilterObj = filters?.find(
+      (filter) => filter.field === "isCmoRequest"
+    );
+    if (cmoRequestFilterObj) {
+      const filter = JSON.parse(cmoRequestFilterObj.filter);
+      let cmoRequestFilter;
+      if (filter.values[0] === "Yes") {
+        cmoRequestFilter = "isCmoRequest = true";
+      } else if (filter.values[0] === "No") {
+        cmoRequestFilter = "isCmoRequest = false OR isCmoRequest IS NULL";
+      } else if (filter.values.length === 0) {
+        cmoRequestFilter = "isCmoRequest <> true AND isCmoRequest <> false";
+      }
+      queryFilters.push(cmoRequestFilter);
     }
   }
 


### PR DESCRIPTION
This PR corresponds with card [#1229](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1229) and adds column filters to the following columns:
- On Requests page:
  - Import Date
  - BIC Analysis
  - CMO Request?
- On Patients page:
  - 12-245 Part A
  - 12-245 Part C
- On Samples page:
  - Last Updated
  - Initial Pipeline Run Date
  - Embargo Date
  - Latest BAM Complete Date
  - Latest MAF Complete Date
  - Latest QC Complete Date