### PR TITLE
Fix concurrency issues when warming up Databricks tables

### DIFF
--- a/graphql-server/src/routes/index.ts
+++ b/graphql-server/src/routes/index.ts
@@ -7,12 +7,12 @@ import {
   updateActiveUserSessions,
 } from "../utils/session";
 import { logOutRoute } from "./auth/logout";
-import { warmUpDatabricksTables } from "../utils/databricks";
+import { warmUpDatabricks } from "../utils/databricks";
 
 export function configureRoutes(app: Express) {
   app.get("/", (_, res) => res.sendStatus(200)); // health check
 
-  app.get("/auth/login", warmUpDatabricksTables, logInRoute);
+  app.get("/auth/login", warmUpDatabricks, logInRoute);
 
   app.get("/auth/callback", callbackRoute);
 

--- a/graphql-server/src/utils/databricks.ts
+++ b/graphql-server/src/utils/databricks.ts
@@ -19,17 +19,17 @@ const connectOptions = {
 };
 const logger = new DBSQLLogger({ level: LogLevel.error });
 const client = new DBSQLClient({ logger: logger });
+const queryOptions = { runAsync: true } as ExecuteStatementOptions;
 
 export async function queryDatabricks<T>(query: string): Promise<Array<T>> {
   try {
     await client.connect(connectOptions);
     const session = await client.openSession();
 
-    const queryOptions = { runAsync: true } as ExecuteStatementOptions;
     const queryOperation = await session.executeStatement(query, queryOptions);
     const result = await queryOperation.fetchAll();
-
     await queryOperation.close();
+
     await session.close();
     await client.close();
 
@@ -48,22 +48,44 @@ export async function queryDatabricks<T>(query: string): Promise<Array<T>> {
  * longer time to run as Databricks requires spawning a new compute instance first. This function
  * executes a simple query on each Databricks table to reduce the latency from the cold start
  */
-export async function warmUpDatabricksTables(
-  _req: ApolloServerContext["req"],
-  _res: any,
-  next: any
-): Promise<void> {
+export async function warmUpDatabricksTables() {
   const databricksTablesToWarmUp = [
     props.databricks_phi_id_mapping_table,
     props.databricks_seq_dates_by_patient_table,
   ];
-  for (const table of databricksTablesToWarmUp) {
-    const query = `SELECT 1 FROM ${table} LIMIT 1`;
-    // Execute each query without `await`-ing the result to let the query run quietly in the background
-    // and not block the event loop
-    queryDatabricks(query).catch((error) =>
-      console.error(`Error warming up table ${table}:`, error)
-    );
+  // Open a single Databricks connection and session to execute all warmup queries concurrently.
+  // This is more efficient than opening a new connection for each query using `queryDatabricks()`,
+  // which could also lead to race conditions when calling it in the "fire-and-forget" manner
+  try {
+    await client.connect(connectOptions);
+    const session = await client.openSession();
+
+    for (const table of databricksTablesToWarmUp) {
+      const query = `SELECT 1 FROM ${table} LIMIT 1`;
+      const queryOperation = await session.executeStatement(
+        query,
+        queryOptions
+      );
+      await queryOperation.fetchAll();
+      await queryOperation.close();
+      console.info(`Warmed up Databricks table: ${table}`); // TODO: delete this after PR is approved
+    }
+
+    await session.close();
+    await client.close();
+  } catch (error) {
+    await client.close();
+    console.error("Error warming up Databricks tables:", error);
   }
+}
+
+export async function warmUpDatabricks(
+  _req: ApolloServerContext["req"],
+  _res: any,
+  next: any
+) {
+  // Execute warmup queries without `await`-ing the result to let them run quietly in the background
+  // and not block the event loop
+  warmUpDatabricksTables();
   next();
 }


### PR DESCRIPTION
This PR fixes the race conditions happening in #227. Because the warm-up queries are called concurrently, one query can finish and close the connection before the other query is done. To solve this, I'm having both queries run inside a single connection.