### PR TITLE
Display tolerated sample errors in request validation report popup

### DIFF
--- a/frontend/src/configs/recordValidationMaps.ts
+++ b/frontend/src/configs/recordValidationMaps.ts
@@ -8,6 +8,8 @@ export type StatusItem = {
   responsibleParty: string;
   sampleLevelValidationHeader?: string; // for request validation only
   igoId?: string; // for request validation only
+  primaryId?: string; // sample validation rendering in request validation popup
+  toleratedSampleLevelValidationHeader?: string; // sample validation rendering in request validation popup
 };
 
 /**
@@ -124,30 +126,6 @@ export const REQUEST_STATUS_MAP: StatusMap = {
       actionItem: getActionItemForMissingIgoField("cmoRequest"),
       responsibleParty: "IGO",
     },
-  "samples (missing) Request JSON is missing 'samples' or 'samples' is an empty list.":
-    {
-      item: "samples (missing)",
-      description:
-        "Request JSON from IGO LIMS REST API is missing 'samples' or 'samples' is an empty list.",
-      actionItem: getActionItemForMissingIgoField("samples"),
-      responsibleParty: "IGO",
-    },
-  "samples (failed) Some request samples failed validation": {
-    item: "samples (failed)",
-    description: "Some request samples failed validation",
-    actionItem:
-      "Sample validation errors of critically failed samples are listed below. See the Request Samples view" +
-      " for errors of tolerable failures. If anything is missing or incorrect, please contact the SMILE team.",
-    responsibleParty: "",
-  },
-  "samples (failed) All request samples failed validation": {
-    item: "samples (failed)",
-    description: "All request samples failed validation",
-    actionItem:
-      "Review each sample's validation error below. If sample-level errors are missing or incorrect, please" +
-      " contact the SMILE team.",
-    responsibleParty: "",
-  },
 };
 
 /**

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1417,6 +1417,7 @@ export type DashboardRequest = {
   piEmail?: Maybe<Scalars["String"]>;
   projectManagerName?: Maybe<Scalars["String"]>;
   qcAccessEmails?: Maybe<Scalars["String"]>;
+  toleratedSampleErrors?: Maybe<Array<Maybe<ToleratedSampleValidationError>>>;
   totalSampleCount?: Maybe<Scalars["Int"]>;
   validationReport?: Maybe<Scalars["String"]>;
   validationStatus?: Maybe<Scalars["Boolean"]>;
@@ -10883,6 +10884,13 @@ export type TemposConnection = {
   totalCount: Scalars["Int"];
 };
 
+export type ToleratedSampleValidationError = {
+  __typename?: "ToleratedSampleValidationError";
+  primaryId: Scalars["String"];
+  validationReport?: Maybe<Scalars["String"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]>;
+};
+
 export type UpdateBamCompletesMutationResponse = {
   __typename?: "UpdateBamCompletesMutationResponse";
   bamCompletes: Array<BamComplete>;
@@ -11023,6 +11031,12 @@ export type DashboardRequestsQuery = {
     isCmoRequest?: boolean | null;
     otherContactEmails?: string | null;
     _total?: number | null;
+    toleratedSampleErrors?: Array<{
+      __typename?: "ToleratedSampleValidationError";
+      primaryId: string;
+      validationStatus?: boolean | null;
+      validationReport?: string | null;
+    } | null> | null;
   }>;
 };
 
@@ -11437,6 +11451,11 @@ export const DashboardRequestsDocument = gql`
       isCmoRequest
       otherContactEmails
       _total
+      toleratedSampleErrors {
+        primaryId
+        validationStatus
+        validationReport
+      }
     }
   }
 `;

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -121,11 +121,19 @@ export const requestColDefs: ColDef<DashboardRequest>[] = [
     headerName: "Status",
     cellRenderer: (params: ICellRendererParams<DashboardRequest>) => {
       if (!params.data) return null;
-      const { igoRequestId, validationStatus, validationReport } = params.data;
+      const {
+        igoRequestId,
+        validationStatus,
+        validationReport,
+        toleratedSampleErrors,
+      } = params.data;
+      // add check for toleratedSampleErrors if ultimately deciding to displaying tolerated errors always
+      // even on the request validation error popup
       return validationReport !== null && validationReport !== "{}" ? (
         <RecordValidation
           validationStatus={validationStatus}
           validationReport={validationReport}
+          toleratedSampleErrors={toleratedSampleErrors}
           modalTitle={`Error report for request ${igoRequestId}`}
           recordStatusMap={REQUEST_STATUS_MAP}
         />
@@ -346,6 +354,7 @@ export const sampleColDefs: ColDef<DashboardSample>[] = [
           <RecordValidation
             validationStatus={validationStatus}
             validationReport={validationReport}
+            toleratedSampleErrors={undefined}
             modalTitle={`Error report for sample ${primaryId}`}
             recordStatusMap={SAMPLE_STATUS_MAP}
           />
@@ -975,6 +984,7 @@ export const accessSampleColDefs: ColDef<DashboardSample>[] = [
           <RecordValidation
             validationStatus={validationStatus}
             validationReport={validationReport}
+            toleratedSampleErrors={undefined}
             modalTitle={`Error report for sample ${primaryId}`}
             recordStatusMap={SAMPLE_STATUS_MAP}
           />

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1416,6 +1416,7 @@ export type DashboardRequest = {
   piEmail?: Maybe<Scalars["String"]>;
   projectManagerName?: Maybe<Scalars["String"]>;
   qcAccessEmails?: Maybe<Scalars["String"]>;
+  toleratedSampleErrors?: Maybe<Array<Maybe<ToleratedSampleValidationError>>>;
   totalSampleCount?: Maybe<Scalars["Int"]>;
   validationReport?: Maybe<Scalars["String"]>;
   validationStatus?: Maybe<Scalars["Boolean"]>;
@@ -10882,6 +10883,13 @@ export type TemposConnection = {
   totalCount: Scalars["Int"];
 };
 
+export type ToleratedSampleValidationError = {
+  __typename?: "ToleratedSampleValidationError";
+  primaryId: Scalars["String"];
+  validationReport?: Maybe<Scalars["String"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]>;
+};
+
 export type UpdateBamCompletesMutationResponse = {
   __typename?: "UpdateBamCompletesMutationResponse";
   bamCompletes: Array<BamComplete>;
@@ -11022,6 +11030,12 @@ export type DashboardRequestsQuery = {
     isCmoRequest?: boolean | null;
     otherContactEmails?: string | null;
     _total?: number | null;
+    toleratedSampleErrors?: Array<{
+      __typename?: "ToleratedSampleValidationError";
+      primaryId: string;
+      validationStatus?: boolean | null;
+      validationReport?: string | null;
+    } | null> | null;
   }>;
 };
 
@@ -11436,6 +11450,11 @@ export const DashboardRequestsDocument = gql`
       isCmoRequest
       otherContactEmails
       _total
+      toleratedSampleErrors {
+        primaryId
+        validationStatus
+        validationReport
+      }
     }
   }
 `;

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -121,6 +121,13 @@ const QUERY_RESULT_TYPEDEFS = gql`
     isCmoRequest: Boolean
     otherContactEmails: String
     _total: Int
+    toleratedSampleErrors: [ToleratedSampleValidationError]
+  }
+
+  type ToleratedSampleValidationError {
+    primaryId: String!
+    validationStatus: Boolean
+    validationReport: String
   }
 
   type DashboardPatient {

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -12723,6 +12723,22 @@
             "deprecationReason": null
           },
           {
+            "name": "toleratedSampleErrors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ToleratedSampleValidationError",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "totalSampleCount",
             "description": null,
             "args": [],
@@ -105091,6 +105107,57 @@
                 "name": "Int",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ToleratedSampleValidationError",
+        "description": null,
+        "fields": [
+          {
+            "name": "primaryId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validationReport",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validationStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -33,6 +33,11 @@ query DashboardRequests(
     isCmoRequest
     otherContactEmails
     _total
+    toleratedSampleErrors {
+      primaryId
+      validationStatus
+      validationReport
+    }
   }
 }
 


### PR DESCRIPTION
# Display tolerated sample errors in the request validation report popup.

Main updates:
- groups of tolerated and critical sample errors are displayed, when applicable 

General:
- updated graphql operations and typedefs to support tolerated sample errors
- removed the general request-level sample error messages that were informative but ultimately not very helpful or actionable.

**Grouped display**
![image](https://github.com/user-attachments/assets/b19e0a04-9824-4094-9623-af0a0d07547c)

**Toggled grouped display**
![image](https://github.com/user-attachments/assets/f4ca6c3d-d3db-4407-b6a1-0e25106ac5fa)

**Toggled grouped display by samples**
![image](https://github.com/user-attachments/assets/8d003560-a164-4f73-8ca9-2c1ed9c8cab8)
