### PR TITLE
Update PHI ID mapping to the new full outer join table

### DIFF
--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -2945,9 +2945,9 @@ export type PatientHasSampleSamplesUpdateFieldInput = {
 
 export type PatientIdsTriplet = {
   __typename?: "PatientIdsTriplet";
-  CMO_ID: Scalars["String"];
-  DMP_ID?: Maybe<Scalars["String"]>;
-  PT_MRN: Scalars["String"];
+  CMO_PATIENT_ID: Scalars["String"];
+  DMP_PATIENT_ID?: Maybe<Scalars["String"]>;
+  MRN: Scalars["String"];
 };
 
 export type PatientOptions = {
@@ -11326,9 +11326,9 @@ export type GetPatientIdsTripletsQuery = {
   __typename?: "Query";
   patientIdsTriplets?: Array<{
     __typename?: "PatientIdsTriplet";
-    CMO_ID: string;
-    DMP_ID?: string | null;
-    PT_MRN: string;
+    CMO_PATIENT_ID: string;
+    DMP_PATIENT_ID?: string | null;
+    MRN: string;
   } | null> | null;
 };
 
@@ -11838,9 +11838,9 @@ export type UpdateDashboardSamplesMutationOptions = Apollo.BaseMutationOptions<
 export const GetPatientIdsTripletsDocument = gql`
   query GetPatientIdsTriplets($patientIds: [String!]!) {
     patientIdsTriplets(patientIds: $patientIds) {
-      CMO_ID
-      DMP_ID
-      PT_MRN
+      CMO_PATIENT_ID
+      DMP_PATIENT_ID
+      MRN
     }
   }
 `;

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -118,10 +118,10 @@ export default function PatientsPage({
       if (patientIdsTriplets.length > 0) {
         patientIdsTriplets.forEach((triplet) => {
           // Add back C- to CMO IDs because they are stored without it in the CRDB
-          const cmoIdWithCDash = addCDashToCMOId(triplet.CMO_ID);
+          const cmoIdWithCDash = addCDashToCMOId(triplet.CMO_PATIENT_ID);
           if (
             !parsedSearchVals.includes(cmoIdWithCDash) &&
-            !parsedSearchVals.includes(triplet.DMP_ID ?? "")
+            !parsedSearchVals.includes(triplet.DMP_PATIENT_ID ?? "")
           ) {
             extraCmoIds.push(cmoIdWithCDash);
           }
@@ -178,11 +178,11 @@ export default function PatientsPage({
             const cmoId = data.cmoPatientId;
 
             const patientIdsTriplet = patientIdsTriplets.find(
-              (triplet) => addCDashToCMOId(triplet.CMO_ID) === cmoId
+              (triplet) => addCDashToCMOId(triplet.CMO_PATIENT_ID) === cmoId
             );
 
             if (patientIdsTriplet) {
-              return patientIdsTriplet.PT_MRN;
+              return patientIdsTriplet.MRN;
             } else {
               return "";
             }

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -2944,9 +2944,9 @@ export type PatientHasSampleSamplesUpdateFieldInput = {
 
 export type PatientIdsTriplet = {
   __typename?: "PatientIdsTriplet";
-  CMO_ID: Scalars["String"];
-  DMP_ID?: Maybe<Scalars["String"]>;
-  PT_MRN: Scalars["String"];
+  CMO_PATIENT_ID: Scalars["String"];
+  DMP_PATIENT_ID?: Maybe<Scalars["String"]>;
+  MRN: Scalars["String"];
 };
 
 export type PatientOptions = {
@@ -11325,9 +11325,9 @@ export type GetPatientIdsTripletsQuery = {
   __typename?: "Query";
   patientIdsTriplets?: Array<{
     __typename?: "PatientIdsTriplet";
-    CMO_ID: string;
-    DMP_ID?: string | null;
-    PT_MRN: string;
+    CMO_PATIENT_ID: string;
+    DMP_PATIENT_ID?: string | null;
+    MRN: string;
   } | null> | null;
 };
 
@@ -11599,9 +11599,9 @@ export type UpdateDashboardSamplesMutationOptions = Apollo.BaseMutationOptions<
 export const GetPatientIdsTripletsDocument = gql`
   query GetPatientIdsTriplets($patientIds: [String!]!) {
     patientIdsTriplets(patientIds: $patientIds) {
-      CMO_ID
-      DMP_ID
-      PT_MRN
+      CMO_PATIENT_ID
+      DMP_PATIENT_ID
+      MRN
     }
   }
 `;

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -26537,7 +26537,7 @@
         "description": null,
         "fields": [
           {
-            "name": "CMO_ID",
+            "name": "CMO_PATIENT_ID",
             "description": null,
             "args": [],
             "type": {
@@ -26553,7 +26553,7 @@
             "deprecationReason": null
           },
           {
-            "name": "DMP_ID",
+            "name": "DMP_PATIENT_ID",
             "description": null,
             "args": [],
             "type": {
@@ -26565,7 +26565,7 @@
             "deprecationReason": null
           },
           {
-            "name": "PT_MRN",
+            "name": "MRN",
             "description": null,
             "args": [],
             "type": {

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -235,8 +235,8 @@ mutation UpdateDashboardSamples(
 
 query GetPatientIdsTriplets($patientIds: [String!]!) {
   patientIdsTriplets(patientIds: $patientIds) {
-    CMO_ID
-    DMP_ID
-    PT_MRN
+    CMO_PATIENT_ID
+    DMP_PATIENT_ID
+    MRN
   }
 }


### PR DESCRIPTION
This PR connects the PHI ID mapping to the new outer join table in Databricks.

Examples of CMO Patient ID with corresponding MRNs for testing:
C-PKDC3H
C-PK3N94
C-XXFMNC

[#1575](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1575)