### PR TITLE
Fix casing mismatches in the request sample validation mapping

### DIFF
--- a/frontend/src/configs/recordValidationMaps.ts
+++ b/frontend/src/configs/recordValidationMaps.ts
@@ -132,7 +132,7 @@ export const REQUEST_STATUS_MAP: StatusMap = {
       actionItem: getActionItemForMissingIgoField("samples"),
       responsibleParty: "IGO",
     },
-  "samples (failed) some request samples failed validation": {
+  "samples (failed) Some request samples failed validation": {
     item: "samples (failed)",
     description: "Some request samples failed validation",
     actionItem:
@@ -140,7 +140,7 @@ export const REQUEST_STATUS_MAP: StatusMap = {
       " contact the SMILE team.",
     responsibleParty: "",
   },
-  "samples (failed) all request samples failed validation": {
+  "samples (failed) All request samples failed validation": {
     item: "samples (failed)",
     description: "All request samples failed validation",
     actionItem:


### PR DESCRIPTION
Quick bug fix to ensure the request validation captures all validation reports correctly. See more details at [#1530](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1530).