### PR TITLE
Warm up Databricks tables upon logging in

### DIFF
--- a/graphql-server/src/middlewares/configureLogging.ts
+++ b/graphql-server/src/middlewares/configureLogging.ts
@@ -3,6 +3,7 @@ import path from "path";
 const morgan = require("morgan");
 import fs from "fs";
 import { props } from "../utils/constants";
+import { ApolloServerContext } from "../utils/servers";
 
 /**
  * Log only PHI queries from logged in users
@@ -15,11 +16,11 @@ export function configureLogging(app: Express) {
     flags: "a+",
   });
 
-  morgan.token("keycloak-user-id", (req: any) => {
+  morgan.token("keycloak-user-id", (req: ApolloServerContext["req"]) => {
     return `Keycloak user ID: ${req.user?.sub || "N/A"}`;
   });
 
-  morgan.token("graphql-query", (req: any) => {
+  morgan.token("graphql-query", (req: ApolloServerContext["req"]) => {
     const { operationName } = req.body;
     return `GraphQL query: ${operationName || "N/A"}`;
   });
@@ -29,7 +30,7 @@ export function configureLogging(app: Express) {
       ":method :url :status - :date[iso] - :keycloak-user-id - :graphql-query",
       {
         stream: accessLogStream,
-        skip: (req: any) => {
+        skip: (req: ApolloServerContext["req"]) => {
           if (
             req.user &&
             req.body.operationName === "DashboardPatients" &&

--- a/graphql-server/src/routes/auth/callback.ts
+++ b/graphql-server/src/routes/auth/callback.ts
@@ -2,7 +2,7 @@ import { REACT_APP_REACT_SERVER_ORIGIN } from "../../utils/constants";
 const passport = require("passport");
 
 /**
- * This second passport.authenticate() serves a distinct function from the one called by the logInRouter.
+ * This second passport.authenticate() serves a distinct function from the one called by logInRoute.
  * It lets Keycloak respond to the above authentication request, following the OpenID protocol.
  * If successful, Passport adds `user` and `isAuthenticated()` to the `req` object.
  */

--- a/graphql-server/src/routes/index.ts
+++ b/graphql-server/src/routes/index.ts
@@ -7,11 +7,12 @@ import {
   updateActiveUserSessions,
 } from "../utils/session";
 import { logOutRoute } from "./auth/logout";
+import { warmUpDatabricksTables } from "../utils/databricks";
 
 export function configureRoutes(app: Express) {
   app.get("/", (_, res) => res.sendStatus(200)); // health check
 
-  app.get("/auth/login", logInRoute);
+  app.get("/auth/login", warmUpDatabricksTables, logInRoute);
 
   app.get("/auth/callback", callbackRoute);
 

--- a/graphql-server/src/utils/servers.ts
+++ b/graphql-server/src/utils/servers.ts
@@ -36,6 +36,10 @@ export interface ApolloServerContext {
     isAuthenticated: () => boolean;
     logOut: (error: any) => void;
     app: Express;
+    body: {
+      operationName: string; // GraphQL query name
+      variables?: any; // GraphQL query variables
+    };
   };
   inMemoryCache: NodeCache;
 }

--- a/graphql-server/src/utils/session.ts
+++ b/graphql-server/src/utils/session.ts
@@ -2,6 +2,7 @@ import { Issuer } from "openid-client";
 import { props } from "../utils/constants";
 import { REACT_APP_EXPRESS_SERVER_ORIGIN } from "./constants";
 import { logOutRoute } from "../routes/auth/logout";
+import { ApolloServerContext } from "./servers";
 
 export async function getKeycloakClient() {
   const keycloakIssuer = await Issuer.discover(props.keycloak_server_uri);
@@ -14,7 +15,11 @@ export async function getKeycloakClient() {
   });
 }
 
-export function checkAuthentication(req: any, res: any, next: any) {
+export function checkAuthentication(
+  req: ApolloServerContext["req"],
+  res: any,
+  next: any
+) {
   // Check if `req.user` is defined
   if (req.isAuthenticated()) {
     return next();
@@ -42,7 +47,11 @@ interface SessionConfig {
  *
  * @param next to include if function is used as middleware
  */
-export function updateActiveUserSessions(req: any, _?: any, next?: any) {
+export function updateActiveUserSessions(
+  req: ApolloServerContext["req"],
+  _?: any,
+  next?: any
+) {
   const keycloakUserId = req.user?.sub;
 
   const { activeUserSessions, sessionIdleTimeout } = req.app


### PR DESCRIPTION
Also improve typings of the `req` object.

### Testing

I couldn't find a way to see all query history of a table<sup>1</sup> so I tested this PR by temporarily printing the "warm up" queries' results when they finish running. Also confirmed that the login flow works as before.

<sup>1</sup> On Databricks, clicking a table > Insights only shows queries ran via the built-in SQL Editor. Only admins can see all tables' histories ([source](https://docs.databricks.com/aws/en/sql/user/queries/query-history#access-the-query-history-system-table)).



[#1598](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1598)