### PR TITLE
Add support for exporting Phenotype files for dbGaP

### DIFF
--- a/frontend/src/components/DownloadModal.tsx
+++ b/frontend/src/components/DownloadModal.tsx
@@ -29,7 +29,7 @@ export function DownloadModal({
     <Modal show={true} size={"sm"}>
       <Modal.Body>
         <div className="d-flex flex-column align-items-center">
-          <p>Downloading data...</p>
+          <p>Preparing to download data...</p>
           <Spinner fadeIn={"none"} color={"lightblue"} name="ball-grid-pulse" />
         </div>
       </Modal.Body>

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -63,8 +63,8 @@ interface ISampleListProps {
   setUserEmail?: Dispatch<SetStateAction<string | null>>;
   customToolbarUI?: JSX.Element;
   exportDropdownItems?: Array<{
-    title: string;
-    colDefs: ColDef[];
+    label: string;
+    columnDefs: ColDef[];
   }>;
 }
 
@@ -84,6 +84,8 @@ export default function SamplesList({
   const [showDownloadModal, setShowDownloadModal] = useState(false);
   const [showUpdateModal, setShowUpdateModal] = useState(false);
   const [alertContent, setAlertContent] = useState<string | null>(null);
+  const [columnDefsForExport, setColumnDefsForExport] =
+    useState<ColDef[]>(columnDefs);
 
   const gridRef = useRef<AgGridReactType>(null);
   const params = useParams();
@@ -322,11 +324,14 @@ export default function SamplesList({
             });
             return buildTsvString(
               data.dashboardSamples,
-              columnDefs,
+              columnDefsForExport,
               gridRef.current?.columnApi?.getAllGridColumns()
             );
           }}
-          onComplete={() => setShowDownloadModal(false)}
+          onComplete={() => {
+            setShowDownloadModal(false);
+            setColumnDefsForExport(columnDefs);
+          }}
           exportFileName={[
             parentDataName?.slice(0, -1),
             Object.values(params)?.[0],
@@ -365,6 +370,7 @@ export default function SamplesList({
         onDownload={() => {
           if (sampleCount && sampleCount > MAX_ROWS_EXPORT) {
             setAlertContent(MAX_ROWS_EXPORT_WARNING.content);
+            setColumnDefsForExport(columnDefs);
           } else {
             setShowDownloadModal(true);
           }
@@ -410,6 +416,7 @@ export default function SamplesList({
           ) : undefined
         }
         exportDropdownItems={exportDropdownItems}
+        setColumnDefsForExport={setColumnDefsForExport}
       />
 
       <AutoSizer>

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -62,6 +62,10 @@ interface ISampleListProps {
   userEmail?: string | null;
   setUserEmail?: Dispatch<SetStateAction<string | null>>;
   customToolbarUI?: JSX.Element;
+  exportDropdownItems?: Array<{
+    title: string;
+    colDefs: ColDef[];
+  }>;
 }
 
 export default function SamplesList({
@@ -72,6 +76,7 @@ export default function SamplesList({
   userEmail,
   setUserEmail,
   customToolbarUI,
+  exportDropdownItems,
 }: ISampleListProps) {
   const [userSearchVal, setUserSearchVal] = useState<string>("");
   const [changes, setChanges] = useState<SampleChange[]>([]);
@@ -376,7 +381,6 @@ export default function SamplesList({
                     gridRef.current?.api?.redrawRows({
                       rowNodes: changes.map((c) => c.rowNode),
                     });
-
                     handleDiscardChanges();
                   }}
                   size={"sm"}
@@ -405,6 +409,7 @@ export default function SamplesList({
             </>
           ) : undefined
         }
+        exportDropdownItems={exportDropdownItems}
       />
 
       <AutoSizer>

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1424,6 +1424,7 @@ export type DashboardSample = {
   _total?: Maybe<Scalars["Int"]>;
   accessLevel?: Maybe<Scalars["String"]>;
   altId?: Maybe<Scalars["String"]>;
+  analyteType?: Maybe<Scalars["String"]>;
   baitSet?: Maybe<Scalars["String"]>;
   bamCompleteDate?: Maybe<Scalars["String"]>;
   bamCompleteStatus?: Maybe<Scalars["String"]>;
@@ -1474,6 +1475,7 @@ export type DashboardSampleInput = {
   _total?: InputMaybe<Scalars["Int"]>;
   accessLevel?: InputMaybe<Scalars["String"]>;
   altId?: InputMaybe<Scalars["String"]>;
+  analyteType?: InputMaybe<Scalars["String"]>;
   baitSet?: InputMaybe<Scalars["String"]>;
   bamCompleteDate?: InputMaybe<Scalars["String"]>;
   bamCompleteStatus?: InputMaybe<Scalars["String"]>;
@@ -1527,7 +1529,7 @@ export type DbGap = {
   samplesHasDbgap: Array<Sample>;
   samplesHasDbgapAggregate?: Maybe<DbGapSampleSamplesHasDbgapAggregationSelection>;
   samplesHasDbgapConnection: DbGapSamplesHasDbgapConnection;
-  smileDbGapId: Scalars["String"];
+  smileDbGapId?: Maybe<Scalars["String"]>;
 };
 
 export type DbGapSamplesHasDbgapArgs = {
@@ -1567,7 +1569,7 @@ export type DbGapConnectWhere = {
 export type DbGapCreateInput = {
   dbGapStudy: Scalars["String"];
   samplesHasDbgap?: InputMaybe<DbGapSamplesHasDbgapFieldInput>;
-  smileDbGapId: Scalars["String"];
+  smileDbGapId?: InputMaybe<Scalars["String"]>;
 };
 
 export type DbGapDeleteInput = {
@@ -1792,7 +1794,7 @@ export type DbGapWhere = {
   smileDbGapId?: InputMaybe<Scalars["String"]>;
   smileDbGapId_CONTAINS?: InputMaybe<Scalars["String"]>;
   smileDbGapId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_IN?: InputMaybe<Array<Scalars["String"]>>;
+  smileDbGapId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   smileDbGapId_MATCHES?: InputMaybe<Scalars["String"]>;
   smileDbGapId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
 };
@@ -11101,6 +11103,7 @@ export type DashboardSamplesQuery = {
     sex?: string | null;
     recipe?: string | null;
     altId?: string | null;
+    analyteType?: string | null;
     historicalCmoSampleNames?: string | null;
     instrumentModel?: string | null;
     platform?: string | null;
@@ -11156,6 +11159,7 @@ export type DashboardSampleMetadataPartsFragment = {
   sex?: string | null;
   recipe?: string | null;
   altId?: string | null;
+  analyteType?: string | null;
   historicalCmoSampleNames?: string | null;
   instrumentModel?: string | null;
   platform?: string | null;
@@ -11242,6 +11246,7 @@ export type UpdateDashboardSamplesMutation = {
     sex?: string | null;
     recipe?: string | null;
     altId?: string | null;
+    analyteType?: string | null;
     historicalCmoSampleNames?: string | null;
     instrumentModel?: string | null;
     platform?: string | null;
@@ -11311,6 +11316,7 @@ export const DashboardSampleMetadataPartsFragmentDoc = gql`
     sex
     recipe
     altId
+    analyteType
     historicalCmoSampleNames
     instrumentModel
     platform

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -63,8 +63,8 @@ export default function SamplesPage() {
       }
       exportDropdownItems={[
         {
-          title: "Generate phenotype report",
-          colDefs: ReadOnlyCohortSampleDetailsColumns, // TODO: replace this with the correct columnDefs
+          label: "Generate phenotype report",
+          columnDefs: ReadOnlyCohortSampleDetailsColumns, // TODO: replace this with the correct columnDefs
         },
       ]}
     />

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -61,6 +61,12 @@ export default function SamplesPage() {
           </Button>
         </>
       }
+      exportDropdownItems={[
+        {
+          title: "Generate phenotype report",
+          colDefs: ReadOnlyCohortSampleDetailsColumns, // TODO: replace this with the correct columnDefs
+        },
+      ]}
     />
   );
 }

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -1,5 +1,6 @@
 import SamplesList from "../../components/SamplesList";
 import {
+  DbGapPhenotypeColumns,
   ReadOnlyCohortSampleDetailsColumns,
   combinedSampleDetailsColumns,
 } from "../../shared/helpers";
@@ -63,8 +64,8 @@ export default function SamplesPage() {
       }
       exportDropdownItems={[
         {
-          label: "Generate phenotype report",
-          columnDefs: ReadOnlyCohortSampleDetailsColumns, // TODO: replace this with the correct columnDefs
+          label: "Generate Phenotype files for dbGaP",
+          columnDefs: DbGapPhenotypeColumns,
         },
       ]}
     />

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -497,6 +497,67 @@ export const SampleColumns: ColDef[] = [
   },
 ];
 
+export const DbGapPhenotypeColumns: ColDef[] = [
+  {
+    field: "cmoPatientId",
+    headerName: "SUBJECT_ID",
+  },
+  {
+    field: "cmoSampleName",
+    headerName: "SAMPLE_ID",
+  },
+  {
+    field: "sex",
+    headerName: "SEX",
+  },
+  {
+    // To be left empty for now as we don't have this data yet
+    headerName: "RACE",
+  },
+  {
+    field: "cancerType",
+    headerName: "CANCER_TYPE",
+  },
+  {
+    field: "tissueLocation",
+    headerName: "BODY_SITE",
+  },
+  {
+    // TODO: return from samples query
+    field: "analyteType",
+    headerName: "ANALYTE_TYPE",
+  },
+  {
+    // TODO: do PMs need this to be boolean?
+    field: "tumorOrNormal",
+    headerName: "IS_TUMOR",
+  },
+  {
+    field: "sampleType",
+    headerName: "SAMPLE_TYPE",
+  },
+  {
+    field: "cancerType",
+    headerName: "HISTOLOGICAL_TYPE",
+  },
+  {
+    field: "cancerTypeDetailed",
+    headerName: "HISTOLOGICAL_SUBTYPE",
+  },
+  {
+    field: "genePanel",
+    headerName: "SEQUENCING_PANEL",
+  },
+  {
+    field: "platform",
+    headerName: "PLATFORM",
+  },
+  {
+    field: "instrumentModel",
+    headerName: "INSTRUMENT_MODEL",
+  },
+];
+
 function createCustomHeader(icons: string) {
   return {
     template: `

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -523,12 +523,10 @@ export const DbGapPhenotypeColumns: ColDef[] = [
     headerName: "BODY_SITE",
   },
   {
-    // TODO: return from samples query
     field: "analyteType",
     headerName: "ANALYTE_TYPE",
   },
   {
-    // TODO: do PMs need this to be boolean?
     field: "tumorOrNormal",
     headerName: "IS_TUMOR",
   },

--- a/frontend/src/shared/tableElements.tsx
+++ b/frontend/src/shared/tableElements.tsx
@@ -1,11 +1,12 @@
 import { ApolloError } from "@apollo/client";
 import classNames from "classnames";
-import { Button, Col, Form, Row } from "react-bootstrap";
+import { Button, ButtonGroup, Dropdown, Col, Form, Row } from "react-bootstrap";
 import Spinner from "react-spinkit";
 import { DataName } from "./types";
 import { Dispatch, SetStateAction } from "react";
 import { InfoToolTip } from "./components/InfoToolTip";
 import { PatientIdsTriplet } from "../generated/graphql";
+import { ColDef } from "ag-grid-community";
 
 export function LoadingSpinner() {
   return (
@@ -33,6 +34,10 @@ interface IToolbarProps {
   onDownload: () => void;
   customUILeft?: JSX.Element;
   customUIRight?: JSX.Element;
+  exportDropdownItems?: Array<{
+    title: string;
+    colDefs: ColDef[];
+  }>;
 }
 
 export function Toolbar({
@@ -45,6 +50,7 @@ export function Toolbar({
   onDownload,
   customUILeft,
   customUIRight,
+  exportDropdownItems,
 }: IToolbarProps) {
   return (
     <Row className={classNames("d-flex align-items-center tableControlsRow")}>
@@ -99,9 +105,24 @@ export function Toolbar({
       {customUIRight}
 
       <Col className={"text-end"}>
-        <Button onClick={onDownload} size={"sm"}>
-          Generate report
-        </Button>
+        <Dropdown as={ButtonGroup}>
+          <Button onClick={onDownload} size={"sm"}>
+            Generate report
+          </Button>
+          {exportDropdownItems?.length && (
+            <>
+              <Dropdown.Toggle size="sm" split id="dropdown-split-basic" />
+              {exportDropdownItems.map((item) => (
+                <Dropdown.Menu>
+                  {/* TODO: make onDownload customizable */}
+                  <Dropdown.Item as={Button} onClick={onDownload}>
+                    {item.title}
+                  </Dropdown.Item>
+                </Dropdown.Menu>
+              ))}
+            </>
+          )}
+        </Dropdown>
       </Col>
     </Row>
   );

--- a/frontend/src/shared/tableElements.tsx
+++ b/frontend/src/shared/tableElements.tsx
@@ -35,9 +35,10 @@ interface IToolbarProps {
   customUILeft?: JSX.Element;
   customUIRight?: JSX.Element;
   exportDropdownItems?: Array<{
-    title: string;
-    colDefs: ColDef[];
+    label: string;
+    columnDefs: ColDef[];
   }>;
+  setColumnDefsForExport?: Dispatch<SetStateAction<ColDef[]>>;
 }
 
 export function Toolbar({
@@ -51,6 +52,7 @@ export function Toolbar({
   customUILeft,
   customUIRight,
   exportDropdownItems,
+  setColumnDefsForExport,
 }: IToolbarProps) {
   return (
     <Row className={classNames("d-flex align-items-center tableControlsRow")}>
@@ -109,14 +111,19 @@ export function Toolbar({
           <Button onClick={onDownload} size={"sm"}>
             Generate report
           </Button>
-          {exportDropdownItems?.length && (
+          {exportDropdownItems?.length && setColumnDefsForExport && (
             <>
               <Dropdown.Toggle size="sm" split id="dropdown-split-basic" />
               {exportDropdownItems.map((item) => (
                 <Dropdown.Menu>
-                  {/* TODO: make onDownload customizable */}
-                  <Dropdown.Item as={Button} onClick={onDownload}>
-                    {item.title}
+                  <Dropdown.Item
+                    as="button"
+                    onClick={() => {
+                      setColumnDefsForExport(item.columnDefs);
+                      onDownload();
+                    }}
+                  >
+                    {item.label}
                   </Dropdown.Item>
                 </Dropdown.Menu>
               ))}

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1423,6 +1423,7 @@ export type DashboardSample = {
   _total?: Maybe<Scalars["Int"]>;
   accessLevel?: Maybe<Scalars["String"]>;
   altId?: Maybe<Scalars["String"]>;
+  analyteType?: Maybe<Scalars["String"]>;
   baitSet?: Maybe<Scalars["String"]>;
   bamCompleteDate?: Maybe<Scalars["String"]>;
   bamCompleteStatus?: Maybe<Scalars["String"]>;
@@ -1473,6 +1474,7 @@ export type DashboardSampleInput = {
   _total?: InputMaybe<Scalars["Int"]>;
   accessLevel?: InputMaybe<Scalars["String"]>;
   altId?: InputMaybe<Scalars["String"]>;
+  analyteType?: InputMaybe<Scalars["String"]>;
   baitSet?: InputMaybe<Scalars["String"]>;
   bamCompleteDate?: InputMaybe<Scalars["String"]>;
   bamCompleteStatus?: InputMaybe<Scalars["String"]>;
@@ -1526,7 +1528,7 @@ export type DbGap = {
   samplesHasDbgap: Array<Sample>;
   samplesHasDbgapAggregate?: Maybe<DbGapSampleSamplesHasDbgapAggregationSelection>;
   samplesHasDbgapConnection: DbGapSamplesHasDbgapConnection;
-  smileDbGapId: Scalars["String"];
+  smileDbGapId?: Maybe<Scalars["String"]>;
 };
 
 export type DbGapSamplesHasDbgapArgs = {
@@ -1566,7 +1568,7 @@ export type DbGapConnectWhere = {
 export type DbGapCreateInput = {
   dbGapStudy: Scalars["String"];
   samplesHasDbgap?: InputMaybe<DbGapSamplesHasDbgapFieldInput>;
-  smileDbGapId: Scalars["String"];
+  smileDbGapId?: InputMaybe<Scalars["String"]>;
 };
 
 export type DbGapDeleteInput = {
@@ -1791,7 +1793,7 @@ export type DbGapWhere = {
   smileDbGapId?: InputMaybe<Scalars["String"]>;
   smileDbGapId_CONTAINS?: InputMaybe<Scalars["String"]>;
   smileDbGapId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_IN?: InputMaybe<Array<Scalars["String"]>>;
+  smileDbGapId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
   smileDbGapId_MATCHES?: InputMaybe<Scalars["String"]>;
   smileDbGapId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
 };
@@ -11100,6 +11102,7 @@ export type DashboardSamplesQuery = {
     sex?: string | null;
     recipe?: string | null;
     altId?: string | null;
+    analyteType?: string | null;
     historicalCmoSampleNames?: string | null;
     instrumentModel?: string | null;
     platform?: string | null;
@@ -11155,6 +11158,7 @@ export type DashboardSampleMetadataPartsFragment = {
   sex?: string | null;
   recipe?: string | null;
   altId?: string | null;
+  analyteType?: string | null;
   historicalCmoSampleNames?: string | null;
   instrumentModel?: string | null;
   platform?: string | null;
@@ -11241,6 +11245,7 @@ export type UpdateDashboardSamplesMutation = {
     sex?: string | null;
     recipe?: string | null;
     altId?: string | null;
+    analyteType?: string | null;
     historicalCmoSampleNames?: string | null;
     instrumentModel?: string | null;
     platform?: string | null;
@@ -11310,6 +11315,7 @@ export const DashboardSampleMetadataPartsFragmentDoc = gql`
     sex
     recipe
     altId
+    analyteType
     historicalCmoSampleNames
     instrumentModel
     platform

--- a/graphql-server/src/schemas/queries/samples.ts
+++ b/graphql-server/src/schemas/queries/samples.ts
@@ -62,6 +62,7 @@ export function buildSamplesQueryBody({
       "qcCompleteStatus",
       "historicalCmoSampleNames",
       "sampleCategory",
+      "dbGapStudy",
     ];
     searchFilters += fieldsToSearch
       .map(

--- a/graphql-server/src/schemas/queries/samples.ts
+++ b/graphql-server/src/schemas/queries/samples.ts
@@ -288,7 +288,8 @@ export function buildSamplesQueryBody({
       t,
       latestBC[0] AS latestBC,
       latestMC[0] AS latestMC,
-      latestQC[0] AS latestQC
+      latestQC[0] AS latestQC,
+      apoc.convert.fromJsonMap(latestSm.cmoSampleIdFields) AS cmoSampleIdFields
 
       ${bamCompleteDateFilter && `WHERE ${bamCompleteDateFilter}`}
       ${mafCompleteDateFilter && `WHERE ${mafCompleteDateFilter}`}
@@ -324,7 +325,8 @@ export function buildSamplesQueryBody({
         tissueLocation: latestSm.tissueLocation,
         sex: latestSm.sex,
         libraries: latestSm.libraries,
-        recipe: apoc.convert.fromJsonMap(latestSm.cmoSampleIdFields).recipe,
+        recipe: cmoSampleIdFields.recipe,
+        analyteType: cmoSampleIdFields.naToExtract,
         altId: apoc.convert.fromJsonMap(latestSm.additionalProperties).altId,
         validationReport: latestSt.validationReport,
         validationStatus: latestSt.validationStatus,

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -51,6 +51,7 @@ const SAMPLE_FIELDS = `
   ## Custom fields
   recipe: String
   altId: String
+  analyteType: String
   historicalCmoSampleNames: String
   instrumentModel: String
   platform: String

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -12770,6 +12770,18 @@
             "deprecationReason": null
           },
           {
+            "name": "analyteType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "baitSet",
             "description": null,
             "args": [],
@@ -13351,6 +13363,18 @@
           },
           {
             "name": "altId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "analyteType",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -14143,13 +14167,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -14315,13 +14335,9 @@
             "name": "smileDbGapId",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -16487,13 +16503,9 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "defaultValue": null,

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -142,6 +142,7 @@ fragment DashboardSampleMetadataParts on DashboardSample {
   ## Custom fields
   recipe
   altId
+  analyteType
   historicalCmoSampleNames
   instrumentModel
   platform


### PR DESCRIPTION
This PR introduces the following:
- Ability to "Generate Phenotype files for dbGaP" on the Samples page
- `analyteType` data in the Samples query's result

![CleanShot 2025-04-23 at 15 46 17](https://github.com/user-attachments/assets/e8162783-d34d-47d7-81db-7e629f7cc4be)

[#1205](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1205)