### PR TITLE
Add cohort IDs for sample records

### DIFF
--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1475,6 +1475,7 @@ export type DashboardSample = {
   revisable?: Maybe<Scalars["Boolean"]>;
   sampleCategory: Scalars["String"];
   sampleClass?: Maybe<Scalars["String"]>;
+  sampleCohortIds?: Maybe<Scalars["String"]>;
   sampleOrigin?: Maybe<Scalars["String"]>;
   sampleType?: Maybe<Scalars["String"]>;
   sex?: Maybe<Scalars["String"]>;
@@ -1529,6 +1530,7 @@ export type DashboardSampleInput = {
   revisable?: InputMaybe<Scalars["Boolean"]>;
   sampleCategory: Scalars["String"];
   sampleClass?: InputMaybe<Scalars["String"]>;
+  sampleCohortIds?: InputMaybe<Scalars["String"]>;
   sampleOrigin?: InputMaybe<Scalars["String"]>;
   sampleType?: InputMaybe<Scalars["String"]>;
   sex?: InputMaybe<Scalars["String"]>;
@@ -11171,6 +11173,7 @@ export type DashboardSamplesQuery = {
     qcCompleteResult?: string | null;
     qcCompleteReason?: string | null;
     qcCompleteStatus?: string | null;
+    sampleCohortIds?: string | null;
     dbGapStudy?: string | null;
     dmpPatientAlias?: string | null;
   }>;
@@ -11233,6 +11236,7 @@ export type DashboardTempoPartsFragment = {
   qcCompleteResult?: string | null;
   qcCompleteReason?: string | null;
   qcCompleteStatus?: string | null;
+  sampleCohortIds?: string | null;
 };
 
 export type DashboardDbGapPartsFragment = {
@@ -11322,6 +11326,7 @@ export type UpdateDashboardSamplesMutation = {
     qcCompleteResult?: string | null;
     qcCompleteReason?: string | null;
     qcCompleteStatus?: string | null;
+    sampleCohortIds?: string | null;
     dbGapStudy?: string | null;
   } | null> | null;
 };
@@ -11383,6 +11388,7 @@ export const DashboardTempoPartsFragmentDoc = gql`
     qcCompleteResult
     qcCompleteReason
     qcCompleteStatus
+    sampleCohortIds
   }
 `;
 export const DashboardDbGapPartsFragmentDoc = gql`

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -581,6 +581,10 @@ export const sampleColDefs: ColDef<DashboardSample>[] = [
     field: "dbGapStudy",
     headerName: "dbGaP Study ID",
   },
+  {
+    field: "sampleCohortIds",
+    headerName: "Sample Cohort IDs",
+  },
 ];
 
 export const DbGapPhenotypeColumns: ColDef<DashboardSample>[] = [

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1474,6 +1474,7 @@ export type DashboardSample = {
   revisable?: Maybe<Scalars["Boolean"]>;
   sampleCategory: Scalars["String"];
   sampleClass?: Maybe<Scalars["String"]>;
+  sampleCohortIds?: Maybe<Scalars["String"]>;
   sampleOrigin?: Maybe<Scalars["String"]>;
   sampleType?: Maybe<Scalars["String"]>;
   sex?: Maybe<Scalars["String"]>;
@@ -1528,6 +1529,7 @@ export type DashboardSampleInput = {
   revisable?: InputMaybe<Scalars["Boolean"]>;
   sampleCategory: Scalars["String"];
   sampleClass?: InputMaybe<Scalars["String"]>;
+  sampleCohortIds?: InputMaybe<Scalars["String"]>;
   sampleOrigin?: InputMaybe<Scalars["String"]>;
   sampleType?: InputMaybe<Scalars["String"]>;
   sex?: InputMaybe<Scalars["String"]>;
@@ -11170,6 +11172,7 @@ export type DashboardSamplesQuery = {
     qcCompleteResult?: string | null;
     qcCompleteReason?: string | null;
     qcCompleteStatus?: string | null;
+    sampleCohortIds?: string | null;
     dbGapStudy?: string | null;
     dmpPatientAlias?: string | null;
   }>;
@@ -11232,6 +11235,7 @@ export type DashboardTempoPartsFragment = {
   qcCompleteResult?: string | null;
   qcCompleteReason?: string | null;
   qcCompleteStatus?: string | null;
+  sampleCohortIds?: string | null;
 };
 
 export type DashboardDbGapPartsFragment = {
@@ -11321,6 +11325,7 @@ export type UpdateDashboardSamplesMutation = {
     qcCompleteResult?: string | null;
     qcCompleteReason?: string | null;
     qcCompleteStatus?: string | null;
+    sampleCohortIds?: string | null;
     dbGapStudy?: string | null;
   } | null> | null;
 };
@@ -11382,6 +11387,7 @@ export const DashboardTempoPartsFragmentDoc = gql`
     qcCompleteResult
     qcCompleteReason
     qcCompleteStatus
+    sampleCohortIds
   }
 `;
 export const DashboardDbGapPartsFragmentDoc = gql`

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -88,6 +88,8 @@ const SAMPLE_FIELDS = `
   qcCompleteResult: String
   qcCompleteReason: String
   qcCompleteStatus: String
+  # (s:Sample)<-[:HAS_COHORT_SAMPLE]-(c:Cohort)
+  sampleCohortIds: String
 
   # (s:Sample)-[:HAS_DBGAP]->(d:DbGap)
   dbGapStudy: String

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -13373,6 +13373,18 @@
             "deprecationReason": null
           },
           {
+            "name": "sampleCohortIds",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sampleOrigin",
             "description": null,
             "args": [],
@@ -14014,6 +14026,18 @@
           },
           {
             "name": "sampleClass",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sampleCohortIds",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -192,6 +192,7 @@ fragment DashboardTempoParts on DashboardSample {
   qcCompleteResult
   qcCompleteReason
   qcCompleteStatus
+  sampleCohortIds
 }
 
 fragment DashboardDbGapParts on DashboardSample {


### PR DESCRIPTION
- Added cohort IDs to sample records
- Cohort IDs are also searchable now on any sample view


Searching for a cohort ID on the samples page:
<img width="940" height="337" alt="image" src="https://github.com/user-attachments/assets/b37a4077-e087-4f80-926f-c9b2ec4c5d5b" />

Search for cohort ID above matches the sample count from the Cohorts View table

<img width="927" height="42" alt="image" src="https://github.com/user-attachments/assets/28c481b6-4b60-4f9f-a287-05711a661204" />


@qu8n cohort IDs column displayed 
<img width="850" height="349" alt="image" src="https://github.com/user-attachments/assets/9aaf241a-8813-45c6-be83-e3e282a839c5" />
