### PR TITLE
Add a new view on Samples page for ACCESS samples

### DIFF
--- a/frontend/src/components/RecordValidation.tsx
+++ b/frontend/src/components/RecordValidation.tsx
@@ -12,6 +12,7 @@ import {
   StatusItem,
   StatusMap,
 } from "../configs/recordValidationMaps";
+import { multiLineColDef } from "../shared/helpers";
 
 type ModalTitle = `Error report for ${string}`;
 
@@ -77,16 +78,6 @@ const validationColDefs: ColDef<StatusItem>[] = [
   },
 ];
 
-const defaultColDef: ColDef = {
-  wrapText: true,
-  autoHeight: true,
-  cellStyle: {
-    wordBreak: "break-word",
-    lineHeight: "1.25",
-    padding: "6px 18px",
-  },
-};
-
 function ErrorReportModal({
   show,
   onHide,
@@ -150,7 +141,7 @@ function ErrorReportModal({
             groupDisplayType="groupRows"
             rowData={validationDataForAgGrid}
             columnDefs={validationColDefs}
-            defaultColDef={defaultColDef}
+            defaultColDef={multiLineColDef}
             onGridReady={(params) => params.api.sizeColumnsToFit()}
           />
         </div>

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -30,7 +30,7 @@ import {
   defaultColDef,
   MAX_ROWS_EXPORT,
 } from "../shared/helpers";
-import { ErrorMessage, Toolbar } from "../shared/tableElements";
+import { ErrorMessage, Toolbar } from "../shared/components/Toolbar";
 import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
 import { BreadCrumb } from "../shared/components/BreadCrumb";
 import { Title } from "../shared/components/Title";

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -17,9 +17,9 @@ import { ColDef, IServerSideGetRowsParams } from "ag-grid-community";
 import { DataName, useHookLazyGeneric } from "../shared/types";
 import SamplesList from "./SamplesList";
 import {
-  DashboardRecordContext,
   DashboardRecordFilter,
   DashboardRecordSort,
+  DashboardSamplesQueryVariables,
   PatientIdsTriplet,
   QueryDashboardCohortsArgs,
   QueryDashboardPatientsArgs,
@@ -49,7 +49,7 @@ interface IRecordsListProps {
   setShowDownloadModal: Dispatch<SetStateAction<boolean>>;
   handleDownload: (recordCount: number) => void;
   samplesColDefs: ColDef[];
-  sampleContext?: DashboardRecordContext;
+  sampleContexts?: DashboardSamplesQueryVariables["contexts"];
   userEmail?: string | null;
   setUserEmail?: Dispatch<SetStateAction<string | null>>;
   customToolbarUI?: JSX.Element;
@@ -68,7 +68,7 @@ export default function RecordsList({
   setShowDownloadModal,
   handleDownload,
   samplesColDefs,
-  sampleContext,
+  sampleContexts,
   userEmail,
   setUserEmail,
   customToolbarUI,
@@ -243,7 +243,7 @@ export default function RecordsList({
                   <SamplesList
                     columnDefs={samplesColDefs}
                     parentDataName={dataName}
-                    sampleContext={sampleContext}
+                    sampleContexts={sampleContexts}
                     setUnsavedChanges={setUnsavedChanges}
                     userEmail={userEmail}
                     setUserEmail={setUserEmail}

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -1,10 +1,7 @@
 import {
   AgGridSortDirection,
-  DashboardRecordContext,
   DashboardRecordFilter,
   DashboardRecordSort,
-  DashboardRequestsQueryVariables,
-  DashboardSamplesQuery,
   DashboardSamplesQueryVariables,
   QueryDashboardSamplesArgs,
   useDashboardSamplesLazyQuery,

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -3,6 +3,9 @@ import {
   DashboardRecordContext,
   DashboardRecordFilter,
   DashboardRecordSort,
+  DashboardRequestsQueryVariables,
+  DashboardSamplesQuery,
+  DashboardSamplesQueryVariables,
   QueryDashboardSamplesArgs,
   useDashboardSamplesLazyQuery,
 } from "../generated/graphql";
@@ -58,7 +61,7 @@ interface ISampleListProps {
   columnDefs: ColDef[];
   setUnsavedChanges?: (unsavedChanges: boolean) => void;
   parentDataName?: DataName;
-  sampleContext?: DashboardRecordContext;
+  sampleContexts?: DashboardSamplesQueryVariables["contexts"];
   userEmail?: string | null;
   setUserEmail?: Dispatch<SetStateAction<string | null>>;
   customToolbarUI?: JSX.Element;
@@ -71,7 +74,7 @@ interface ISampleListProps {
 export default function SamplesList({
   columnDefs,
   parentDataName,
-  sampleContext,
+  sampleContexts,
   setUnsavedChanges,
   userEmail,
   setUserEmail,
@@ -95,7 +98,7 @@ export default function SamplesList({
     useDashboardSamplesLazyQuery({
       variables: {
         searchVals: [],
-        context: sampleContext,
+        contexts: sampleContexts,
         sort: DEFAULT_SORT,
         limit: CACHE_BLOCK_SIZE,
         offset: 0,
@@ -107,7 +110,7 @@ export default function SamplesList({
   const sampleCount = data?.dashboardSamples[0]?._total || 0;
 
   const getServerSideDatasource = useCallback(
-    ({ userSearchVal, sampleContext }) => {
+    ({ userSearchVal, sampleContexts }) => {
       return {
         getRows: async (params: IServerSideGetRowsParams) => {
           let filters: DashboardRecordFilter[] | undefined;
@@ -125,7 +128,7 @@ export default function SamplesList({
 
           const fetchInput = {
             searchVals: parseUserSearchVal(userSearchVal),
-            sampleContext,
+            contexts: sampleContexts,
             sort: params.request.sortModel[0] || DEFAULT_SORT,
             filters,
             offset: params.request.startRow ?? 0,
@@ -159,7 +162,7 @@ export default function SamplesList({
   function refreshData(userSearchVal: string) {
     const newDatasource = getServerSideDatasource({
       userSearchVal,
-      sampleContext,
+      sampleContexts,
     });
     gridRef.current?.api.setServerSideDatasource(newDatasource); // triggers a refresh
   }

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -33,7 +33,7 @@ import {
   ColDef,
   IServerSideGetRowsParams,
 } from "ag-grid-community";
-import { ErrorMessage, Toolbar } from "../shared/tableElements";
+import { ErrorMessage, Toolbar } from "../shared/components/Toolbar";
 import styles from "./records.module.scss";
 import { getUserEmail } from "../utils/getUserEmail";
 import { openLoginPopup } from "../utils/openLoginPopup";

--- a/frontend/src/configs/recordValidationMaps.ts
+++ b/frontend/src/configs/recordValidationMaps.ts
@@ -136,8 +136,8 @@ export const REQUEST_STATUS_MAP: StatusMap = {
     item: "samples (failed)",
     description: "Some request samples failed validation",
     actionItem:
-      "Review each sample's validation error below. If sample-level errors are missing or incorrect, please" +
-      " contact the SMILE team.",
+      "Sample validation errors of critically failed samples are listed below. See the Request Samples view" +
+      " for errors of tolerable failures. If anything is missing or incorrect, please contact the SMILE team.",
     responsibleParty: "",
   },
   "samples (failed) All request samples failed validation": {

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1435,6 +1435,7 @@ export type DashboardSample = {
   billedBy?: Maybe<Scalars["String"]>;
   cancerType?: Maybe<Scalars["String"]>;
   cancerTypeDetailed?: Maybe<Scalars["String"]>;
+  cfDNA2dBarcode?: Maybe<Scalars["String"]>;
   cmoPatientId?: Maybe<Scalars["String"]>;
   cmoSampleName?: Maybe<Scalars["String"]>;
   collectionYear?: Maybe<Scalars["String"]>;
@@ -1486,6 +1487,7 @@ export type DashboardSampleInput = {
   billedBy?: InputMaybe<Scalars["String"]>;
   cancerType?: InputMaybe<Scalars["String"]>;
   cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
   changedFieldNames: Array<Scalars["String"]>;
   cmoPatientId?: InputMaybe<Scalars["String"]>;
   cmoSampleName?: InputMaybe<Scalars["String"]>;
@@ -11110,6 +11112,7 @@ export type DashboardSamplesQuery = {
     sampleOrigin?: string | null;
     tissueLocation?: string | null;
     sex?: string | null;
+    cfDNA2dBarcode?: string | null;
     recipe?: string | null;
     altId?: string | null;
     analyteType?: string | null;
@@ -11166,6 +11169,7 @@ export type DashboardSampleMetadataPartsFragment = {
   sampleOrigin?: string | null;
   tissueLocation?: string | null;
   sex?: string | null;
+  cfDNA2dBarcode?: string | null;
   recipe?: string | null;
   altId?: string | null;
   analyteType?: string | null;
@@ -11253,6 +11257,7 @@ export type UpdateDashboardSamplesMutation = {
     sampleOrigin?: string | null;
     tissueLocation?: string | null;
     sex?: string | null;
+    cfDNA2dBarcode?: string | null;
     recipe?: string | null;
     altId?: string | null;
     analyteType?: string | null;
@@ -11323,6 +11328,7 @@ export const DashboardSampleMetadataPartsFragmentDoc = gql`
     sampleOrigin
     tissueLocation
     sex
+    cfDNA2dBarcode
     recipe
     altId
     analyteType

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -4184,7 +4184,7 @@ export type QueryDashboardRequestsArgs = {
 };
 
 export type QueryDashboardSamplesArgs = {
-  context?: InputMaybe<DashboardRecordContext>;
+  contexts?: InputMaybe<Array<InputMaybe<DashboardRecordContext>>>;
   filters?: InputMaybe<Array<DashboardRecordFilter>>;
   limit: Scalars["Int"];
   offset: Scalars["Int"];
@@ -11075,7 +11075,10 @@ export type DashboardCohortsQuery = {
 
 export type DashboardSamplesQueryVariables = Exact<{
   searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
-  context?: InputMaybe<DashboardRecordContext>;
+  contexts?: InputMaybe<
+    | Array<InputMaybe<DashboardRecordContext>>
+    | InputMaybe<DashboardRecordContext>
+  >;
   sort: DashboardRecordSort;
   filters?: InputMaybe<Array<DashboardRecordFilter> | DashboardRecordFilter>;
   limit: Scalars["Int"];
@@ -11643,7 +11646,7 @@ export type DashboardCohortsQueryResult = Apollo.QueryResult<
 export const DashboardSamplesDocument = gql`
   query DashboardSamples(
     $searchVals: [String!]
-    $context: DashboardRecordContext
+    $contexts: [DashboardRecordContext]
     $sort: DashboardRecordSort!
     $filters: [DashboardRecordFilter!]
     $limit: Int!
@@ -11651,7 +11654,7 @@ export const DashboardSamplesDocument = gql`
   ) {
     dashboardSamples(
       searchVals: $searchVals
-      context: $context
+      contexts: $contexts
       sort: $sort
       filters: $filters
       limit: $limit
@@ -11683,7 +11686,7 @@ export const DashboardSamplesDocument = gql`
  * const { data, loading, error } = useDashboardSamplesQuery({
  *   variables: {
  *      searchVals: // value for 'searchVals'
- *      context: // value for 'context'
+ *      contexts: // value for 'contexts'
  *      sort: // value for 'sort'
  *      filters: // value for 'filters'
  *      limit: // value for 'limit'

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1442,6 +1442,7 @@ export type DashboardSample = {
   costCenter?: Maybe<Scalars["String"]>;
   custodianInformation?: Maybe<Scalars["String"]>;
   dbGapStudy?: Maybe<Scalars["String"]>;
+  dmpPatientAlias?: Maybe<Scalars["String"]>;
   embargoDate?: Maybe<Scalars["String"]>;
   genePanel?: Maybe<Scalars["String"]>;
   historicalCmoSampleNames?: Maybe<Scalars["String"]>;
@@ -1495,6 +1496,7 @@ export type DashboardSampleInput = {
   costCenter?: InputMaybe<Scalars["String"]>;
   custodianInformation?: InputMaybe<Scalars["String"]>;
   dbGapStudy?: InputMaybe<Scalars["String"]>;
+  dmpPatientAlias?: InputMaybe<Scalars["String"]>;
   embargoDate?: InputMaybe<Scalars["String"]>;
   genePanel?: InputMaybe<Scalars["String"]>;
   historicalCmoSampleNames?: InputMaybe<Scalars["String"]>;
@@ -11140,6 +11142,7 @@ export type DashboardSamplesQuery = {
     qcCompleteReason?: string | null;
     qcCompleteStatus?: string | null;
     dbGapStudy?: string | null;
+    dmpPatientAlias?: string | null;
   }>;
 };
 
@@ -11205,6 +11208,11 @@ export type DashboardTempoPartsFragment = {
 export type DashboardDbGapPartsFragment = {
   __typename?: "DashboardSample";
   dbGapStudy?: string | null;
+};
+
+export type DashboardPatientPartsFragment = {
+  __typename?: "DashboardSample";
+  dmpPatientAlias?: string | null;
 };
 
 export type RequestPartsFragment = {
@@ -11364,6 +11372,11 @@ export const DashboardTempoPartsFragmentDoc = gql`
 export const DashboardDbGapPartsFragmentDoc = gql`
   fragment DashboardDbGapParts on DashboardSample {
     dbGapStudy
+  }
+`;
+export const DashboardPatientPartsFragmentDoc = gql`
+  fragment DashboardPatientParts on DashboardSample {
+    dmpPatientAlias
   }
 `;
 export const RequestPartsFragmentDoc = gql`
@@ -11670,6 +11683,7 @@ export const DashboardSamplesDocument = gql`
       ...DashboardSampleMetadataParts
       ...DashboardTempoParts
       ...DashboardDbGapParts
+      ...DashboardPatientParts
       _total
     }
   }
@@ -11677,6 +11691,7 @@ export const DashboardSamplesDocument = gql`
   ${DashboardSampleMetadataPartsFragmentDoc}
   ${DashboardTempoPartsFragmentDoc}
   ${DashboardDbGapPartsFragmentDoc}
+  ${DashboardPatientPartsFragmentDoc}
 `;
 
 /**

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -61,12 +61,14 @@ export default function CohortsPage({
           }
         }}
         samplesColDefs={wesSampleColDefs}
-        sampleContext={
+        sampleContexts={
           sampleQueryParamValue
-            ? {
-                fieldName: sampleQueryParamFieldName,
-                values: [sampleQueryParamValue],
-              }
+            ? [
+                {
+                  fieldName: sampleQueryParamFieldName,
+                  values: [sampleQueryParamValue],
+                },
+              ]
             : undefined
         }
         userEmail={userEmail}

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -234,12 +234,14 @@ export default function PatientsPage({
           }
         }}
         samplesColDefs={sampleColDefs}
-        sampleContext={
+        sampleContexts={
           sampleQueryParamValue
-            ? {
-                fieldName: sampleQueryParamFieldName,
-                values: [sampleQueryParamValue],
-              }
+            ? [
+                {
+                  fieldName: sampleQueryParamFieldName,
+                  values: [sampleQueryParamValue],
+                },
+              ]
             : undefined
         }
         customToolbarUI={

--- a/frontend/src/pages/requests/RequestsPage.tsx
+++ b/frontend/src/pages/requests/RequestsPage.tsx
@@ -53,12 +53,14 @@ export default function RequestsPage() {
           }
         }}
         samplesColDefs={sampleColDefs}
-        sampleContext={
+        sampleContexts={
           sampleQueryParamValue
-            ? {
-                fieldName: sampleQueryParamFieldName,
-                values: [sampleQueryParamValue],
-              }
+            ? [
+                {
+                  fieldName: sampleQueryParamFieldName,
+                  values: [sampleQueryParamValue],
+                },
+              ]
             : undefined
         }
       />

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -10,30 +10,32 @@ import _ from "lodash";
 import { CustomTooltip } from "../../shared/components/CustomToolTip";
 import InfoIcon from "@material-ui/icons/InfoOutlined";
 
-const WES_SAMPLE_CONTEXT = {
-  fieldName: "genePanel",
-  values: [
-    "Agilent_51MB",
-    "Agilent_v4_51MB_Human",
-    "CustomCapture",
-    "IDT_Exome_v1_FP",
-    "IDT_Exome_V1_IMPACT468",
-    "WES_Human",
-    "WholeExomeSequencing",
-  ],
-};
+const WES_SAMPLE_CONTEXT = [
+  {
+    fieldName: "genePanel",
+    values: [
+      "Agilent_51MB",
+      "Agilent_v4_51MB_Human",
+      "CustomCapture",
+      "IDT_Exome_v1_FP",
+      "IDT_Exome_V1_IMPACT468",
+      "WES_Human",
+      "WholeExomeSequencing",
+    ],
+  },
+];
 
 export default function SamplesPage() {
   const [columnDefs, setColumnDefs] = useState(combinedSampleDetailsColumns);
 
-  const sampleContext = _.isEqual(columnDefs, combinedSampleDetailsColumns)
+  const sampleContexts = _.isEqual(columnDefs, combinedSampleDetailsColumns)
     ? undefined
     : WES_SAMPLE_CONTEXT;
 
   return (
     <SamplesList
       columnDefs={columnDefs}
-      sampleContext={sampleContext}
+      sampleContexts={sampleContexts}
       customToolbarUI={
         <>
           <CustomTooltip

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -85,7 +85,7 @@ const tabSettings = new Map<
     },
   ],
   [
-    "ACCESS",
+    "ACCESS/CMO-CH",
     {
       columnDefs: readOnlyAccessSampleColDefs,
       sampleContexts: ACCESS_SAMPLE_CONTEXT,
@@ -108,8 +108,8 @@ export default function SamplesPage() {
             icon={<InfoIcon style={{ fontSize: 18, color: "grey" }} />}
           >
             These tabs filter the data and relevant columns displayed in the
-            table. "All" shows all samples, whereas "WES" and "ACCESS" show only
-            whole exome and MSK-ACCESS/CMO-CH samples, respectively.
+            table. "All" shows all samples, whereas "WES" and "ACCESS/CMO-CH"
+            show only whole exome and MSK-ACCESS/CMO-CH samples, respectively.
           </CustomTooltip>{" "}
           <ButtonGroup>
             {Array.from(tabSettings.keys()).map((tabKey) => (

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -5,10 +5,16 @@ import {
   combinedSampleDetailsColumns,
 } from "../../shared/helpers";
 import { useState } from "react";
-import { Button } from "react-bootstrap";
+import {
+  Button,
+  Dropdown,
+  DropdownButton,
+  DropdownButtonProps,
+} from "react-bootstrap";
 import _ from "lodash";
 import { CustomTooltip } from "../../shared/components/CustomToolTip";
 import InfoIcon from "@material-ui/icons/InfoOutlined";
+import { ButtonVariant } from "react-bootstrap/esm/types";
 
 const WES_SAMPLE_CONTEXT = [
   {
@@ -68,40 +74,38 @@ export default function SamplesPage() {
     ? undefined
     : WES_SAMPLE_CONTEXT;
 
+  const filterButtonTitle = _.isEqual(columnDefs, combinedSampleDetailsColumns)
+    ? "Filter sample views"
+    : "View WES samples";
+
+  const filterButtonColorVariant: ButtonVariant = _.isEqual(
+    columnDefs,
+    combinedSampleDetailsColumns
+  )
+    ? "outline-secondary"
+    : "success";
+
   return (
     <SamplesList
       columnDefs={columnDefs}
       sampleContexts={sampleContexts}
       customToolbarUI={
-        <>
-          <CustomTooltip
-            icon={<InfoIcon style={{ fontSize: 18, color: "grey" }} />}
-          >
-            These tabs change the data displayed in the table. "View all
-            samples" shows all data and columns, including those of
-            SampleMetadata and WES samples.
-          </CustomTooltip>{" "}
-          <Button
-            onClick={() => {
-              setColumnDefs(combinedSampleDetailsColumns);
-            }}
-            size="sm"
-            variant="outline-secondary"
-            active={_.isEqual(columnDefs, combinedSampleDetailsColumns)}
+        <DropdownButton
+          title={filterButtonTitle}
+          size="sm"
+          variant={filterButtonColorVariant}
+        >
+          <Dropdown.Item
+            onClick={() => setColumnDefs(combinedSampleDetailsColumns)}
           >
             View all samples
-          </Button>{" "}
-          <Button
-            onClick={() => {
-              setColumnDefs(ReadOnlyCohortSampleDetailsColumns);
-            }}
-            size="sm"
-            variant="outline-secondary"
-            active={_.isEqual(columnDefs, ReadOnlyCohortSampleDetailsColumns)}
+          </Dropdown.Item>
+          <Dropdown.Item
+            onClick={() => setColumnDefs(ReadOnlyCohortSampleDetailsColumns)}
           >
             View WES samples
-          </Button>
-        </>
+          </Dropdown.Item>
+        </DropdownButton>
       }
       exportDropdownItems={[
         {

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -25,6 +25,42 @@ const WES_SAMPLE_CONTEXT = [
   },
 ];
 
+const ACCESS_SAMPLE_CONTEXT = [
+  {
+    fieldName: "genePanel",
+    values: [
+      "ACCESS129",
+      "ACCESS146",
+      "ACCESS148",
+      "ACCESS-Heme",
+      "ACCESS-HEME-115",
+      "HC_ACCESS",
+      "HC_Custom",
+      "MSK-ACCESS_v1",
+      "MSK-ACCESS_v2",
+      "HC_CMOCH",
+      "CMO-CH",
+    ],
+  },
+  {
+    fieldName: "baitSet",
+    values: [
+      "MSK-ACCESS-v1_0-probesAllwFP",
+      "MSK-ACCESS-v1_0-probesAllwFP_GRCh38",
+      "MSK-ACCESS-v1_0-probesAllwFP_hg19_sort_BAITS",
+      "MSK-ACCESS-v1_0-probesAllwFP_hg37_sort-BAITS",
+      "MSK-ACCESS-v2_0-probesAllwFP",
+      "ACCESS_HEME_MN1",
+      "ACCESS129",
+      "ACCESS146",
+      "ACCESS148",
+      "ACCESS-HEME-115",
+      "CMO-CH",
+      "MSK-CH",
+    ],
+  },
+];
+
 export default function SamplesPage() {
   const [columnDefs, setColumnDefs] = useState(combinedSampleDetailsColumns);
 

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -3,7 +3,7 @@ import {
   DbGapPhenotypeColumns,
   readOnlyAccessSampleColDefs,
   readOnlyWesSampleColDefs,
-  combinedSampleDetailsColumns,
+  combinedSampleColDefs,
 } from "../../shared/helpers";
 import { useState } from "react";
 import { Button, ButtonGroup } from "react-bootstrap";
@@ -73,7 +73,7 @@ const tabSettings = new Map<
   [
     "All",
     {
-      columnDefs: combinedSampleDetailsColumns,
+      columnDefs: combinedSampleColDefs,
       sampleContexts: undefined,
     },
   ],
@@ -93,14 +93,14 @@ const tabSettings = new Map<
   ],
 ]);
 
-type TabKey = typeof tabSettings extends Map<infer K, any> ? K : never;
-
 export default function SamplesPage() {
-  const [filteredTabKey, setFilteredTabKey] = useState<TabKey>("All");
+  const [filteredTabKey, setFilteredTabKey] = useState("All");
 
   return (
     <SamplesList
-      columnDefs={tabSettings.get(filteredTabKey)?.columnDefs!}
+      columnDefs={
+        tabSettings.get(filteredTabKey)?.columnDefs ?? combinedSampleColDefs
+      }
       sampleContexts={tabSettings.get(filteredTabKey)?.sampleContexts}
       customToolbarUI={
         <>
@@ -114,7 +114,8 @@ export default function SamplesPage() {
           <ButtonGroup>
             {Array.from(tabSettings.keys()).map((tabKey) => (
               <Button
-                onClick={() => setFilteredTabKey(tabKey as TabKey)}
+                key={tabKey}
+                onClick={() => setFilteredTabKey(tabKey)}
                 size="sm"
                 variant="outline-secondary"
                 active={filteredTabKey === tabKey}

--- a/frontend/src/shared/components/Toolbar.tsx
+++ b/frontend/src/shared/components/Toolbar.tsx
@@ -2,10 +2,10 @@ import { ApolloError } from "@apollo/client";
 import classNames from "classnames";
 import { Button, ButtonGroup, Dropdown, Col, Form, Row } from "react-bootstrap";
 import Spinner from "react-spinkit";
-import { DataName } from "./types";
+import { DataName } from "../types";
 import { Dispatch, SetStateAction } from "react";
-import { CustomTooltip } from "./components/CustomToolTip";
-import { PatientIdsTriplet } from "../generated/graphql";
+import { CustomTooltip } from "./CustomToolTip";
+import { PatientIdsTriplet } from "../../generated/graphql";
 import { ColDef } from "ag-grid-community";
 import InfoIcon from "@material-ui/icons/InfoOutlined";
 
@@ -42,7 +42,6 @@ interface IToolbarProps {
   setColumnDefsForExport?: Dispatch<SetStateAction<ColDef[]>>;
 }
 
-// TODO: rename file to Toolbar.tsx
 export function Toolbar({
   dataName,
   userSearchVal,
@@ -61,6 +60,18 @@ export function Toolbar({
       <Col>{customUILeft}</Col>
 
       <Col md="auto">
+        <CustomTooltip
+          icon={
+            <InfoIcon style={{ fontSize: 18, color: "grey", marginRight: 5 }} />
+          }
+        >
+          Click on "Search" or press "Enter" to start searching. To bulk search,
+          input a list of values separated by spaces or commas (example:{" "}
+          <code>value1 value2 value3</code>). To include multiple words in a
+          single search term, enclose them in single or double quotes (example:{" "}
+          <code>"Bone Cancer"</code>).
+        </CustomTooltip>
+
         <Form.Control
           className={"d-inline-block"}
           style={{ width: "300px" }}
@@ -85,18 +96,6 @@ export function Toolbar({
       </Col>
 
       <Col md="auto" style={{ marginLeft: -15 }}>
-        <CustomTooltip
-          icon={<InfoIcon style={{ fontSize: 18, color: "grey" }} />}
-        >
-          Click on "Search" or press "Enter" to start searching. To bulk search,
-          input a list of values separated by spaces or commas (example:{" "}
-          <code>value1 value2 value3</code>). To include multiple words in a
-          single search term, enclose them in single or double quotes (example:{" "}
-          <code>"Bone Cancer"</code>).
-        </CustomTooltip>
-      </Col>
-
-      <Col md="auto" style={{ marginLeft: -15 }}>
         <Button
           onClick={() => onSearch(userSearchVal)}
           className={"btn btn-secondary"}
@@ -113,13 +112,16 @@ export function Toolbar({
       <Col className={"text-end"}>
         <Dropdown as={ButtonGroup}>
           <Button onClick={onDownload} size={"sm"}>
-            Generate report
+            Export as TSV
           </Button>
           {exportDropdownItems?.length && setColumnDefsForExport && (
             <>
               <Dropdown.Toggle size="sm" split id="dropdown-split-basic" />
-              {exportDropdownItems.map((item) => (
-                <Dropdown.Menu>
+              <Dropdown.Menu>
+                <Dropdown.Item as="button" onClick={onDownload}>
+                  Export as TSV
+                </Dropdown.Item>
+                {exportDropdownItems.map((item) => (
                   <Dropdown.Item
                     as="button"
                     onClick={() => {
@@ -129,8 +131,8 @@ export function Toolbar({
                   >
                     {item.label}
                   </Dropdown.Item>
-                </Dropdown.Menu>
-              ))}
+                ))}
+              </Dropdown.Menu>
             </>
           )}
         </Dropdown>

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -13,7 +13,12 @@ import CheckIcon from "@material-ui/icons/Check";
 import moment from "moment";
 import _ from "lodash";
 import { RecordValidation } from "../components/RecordValidation";
-import { DashboardRequest, DashboardSample } from "../generated/graphql";
+import {
+  DashboardCohort,
+  DashboardPatient,
+  DashboardRequest,
+  DashboardSample,
+} from "../generated/graphql";
 import {
   REQUEST_STATUS_MAP,
   SAMPLE_STATUS_MAP,
@@ -87,7 +92,7 @@ export const multiLineColDef: ColDef = {
   },
 };
 
-export const requestColDefs: ColDef[] = [
+export const requestColDefs: ColDef<DashboardRequest>[] = [
   {
     headerName: "View Samples",
     cellRenderer: (params: ICellRendererParams) => {
@@ -145,12 +150,6 @@ export const requestColDefs: ColDef[] = [
   {
     field: "totalSampleCount",
     headerName: "# Samples",
-    cellClass: (params) => {
-      if (params.data.revisable === false) {
-        return "pendingCell";
-      }
-      return undefined;
-    },
   },
   {
     field: "projectManagerName",
@@ -220,7 +219,7 @@ export const requestColDefs: ColDef[] = [
   },
 ];
 
-export const patientColDefs: ColDef[] = [
+export const patientColDefs: ColDef<DashboardPatient>[] = [
   {
     headerName: "View Samples",
     cellRenderer: (params: ICellRendererParams) => {
@@ -319,7 +318,7 @@ const ONCOTREE_CODE_NA_TOOLTIP =
   "This code might have been remapped (renamed) between different versions of the Oncotree API. " +
   "For remapping details, visit the docs at https://oncotree.mskcc.org/#/home?tab=mapping";
 
-export const sampleColDefs: ColDef[] = [
+export const sampleColDefs: ColDef<DashboardSample>[] = [
   {
     field: "primaryId",
     headerName: "Primary ID",
@@ -557,7 +556,7 @@ export const sampleColDefs: ColDef[] = [
   },
 ];
 
-export const DbGapPhenotypeColumns: ColDef[] = [
+export const DbGapPhenotypeColumns: ColDef<DashboardSample>[] = [
   {
     field: "cmoPatientId",
     headerName: "SUBJECT_ID",
@@ -712,7 +711,7 @@ function setupEditableSampleFields(
   });
 }
 
-export const cohortColDefs: ColDef[] = [
+export const cohortColDefs: ColDef<DashboardCohort>[] = [
   {
     headerName: "View Samples",
     cellRenderer: (params: ICellRendererParams) => {
@@ -779,7 +778,7 @@ export const cohortColDefs: ColDef[] = [
   },
 ];
 
-export const wesSampleColDefs: ColDef[] = [
+export const wesSampleColDefs: ColDef<DashboardSample>[] = [
   {
     field: "primaryId",
     headerName: "Primary ID",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -77,6 +77,16 @@ function getAgGridBooleanValueFormatter({
   };
 }
 
+export const multiLineColDef: ColDef = {
+  wrapText: true,
+  autoHeight: true,
+  cellStyle: {
+    wordBreak: "break-word",
+    lineHeight: "1.25",
+    padding: "6px 18px",
+  },
+};
+
 export const requestColDefs: ColDef[] = [
   {
     headerName: "View Samples",
@@ -355,9 +365,8 @@ export const sampleColDefs: ColDef[] = [
   {
     field: "historicalCmoSampleNames",
     headerName: "Historical CMO Sample Names",
-    wrapText: true,
-    autoHeight: true,
     maxWidth: 300,
+    ...multiLineColDef,
   },
   {
     field: "importDate",
@@ -786,9 +795,8 @@ export const wesSampleColDefs: ColDef[] = [
   {
     field: "historicalCmoSampleNames",
     headerName: "Historical CMO Sample Names",
-    wrapText: true,
-    autoHeight: true,
     maxWidth: 300,
+    ...multiLineColDef,
   },
   {
     field: "investigatorSampleId",

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -937,6 +937,134 @@ export const wesSampleColDefs: ColDef<DashboardSample>[] = [
   },
 ];
 
+export const accessSampleColDefs: ColDef<DashboardSample>[] = [
+  {
+    field: "primaryId",
+    headerName: "Primary ID",
+  },
+  {
+    field: "altId",
+    headerName: "Alt ID",
+  },
+  {
+    headerName: "Status",
+    cellRenderer: (params: ICellRendererParams<DashboardSample>) => {
+      if (!params.data) return null;
+      const {
+        revisable,
+        validationStatus,
+        validationReport,
+        sampleCategory,
+        primaryId,
+      } = params.data;
+
+      if (revisable === true) {
+        return validationStatus === false ||
+          (validationStatus === null && sampleCategory !== "clinical") ? (
+          <RecordValidation
+            validationStatus={validationStatus}
+            validationReport={validationReport}
+            modalTitle={`Error report for sample ${primaryId}`}
+            recordStatusMap={SAMPLE_STATUS_MAP}
+          />
+        ) : (
+          <CheckIcon />
+        );
+      } else {
+        return <LoadingIcon />;
+      }
+    },
+    sortable: false,
+  },
+  {
+    field: "cmoSampleName",
+    headerName: "CMO Sample Name",
+  },
+  {
+    field: "historicalCmoSampleNames",
+    headerName: "Historical CMO Sample Names",
+    maxWidth: 300,
+    ...multiLineColDef,
+  },
+  {
+    field: "importDate",
+    headerName: "Last Updated",
+    ...getAgGridDateFilterConfigs(),
+  },
+  {
+    field: "cmoPatientId",
+    headerName: "CMO Patient ID",
+  },
+  {
+    field: "investigatorSampleId",
+    headerName: "Investigator Sample ID",
+  },
+  {
+    field: "sampleType",
+    headerName: "Sample Type",
+  },
+  {
+    field: "species",
+    headerName: "Species",
+  },
+  {
+    field: "genePanel",
+    headerName: "Gene Panel",
+  },
+  {
+    field: "baitSet",
+    headerName: "Bait Set",
+  },
+  {
+    field: "preservation",
+    headerName: "Preservation",
+  },
+  {
+    field: "tumorOrNormal",
+    headerName: "Tumor Or Normal",
+  },
+  {
+    field: "sampleClass",
+    headerName: "Sample Class",
+  },
+  {
+    field: "oncotreeCode",
+    headerName: "Oncotree Code",
+  },
+  {
+    field: "cancerType",
+    headerName: "Cancer Type",
+  },
+  {
+    field: "cancerTypeDetailed",
+    headerName: "Cancer Type Detailed",
+  },
+  {
+    field: "collectionYear",
+    headerName: "Collection Year",
+  },
+  {
+    field: "sampleOrigin",
+    headerName: "Sample Origin",
+  },
+  {
+    field: "tissueLocation",
+    headerName: "Tissue Location",
+  },
+  {
+    field: "sex",
+    headerName: "Sex",
+  },
+  {
+    field: "recipe",
+    headerName: "Recipe",
+  },
+  {
+    field: "sampleCategory",
+    headerName: "SMILE Sample Category",
+  },
+];
+
 export const ReadOnlyCohortSampleDetailsColumns = _.cloneDeep(wesSampleColDefs);
 
 export const defaultColDef: ColDef = {

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -1113,8 +1113,12 @@ const editableWesSampleFields = [
 setupEditableSampleFields(sampleColDefs, editableSampleFields);
 setupEditableSampleFields(wesSampleColDefs, editableWesSampleFields);
 
-export const combinedSampleDetailsColumns = _.uniqBy(
-  [...sampleColDefs, ...readOnlyWesSampleColDefs],
+export const combinedSampleColDefs = _.uniqBy(
+  [
+    ...sampleColDefs,
+    ...readOnlyWesSampleColDefs,
+    ...readOnlyAccessSampleColDefs,
+  ],
   "field"
 );
 

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -1067,6 +1067,10 @@ export const accessSampleColDefs: ColDef<DashboardSample>[] = [
     field: "cfDNA2dBarcode",
     headerName: "2D Barcode",
   },
+  {
+    field: "dmpPatientAlias",
+    headerName: "DMP Patient Alias",
+  },
 ];
 
 export const readOnlyWesSampleColDefs = _.cloneDeep(wesSampleColDefs);

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -1065,7 +1065,8 @@ export const accessSampleColDefs: ColDef<DashboardSample>[] = [
   },
 ];
 
-export const ReadOnlyCohortSampleDetailsColumns = _.cloneDeep(wesSampleColDefs);
+export const readOnlyWesSampleColDefs = _.cloneDeep(wesSampleColDefs);
+export const readOnlyAccessSampleColDefs = _.cloneDeep(accessSampleColDefs);
 
 export const defaultColDef: ColDef = {
   sortable: true,
@@ -1105,7 +1106,7 @@ setupEditableSampleFields(sampleColDefs, editableSampleFields);
 setupEditableSampleFields(wesSampleColDefs, editableWesSampleFields);
 
 export const combinedSampleDetailsColumns = _.uniqBy(
-  [...sampleColDefs, ...ReadOnlyCohortSampleDetailsColumns],
+  [...sampleColDefs, ...readOnlyWesSampleColDefs],
   "field"
 );
 

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -1063,6 +1063,10 @@ export const accessSampleColDefs: ColDef<DashboardSample>[] = [
     field: "sampleCategory",
     headerName: "SMILE Sample Category",
   },
+  {
+    field: "cfDNA2dBarcode",
+    headerName: "2D Barcode",
+  },
 ];
 
 export const readOnlyWesSampleColDefs = _.cloneDeep(wesSampleColDefs);

--- a/frontend/src/shared/tableElements.tsx
+++ b/frontend/src/shared/tableElements.tsx
@@ -42,6 +42,7 @@ interface IToolbarProps {
   setColumnDefsForExport?: Dispatch<SetStateAction<ColDef[]>>;
 }
 
+// TODO: rename file to Toolbar.tsx
 export function Toolbar({
   dataName,
   userSearchVal,

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1434,6 +1434,7 @@ export type DashboardSample = {
   billedBy?: Maybe<Scalars["String"]>;
   cancerType?: Maybe<Scalars["String"]>;
   cancerTypeDetailed?: Maybe<Scalars["String"]>;
+  cfDNA2dBarcode?: Maybe<Scalars["String"]>;
   cmoPatientId?: Maybe<Scalars["String"]>;
   cmoSampleName?: Maybe<Scalars["String"]>;
   collectionYear?: Maybe<Scalars["String"]>;
@@ -1485,6 +1486,7 @@ export type DashboardSampleInput = {
   billedBy?: InputMaybe<Scalars["String"]>;
   cancerType?: InputMaybe<Scalars["String"]>;
   cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
   changedFieldNames: Array<Scalars["String"]>;
   cmoPatientId?: InputMaybe<Scalars["String"]>;
   cmoSampleName?: InputMaybe<Scalars["String"]>;
@@ -11109,6 +11111,7 @@ export type DashboardSamplesQuery = {
     sampleOrigin?: string | null;
     tissueLocation?: string | null;
     sex?: string | null;
+    cfDNA2dBarcode?: string | null;
     recipe?: string | null;
     altId?: string | null;
     analyteType?: string | null;
@@ -11165,6 +11168,7 @@ export type DashboardSampleMetadataPartsFragment = {
   sampleOrigin?: string | null;
   tissueLocation?: string | null;
   sex?: string | null;
+  cfDNA2dBarcode?: string | null;
   recipe?: string | null;
   altId?: string | null;
   analyteType?: string | null;
@@ -11252,6 +11256,7 @@ export type UpdateDashboardSamplesMutation = {
     sampleOrigin?: string | null;
     tissueLocation?: string | null;
     sex?: string | null;
+    cfDNA2dBarcode?: string | null;
     recipe?: string | null;
     altId?: string | null;
     analyteType?: string | null;
@@ -11322,6 +11327,7 @@ export const DashboardSampleMetadataPartsFragmentDoc = gql`
     sampleOrigin
     tissueLocation
     sex
+    cfDNA2dBarcode
     recipe
     altId
     analyteType

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1441,6 +1441,7 @@ export type DashboardSample = {
   costCenter?: Maybe<Scalars["String"]>;
   custodianInformation?: Maybe<Scalars["String"]>;
   dbGapStudy?: Maybe<Scalars["String"]>;
+  dmpPatientAlias?: Maybe<Scalars["String"]>;
   embargoDate?: Maybe<Scalars["String"]>;
   genePanel?: Maybe<Scalars["String"]>;
   historicalCmoSampleNames?: Maybe<Scalars["String"]>;
@@ -1494,6 +1495,7 @@ export type DashboardSampleInput = {
   costCenter?: InputMaybe<Scalars["String"]>;
   custodianInformation?: InputMaybe<Scalars["String"]>;
   dbGapStudy?: InputMaybe<Scalars["String"]>;
+  dmpPatientAlias?: InputMaybe<Scalars["String"]>;
   embargoDate?: InputMaybe<Scalars["String"]>;
   genePanel?: InputMaybe<Scalars["String"]>;
   historicalCmoSampleNames?: InputMaybe<Scalars["String"]>;
@@ -11139,6 +11141,7 @@ export type DashboardSamplesQuery = {
     qcCompleteReason?: string | null;
     qcCompleteStatus?: string | null;
     dbGapStudy?: string | null;
+    dmpPatientAlias?: string | null;
   }>;
 };
 
@@ -11204,6 +11207,11 @@ export type DashboardTempoPartsFragment = {
 export type DashboardDbGapPartsFragment = {
   __typename?: "DashboardSample";
   dbGapStudy?: string | null;
+};
+
+export type DashboardPatientPartsFragment = {
+  __typename?: "DashboardSample";
+  dmpPatientAlias?: string | null;
 };
 
 export type RequestPartsFragment = {
@@ -11365,6 +11373,11 @@ export const DashboardDbGapPartsFragmentDoc = gql`
     dbGapStudy
   }
 `;
+export const DashboardPatientPartsFragmentDoc = gql`
+  fragment DashboardPatientParts on DashboardSample {
+    dmpPatientAlias
+  }
+`;
 export const RequestPartsFragmentDoc = gql`
   fragment RequestParts on Request {
     igoRequestId
@@ -11516,6 +11529,7 @@ export const DashboardSamplesDocument = gql`
       ...DashboardSampleMetadataParts
       ...DashboardTempoParts
       ...DashboardDbGapParts
+      ...DashboardPatientParts
       _total
     }
   }
@@ -11523,6 +11537,7 @@ export const DashboardSamplesDocument = gql`
   ${DashboardSampleMetadataPartsFragmentDoc}
   ${DashboardTempoPartsFragmentDoc}
   ${DashboardDbGapPartsFragmentDoc}
+  ${DashboardPatientPartsFragmentDoc}
 `;
 export type DashboardSamplesQueryResult = Apollo.QueryResult<
   DashboardSamplesQuery,

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -4183,7 +4183,7 @@ export type QueryDashboardRequestsArgs = {
 };
 
 export type QueryDashboardSamplesArgs = {
-  context?: InputMaybe<DashboardRecordContext>;
+  contexts?: InputMaybe<Array<InputMaybe<DashboardRecordContext>>>;
   filters?: InputMaybe<Array<DashboardRecordFilter>>;
   limit: Scalars["Int"];
   offset: Scalars["Int"];
@@ -11074,7 +11074,10 @@ export type DashboardCohortsQuery = {
 
 export type DashboardSamplesQueryVariables = Exact<{
   searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
-  context?: InputMaybe<DashboardRecordContext>;
+  contexts?: InputMaybe<
+    | Array<InputMaybe<DashboardRecordContext>>
+    | InputMaybe<DashboardRecordContext>
+  >;
   sort: DashboardRecordSort;
   filters?: InputMaybe<Array<DashboardRecordFilter> | DashboardRecordFilter>;
   limit: Scalars["Int"];
@@ -11489,7 +11492,7 @@ export type DashboardCohortsQueryResult = Apollo.QueryResult<
 export const DashboardSamplesDocument = gql`
   query DashboardSamples(
     $searchVals: [String!]
-    $context: DashboardRecordContext
+    $contexts: [DashboardRecordContext]
     $sort: DashboardRecordSort!
     $filters: [DashboardRecordFilter!]
     $limit: Int!
@@ -11497,7 +11500,7 @@ export const DashboardSamplesDocument = gql`
   ) {
     dashboardSamples(
       searchVals: $searchVals
-      context: $context
+      contexts: $contexts
       sort: $sort
       filters: $filters
       limit: $limit

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -148,7 +148,7 @@ export async function buildCustomSchema(ogm: OGM) {
         // Here, we're returning newDashboardSamples for simplicity. However, if we were to follow
         // GraphQL's convention, we'd return the actual resulting data from the database update. This
         // means we'd wait for SMILE services to finish processing the data changes, then query that
-        // data to return it to the frontend. For more conext, see:
+        // data to return it to the frontend. For more context, see:
         // https://www.apollographql.com/docs/react/performance/optimistic-ui/#optimistic-mutation-lifecycle
         return newDashboardSamples;
       },

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -86,7 +86,7 @@ export async function buildCustomSchema(ogm: OGM) {
         _source: undefined,
         {
           searchVals,
-          context,
+          contexts,
           sort,
           filters,
           limit,
@@ -108,7 +108,7 @@ export async function buildCustomSchema(ogm: OGM) {
 
         const queryBody = buildSamplesQueryBody({
           searchVals,
-          context,
+          contexts,
           filters,
           addlOncotreeCodes,
         });
@@ -148,7 +148,7 @@ export async function buildCustomSchema(ogm: OGM) {
         // Here, we're returning newDashboardSamples for simplicity. However, if we were to follow
         // GraphQL's convention, we'd return the actual resulting data from the database update. This
         // means we'd wait for SMILE services to finish processing the data changes, then query that
-        // data to return it to the frontend. For more context, see:
+        // data to return it to the frontend. For more conext, see:
         // https://www.apollographql.com/docs/react/performance/optimistic-ui/#optimistic-mutation-lifecycle
         return newDashboardSamples;
       },

--- a/graphql-server/src/schemas/queries/samples.ts
+++ b/graphql-server/src/schemas/queries/samples.ts
@@ -374,7 +374,6 @@ export function buildSamplesQueryBody({
 
     ${searchFilters && `WHERE ${searchFilters}`}
   `;
-  console.log("samplesQueryBody", samplesQueryBody);
 
   return samplesQueryBody;
 }

--- a/graphql-server/src/schemas/queries/samples.ts
+++ b/graphql-server/src/schemas/queries/samples.ts
@@ -86,6 +86,13 @@ export function buildSamplesQueryBody({
       )}).*'`
     : "";
 
+  const baitSetContextObj = contexts?.find(
+    (ctx) => ctx?.fieldName === "baitSet"
+  );
+  const baitSetContext = baitSetContextObj
+    ? `latestSm.baitSet =~ '(?i).*(${baitSetContextObj.values.join("|")}).*'`
+    : "";
+
   // Filter for the current request in the Request Samples view
   const requestContextObj = contexts?.find(
     (ctx) => ctx?.fieldName === "igoRequestId"
@@ -235,7 +242,9 @@ export function buildSamplesQueryBody({
       ", ") AS historicalCmoSampleNames
 
     // Filters for either the WES Samples or Request Samples view, if applicable
-    ${genePanelContext && `WHERE ${genePanelContext}`}
+    ${genePanelContext && `WHERE ${genePanelContext}`} ${
+    baitSetContext && `OR ${baitSetContext}`
+  }
     ${requestContext && `WHERE ${requestContext}`}
 
     // Get SampleMetadata's Status
@@ -365,6 +374,7 @@ export function buildSamplesQueryBody({
 
     ${searchFilters && `WHERE ${searchFilters}`}
   `;
+  console.log("samplesQueryBody", samplesQueryBody);
 
   return samplesQueryBody;
 }

--- a/graphql-server/src/schemas/queries/samples.ts
+++ b/graphql-server/src/schemas/queries/samples.ts
@@ -344,6 +344,7 @@ export function buildSamplesQueryBody({
         sampleOrigin: latestSm.sampleOrigin,
         tissueLocation: latestSm.tissueLocation,
         sex: latestSm.sex,
+        cfDNA2dBarcode: latestSm.cfDNA2dBarcode,
         libraries: latestSm.libraries,
         recipe: cmoSampleIdFields.recipe,
         analyteType: cmoSampleIdFields.naToExtract,

--- a/graphql-server/src/schemas/queries/samples.ts
+++ b/graphql-server/src/schemas/queries/samples.ts
@@ -12,12 +12,12 @@ import {
 
 export function buildSamplesQueryBody({
   searchVals,
-  context,
+  contexts,
   filters,
   addlOncotreeCodes,
 }: {
   searchVals: QueryDashboardSamplesArgs["searchVals"];
-  context?: QueryDashboardSamplesArgs["context"];
+  contexts?: QueryDashboardSamplesArgs["contexts"];
   filters?: QueryDashboardSamplesArgs["filters"];
   addlOncotreeCodes: string[];
 }) {
@@ -76,29 +76,39 @@ export function buildSamplesQueryBody({
     }
   }
 
-  // Filter for WES samples on click on the Samples page
-  const wesContext =
-    context?.fieldName === "genePanel"
-      ? `latestSm.genePanel =~ '(?i).*(${context.values.join("|")}).*'`
-      : "";
+  // Filter for the WES samples on the Samples page
+  const genePanelContextObj = contexts?.find(
+    (ctx) => ctx?.fieldName === "genePanel"
+  );
+  const genePanelContext = genePanelContextObj
+    ? `latestSm.genePanel =~ '(?i).*(${genePanelContextObj.values.join(
+        "|"
+      )}).*'`
+    : "";
 
   // Filter for the current request in the Request Samples view
-  const requestContext =
-    context?.fieldName === "igoRequestId"
-      ? `latestSm.igoRequestId = '${context.values[0]}'`
-      : "";
+  const requestContextObj = contexts?.find(
+    (ctx) => ctx?.fieldName === "igoRequestId"
+  );
+  const requestContext = requestContextObj
+    ? `latestSm.igoRequestId = '${requestContextObj.values[0]}'`
+    : "";
 
   // Filter for the current patient for the Patient Samples view
-  const patientContext =
-    context?.fieldName === "patientId"
-      ? `pa.value = '${context.values[0]}'`
-      : "";
+  const patientContextObj = contexts?.find(
+    (ctx) => ctx?.fieldName === "patientId"
+  );
+  const patientContext = patientContextObj
+    ? `pa.value = '${patientContextObj.values[0]}'`
+    : "";
 
   // Filter for the current cohort for the Cohort Samples view
-  const cohortContext =
-    context?.fieldName === "cohortId"
-      ? `c.cohortId = '${context.values[0]}'`
-      : "";
+  const cohortContextObj = contexts?.find(
+    (ctx) => ctx?.fieldName === "cohortId"
+  );
+  const cohortContext = cohortContextObj
+    ? `c.cohortId = '${cohortContextObj.values[0]}'`
+    : "";
 
   // "Last Updated" column filter in the Samples Metadata view
   let importDateFilter = "";
@@ -225,7 +235,7 @@ export function buildSamplesQueryBody({
       ", ") AS historicalCmoSampleNames
 
     // Filters for either the WES Samples or Request Samples view, if applicable
-    ${wesContext && `WHERE ${wesContext}`}
+    ${genePanelContext && `WHERE ${genePanelContext}`}
     ${requestContext && `WHERE ${requestContext}`}
 
     // Get SampleMetadata's Status

--- a/graphql-server/src/utils/cache.ts
+++ b/graphql-server/src/utils/cache.ts
@@ -27,18 +27,20 @@ const SAMPLES_DEFAULT_SORT = {
   colId: "importDate",
   sort: "desc",
 } as DashboardRecordSort; // from SamplesList.tsx
-const WES_SAMPLE_CONTEXT = {
-  fieldName: "genePanel",
-  values: [
-    "Agilent_51MB",
-    "Agilent_v4_51MB_Human",
-    "CustomCapture",
-    "IDT_Exome_v1_FP",
-    "IDT_Exome_V1_IMPACT468",
-    "WES_Human",
-    "WholeExomeSequencing",
-  ],
-}; // from SamplesPage.tsx
+const WES_SAMPLE_CONTEXT = [
+  {
+    fieldName: "genePanel",
+    values: [
+      "Agilent_51MB",
+      "Agilent_v4_51MB_Human",
+      "CustomCapture",
+      "IDT_Exome_v1_FP",
+      "IDT_Exome_V1_IMPACT468",
+      "WES_Human",
+      "WholeExomeSequencing",
+    ],
+  },
+]; // from SamplesPage.tsx
 
 const MAX_RETRIES_UPON_FALSE_SAMPLE_STATUS = 3;
 const RETRY_INTERVAL_UPON_FALSE_SAMPLE_STATUS = 3000; // 3s
@@ -156,13 +158,13 @@ async function updateSamplesCache(inMemoryCache: NodeCache) {
   // Build query bodies for all samples and WES samples queries of Samples page
   const allSamplesQueryBody = buildSamplesQueryBody({
     searchVals: [],
-    context: undefined,
+    contexts: undefined,
     filters: undefined,
     addlOncotreeCodes: [],
   });
   const wesSamplesQueryBody = buildSamplesQueryBody({
     searchVals: [],
-    context: WES_SAMPLE_CONTEXT,
+    contexts: WES_SAMPLE_CONTEXT,
     filters: undefined,
     addlOncotreeCodes: [],
   });

--- a/graphql-server/src/utils/cache.ts
+++ b/graphql-server/src/utils/cache.ts
@@ -69,21 +69,21 @@ export type OncotreeApiTumorType = {
 export async function initializeInMemoryCache() {
   const inMemoryCache = new NodeCache();
 
-  // // Warm up the cache
-  // await updateOncotreeCache(inMemoryCache);
-  // await updateSamplesCache(inMemoryCache);
-  // logCacheStats(inMemoryCache);
-  //
-  // // Add cache item expiration handlers
-  // // (node-cache checks for expired items and runs this event listener every 10m by default)
-  // inMemoryCache.on("expired", async (key) => {
-  //   if (key === ONCOTREE_CACHE_KEY) {
-  //     await updateOncotreeCache(inMemoryCache);
-  //   }
-  //   if (key === SAMPLES_CACHE_KEY) {
-  //     await updateSamplesCache(inMemoryCache);
-  //   }
-  // });
+  // Warm up the cache
+  await updateOncotreeCache(inMemoryCache);
+  await updateSamplesCache(inMemoryCache);
+  logCacheStats(inMemoryCache);
+
+  // Add cache item expiration handlers
+  // (node-cache checks for expired items and runs this event listener every 10m by default)
+  inMemoryCache.on("expired", async (key) => {
+    if (key === ONCOTREE_CACHE_KEY) {
+      await updateOncotreeCache(inMemoryCache);
+    }
+    if (key === SAMPLES_CACHE_KEY) {
+      await updateSamplesCache(inMemoryCache);
+    }
+  });
 
   return inMemoryCache;
 }

--- a/graphql-server/src/utils/cache.ts
+++ b/graphql-server/src/utils/cache.ts
@@ -67,21 +67,21 @@ export type OncotreeApiTumorType = {
 export async function initializeInMemoryCache() {
   const inMemoryCache = new NodeCache();
 
-  // Warm up the cache
-  await updateOncotreeCache(inMemoryCache);
-  await updateSamplesCache(inMemoryCache);
-  logCacheStats(inMemoryCache);
-
-  // Add cache item expiration handlers
-  // (node-cache checks for expired items and runs this event listener every 10m by default)
-  inMemoryCache.on("expired", async (key) => {
-    if (key === ONCOTREE_CACHE_KEY) {
-      await updateOncotreeCache(inMemoryCache);
-    }
-    if (key === SAMPLES_CACHE_KEY) {
-      await updateSamplesCache(inMemoryCache);
-    }
-  });
+  // // Warm up the cache
+  // await updateOncotreeCache(inMemoryCache);
+  // await updateSamplesCache(inMemoryCache);
+  // logCacheStats(inMemoryCache);
+  //
+  // // Add cache item expiration handlers
+  // // (node-cache checks for expired items and runs this event listener every 10m by default)
+  // inMemoryCache.on("expired", async (key) => {
+  //   if (key === ONCOTREE_CACHE_KEY) {
+  //     await updateOncotreeCache(inMemoryCache);
+  //   }
+  //   if (key === SAMPLES_CACHE_KEY) {
+  //     await updateSamplesCache(inMemoryCache);
+  //   }
+  // });
 
   return inMemoryCache;
 }

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -48,6 +48,7 @@ const SAMPLE_FIELDS = `
   sampleOrigin: String
   tissueLocation: String
   sex: String
+  cfDNA2dBarcode: String
   ## Custom fields
   recipe: String
   altId: String

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -90,6 +90,10 @@ const SAMPLE_FIELDS = `
   # (s:Sample)-[:HAS_DBGAP]->(d:DbGap)
   dbGapStudy: String
 
+  # (s:Sample)<-[:HAS_SAMPLE]-(p:Patient)<-[:IS_ALIAS]-(pa:PatientAlias)
+  ## Custom fields
+  dmpPatientAlias: String
+
   # results total
   _total: Int
 `;

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -178,7 +178,7 @@ const QUERY_TYPEDEFS = gql`
 
     dashboardSamples(
       searchVals: [String!]
-      context: DashboardRecordContext
+      contexts: [DashboardRecordContext]
       filters: [DashboardRecordFilter!]
       sort: DashboardRecordSort!
       limit: Int!

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -12902,6 +12902,18 @@
             "deprecationReason": null
           },
           {
+            "name": "cfDNA2dBarcode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cmoPatientId",
             "description": null,
             "args": [],
@@ -13495,6 +13507,18 @@
           },
           {
             "name": "cancerTypeDetailed",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cfDNA2dBarcode",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -12986,6 +12986,18 @@
             "deprecationReason": null
           },
           {
+            "name": "dmpPatientAlias",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "embargoDate",
             "description": null,
             "args": [],
@@ -13615,6 +13627,18 @@
           },
           {
             "name": "dbGapStudy",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dmpPatientAlias",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -38393,12 +38393,16 @@
             "description": null,
             "args": [
               {
-                "name": "context",
+                "name": "contexts",
                 "description": null,
                 "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "DashboardRecordContext",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "DashboardRecordContext",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null,
                 "isDeprecated": false,

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -93,7 +93,7 @@ query DashboardCohorts(
 
 query DashboardSamples(
   $searchVals: [String!]
-  $context: DashboardRecordContext
+  $contexts: [DashboardRecordContext]
   $sort: DashboardRecordSort!
   $filters: [DashboardRecordFilter!]
   $limit: Int!
@@ -101,7 +101,7 @@ query DashboardSamples(
 ) {
   dashboardSamples(
     searchVals: $searchVals
-    context: $context
+    contexts: $contexts
     sort: $sort
     filters: $filters
     limit: $limit

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -111,6 +111,7 @@ query DashboardSamples(
     ...DashboardSampleMetadataParts
     ...DashboardTempoParts
     ...DashboardDbGapParts
+    ...DashboardPatientParts
     _total
   }
 }
@@ -187,6 +188,12 @@ fragment DashboardTempoParts on DashboardSample {
 fragment DashboardDbGapParts on DashboardSample {
   # (s:Sample)-[:HAS_DBGAP]->(d:DbGap)
   dbGapStudy
+}
+
+fragment DashboardPatientParts on DashboardSample {
+  # (s:Sample)<-[:HAS_SAMPLE]-(p:Patient)<-[:IS_ALIAS]-(pa:PatientAlias)
+  ## Custom fields
+  dmpPatientAlias
 }
 
 fragment RequestParts on Request {

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -142,6 +142,7 @@ fragment DashboardSampleMetadataParts on DashboardSample {
   sampleOrigin
   tissueLocation
   sex
+  cfDNA2dBarcode
   ## Custom fields
   recipe
   altId


### PR DESCRIPTION
This PR adds a new ACCESS samples tab to the Samples page.

## Screenshot

![CleanShot 2025-05-27 at 16 31 31](https://github.com/user-attachments/assets/f3fe6c04-9006-44be-b2cf-ed8ce0014b6b)

## Related tickets

[Add a new view on Samples page for ACCESS samples #1520](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1520) (main ticket)
[Move the info tooltip icon on the right of the search field to the left of it #1519](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1519)
[Use clearer / more user-friendly languages (e.g. “Export to TSV” instead of “Generate report”) #1518](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1518)

Signed-off-by: Quan Nguyen <86090707+qu8n@users.noreply.github.com>