### PR TITLE
Enable exporting all anchor sequencing dates of patients

### DIFF
--- a/frontend/src/components/AlertModal.tsx
+++ b/frontend/src/components/AlertModal.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from "react";
+import { FunctionComponent, useEffect } from "react";
 import Button from "react-bootstrap/Button";
 import Modal from "react-bootstrap/Modal";
 
@@ -8,6 +8,20 @@ export const AlertModal: FunctionComponent<{
   content: string | null;
   onHide: () => void;
 }> = ({ show, title, content, onHide }) => {
+  useEffect(() => {
+    if (!show) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        onHide();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [show, onHide]);
+
   return (
     <Modal
       show={show}

--- a/frontend/src/components/DownloadModal.tsx
+++ b/frontend/src/components/DownloadModal.tsx
@@ -30,8 +30,8 @@ export function DownloadModal({
       <Modal.Body>
         <div className="d-flex flex-column align-items-center">
           <p>
-            Downloading the latest version of your data request and converting
-            it to TSV format. This may take up to 30 seconds.
+            Downloading the most up-to-date version of your data request. Note
+            that large data requests may take up to a minute to process.
           </p>
           <Spinner fadeIn={"none"} color={"lightblue"} name="ball-grid-pulse" />
         </div>

--- a/frontend/src/components/DownloadModal.tsx
+++ b/frontend/src/components/DownloadModal.tsx
@@ -31,7 +31,7 @@ export function DownloadModal({
         <div className="d-flex flex-column align-items-center">
           <p>
             Downloading the latest version of your data request and converting
-            it to TSV format. This may take up to 30s.
+            it to TSV format. This may take up to 30 seconds.
           </p>
           <Spinner fadeIn={"none"} color={"lightblue"} name="ball-grid-pulse" />
         </div>

--- a/frontend/src/components/DownloadModal.tsx
+++ b/frontend/src/components/DownloadModal.tsx
@@ -31,7 +31,7 @@ export function DownloadModal({
         <div className="d-flex flex-column align-items-center">
           <p>
             Downloading the most up-to-date version of your data request. Note
-            that large data requests may take up to a minute to process.
+            that large data requests may take minutes to process.
           </p>
           <Spinner fadeIn={"none"} color={"lightblue"} name="ball-grid-pulse" />
         </div>

--- a/frontend/src/components/DownloadModal.tsx
+++ b/frontend/src/components/DownloadModal.tsx
@@ -29,7 +29,10 @@ export function DownloadModal({
     <Modal show={true} size={"sm"}>
       <Modal.Body>
         <div className="d-flex flex-column align-items-center">
-          <p>Preparing to download data...</p>
+          <p>
+            Downloading the latest version of your data request and converting
+            it to TSV format. This may take up to 30s.
+          </p>
           <Spinner fadeIn={"none"} color={"lightblue"} name="ball-grid-pulse" />
         </div>
       </Modal.Body>

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -27,13 +27,18 @@ import {
   CACHE_BLOCK_SIZE,
   defaultColDef,
   getColumnFilters,
-  MAX_ROWS_EXPORT,
 } from "../shared/helpers";
 import { ErrorMessage, Toolbar } from "../shared/components/Toolbar";
 import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
 import { BreadCrumb } from "../shared/components/BreadCrumb";
 import { Title } from "../shared/components/Title";
 import { parseUserSearchVal } from "../utils/parseSearchQueries";
+
+export interface IExportDropdownItem {
+  label: string;
+  columnDefs: ColDef[];
+  customLoader?: () => Promise<any>;
+}
 
 interface IRecordsListProps {
   columnDefs: ColDef[];
@@ -45,12 +50,13 @@ interface IRecordsListProps {
   setUserSearchVal: Dispatch<SetStateAction<string>>;
   showDownloadModal: boolean;
   setShowDownloadModal: Dispatch<SetStateAction<boolean>>;
-  handleDownload: (recordCount: number) => void;
+  handleDownload: () => void;
   samplesColDefs: ColDef[];
   sampleContexts?: DashboardSamplesQueryVariables["contexts"];
   userEmail?: string | null;
   setUserEmail?: Dispatch<SetStateAction<string | null>>;
   customToolbarUI?: JSX.Element;
+  exportDropdownItems?: IExportDropdownItem[];
 }
 
 export default function RecordsList({
@@ -69,9 +75,14 @@ export default function RecordsList({
   userEmail,
   setUserEmail,
   customToolbarUI,
+  exportDropdownItems,
 }: IRecordsListProps) {
   const [showClosingWarning, setShowClosingWarning] = useState(false);
   const [unsavedChanges, setUnsavedChanges] = useState(false);
+  const [columnDefsForExport, setColumnDefsForExport] =
+    useState<ColDef[]>(columnDefs);
+  const [selectedExportItem, setSelectedExportItem] =
+    useState<IExportDropdownItem | null>(null);
 
   const gridRef = useRef<AgGridReactType>(null);
   const navigate = useNavigate();
@@ -148,6 +159,23 @@ export default function RecordsList({
     }
   };
 
+  async function getExportLoader() {
+    if (selectedExportItem && selectedExportItem.customLoader) {
+      const data = await selectedExportItem.customLoader!();
+      return buildTsvString(
+        data,
+        selectedExportItem.columnDefs,
+        gridRef.current?.columnApi?.getAllGridColumns()
+      );
+    }
+    const { data } = await fetchMore({ variables: { offset: 0 } });
+    return buildTsvString(
+      data[recordsQueryName],
+      columnDefsForExport,
+      gridRef.current?.columnApi?.getAllGridColumns()
+    );
+  }
+
   return (
     <Container fluid>
       <BreadCrumb currPageTitle={dataName} />
@@ -155,21 +183,12 @@ export default function RecordsList({
 
       {showDownloadModal && (
         <DownloadModal
-          loader={async () => {
-            // Using fetchMore instead of refetch to avoid overriding the cached variables
-            const { data } = await fetchMore({
-              variables: {
-                offset: 0,
-                limit: MAX_ROWS_EXPORT,
-              },
-            });
-            return buildTsvString(
-              data[recordsQueryName],
-              columnDefs,
-              gridRef.current?.columnApi?.getAllGridColumns()
-            );
+          loader={getExportLoader}
+          onComplete={() => {
+            setShowDownloadModal(false);
+            setColumnDefsForExport(columnDefs);
+            setSelectedExportItem(null);
           }}
-          onComplete={() => setShowDownloadModal(false)}
           exportFileName={`${dataName}.tsv`}
         />
       )}
@@ -246,8 +265,11 @@ export default function RecordsList({
             ? `(${uniqueSampleCount.toLocaleString()} unique samples)`
             : ""
         }`}
-        onDownload={() => handleDownload(recordCount)}
+        onDownload={() => handleDownload()}
         customUIRight={customToolbarUI}
+        exportDropdownItems={exportDropdownItems}
+        setColumnDefsForExport={setColumnDefsForExport}
+        setSelectedExportItem={setSelectedExportItem}
       />
 
       <AutoSizer>

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -51,7 +51,7 @@ interface IRecordsListProps {
   userEmail?: string | null;
   setUserEmail?: Dispatch<SetStateAction<string | null>>;
   customToolbarUI?: JSX.Element;
-  exportDropdownItems?: IExportDropdownItem[];
+  addlExportDropdownItems?: IExportDropdownItem[];
 }
 
 export default function RecordsList({
@@ -70,7 +70,7 @@ export default function RecordsList({
   userEmail,
   setUserEmail,
   customToolbarUI,
-  exportDropdownItems,
+  addlExportDropdownItems,
 }: IRecordsListProps) {
   const [showClosingWarning, setShowClosingWarning] = useState(false);
   const [unsavedChanges, setUnsavedChanges] = useState(false);
@@ -163,7 +163,11 @@ export default function RecordsList({
       );
     }
     const { data } = await fetchMore({
-      variables: { offset: 0, limit: recordCount },
+      variables: {
+        searchVals: parseUserSearchVal(userSearchVal),
+        offset: 0,
+        limit: recordCount,
+      },
     });
     return buildTsvString(
       data[recordsQueryName],
@@ -263,7 +267,7 @@ export default function RecordsList({
         }`}
         onDownload={() => handleDownload()}
         customUIRight={customToolbarUI}
-        exportDropdownItems={exportDropdownItems}
+        addlExportDropdownItems={addlExportDropdownItems}
         setColumnDefsForExport={setColumnDefsForExport}
         setSelectedExportItem={setSelectedExportItem}
       />

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -27,20 +27,13 @@ import {
   CACHE_BLOCK_SIZE,
   defaultColDef,
   getColumnFilters,
+  IExportDropdownItem,
 } from "../shared/helpers";
 import { ErrorMessage, Toolbar } from "../shared/components/Toolbar";
 import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
 import { BreadCrumb } from "../shared/components/BreadCrumb";
 import { Title } from "../shared/components/Title";
 import { parseUserSearchVal } from "../utils/parseSearchQueries";
-
-export interface IExportDropdownItem {
-  label: string;
-  columnDefs: ColDef[];
-  customLoader?: () => Promise<any>;
-  disabled?: boolean;
-  tooltip?: string;
-}
 
 interface IRecordsListProps {
   columnDefs: ColDef[];

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -74,8 +74,7 @@ export default function RecordsList({
 }: IRecordsListProps) {
   const [showClosingWarning, setShowClosingWarning] = useState(false);
   const [unsavedChanges, setUnsavedChanges] = useState(false);
-  const [columnDefsForExport, setColumnDefsForExport] =
-    useState<ColDef[]>(columnDefs);
+  const [, setColumnDefsForExport] = useState<ColDef[]>(columnDefs);
   const [selectedExportItem, setSelectedExportItem] =
     useState<IExportDropdownItem | null>(null);
 
@@ -168,7 +167,7 @@ export default function RecordsList({
     });
     return buildTsvString(
       data[recordsQueryName],
-      columnDefsForExport,
+      columnDefs,
       gridRef.current?.columnApi?.getAllGridColumns()
     );
   }

--- a/frontend/src/components/RecordsList.tsx
+++ b/frontend/src/components/RecordsList.tsx
@@ -38,6 +38,8 @@ export interface IExportDropdownItem {
   label: string;
   columnDefs: ColDef[];
   customLoader?: () => Promise<any>;
+  disabled?: boolean;
+  tooltip?: string;
 }
 
 interface IRecordsListProps {
@@ -168,7 +170,9 @@ export default function RecordsList({
         gridRef.current?.columnApi?.getAllGridColumns()
       );
     }
-    const { data } = await fetchMore({ variables: { offset: 0 } });
+    const { data } = await fetchMore({
+      variables: { offset: 0, limit: recordCount },
+    });
     return buildTsvString(
       data[recordsQueryName],
       columnDefsForExport,

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -62,7 +62,7 @@ interface ISampleListProps {
   userEmail?: string | null;
   setUserEmail?: Dispatch<SetStateAction<string | null>>;
   customToolbarUI?: JSX.Element;
-  exportDropdownItems?: IExportDropdownItem[];
+  addlExportDropdownItems?: IExportDropdownItem[];
 }
 
 export default function SamplesList({
@@ -73,7 +73,7 @@ export default function SamplesList({
   userEmail,
   setUserEmail,
   customToolbarUI,
-  exportDropdownItems,
+  addlExportDropdownItems,
 }: ISampleListProps) {
   const [userSearchVal, setUserSearchVal] = useState<string>("");
   const [changes, setChanges] = useState<SampleChange[]>([]);
@@ -391,7 +391,7 @@ export default function SamplesList({
             </>
           ) : undefined
         }
-        exportDropdownItems={exportDropdownItems}
+        addlExportDropdownItems={addlExportDropdownItems}
         setColumnDefsForExport={setColumnDefsForExport}
       />
 

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -304,8 +304,9 @@ export default function SamplesList({
         <DownloadModal
           loader={async () => {
             // Using fetchMore instead of refetch to avoid overriding the cached variables
+            // TODO: fix "Error: Cannot return null for non-nullable field DashboardSample.primaryId." when trying to export everything
             const { data } = await fetchMore({
-              variables: { offset: 0 },
+              variables: { offset: 0, limit: sampleCount },
             });
             return buildTsvString(
               data.dashboardSamples,

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -14,6 +14,7 @@ import { AlertModal } from "./AlertModal";
 import { buildTsvString } from "../utils/stringBuilders";
 import {
   CACHE_BLOCK_SIZE,
+  IExportDropdownItem,
   SampleChange,
   defaultColDef,
   formatDate,
@@ -61,10 +62,7 @@ interface ISampleListProps {
   userEmail?: string | null;
   setUserEmail?: Dispatch<SetStateAction<string | null>>;
   customToolbarUI?: JSX.Element;
-  exportDropdownItems?: Array<{
-    label: string;
-    columnDefs: ColDef[];
-  }>;
+  exportDropdownItems?: IExportDropdownItem[];
 }
 
 export default function SamplesList({

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -304,7 +304,6 @@ export default function SamplesList({
         <DownloadModal
           loader={async () => {
             // Using fetchMore instead of refetch to avoid overriding the cached variables
-            // TODO: fix "Error: Cannot return null for non-nullable field DashboardSample.primaryId." when trying to export everything
             const { data } = await fetchMore({
               variables: { offset: 0, limit: sampleCount },
             });

--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -14,8 +14,6 @@ import { AlertModal } from "./AlertModal";
 import { buildTsvString } from "../utils/stringBuilders";
 import {
   CACHE_BLOCK_SIZE,
-  MAX_ROWS_EXPORT,
-  MAX_ROWS_EXPORT_WARNING,
   SampleChange,
   defaultColDef,
   formatDate,
@@ -307,10 +305,7 @@ export default function SamplesList({
           loader={async () => {
             // Using fetchMore instead of refetch to avoid overriding the cached variables
             const { data } = await fetchMore({
-              variables: {
-                offset: 0,
-                limit: MAX_ROWS_EXPORT,
-              },
+              variables: { offset: 0 },
             });
             return buildTsvString(
               data.dashboardSamples,
@@ -357,14 +352,7 @@ export default function SamplesList({
         matchingResultsCount={`${
           sampleCount !== undefined ? sampleCount?.toLocaleString() : "Loading"
         } matching samples`}
-        onDownload={() => {
-          if (sampleCount && sampleCount > MAX_ROWS_EXPORT) {
-            setAlertContent(MAX_ROWS_EXPORT_WARNING.content);
-            setColumnDefsForExport(columnDefs);
-          } else {
-            setShowDownloadModal(true);
-          }
-        }}
+        onDownload={() => setShowDownloadModal(true)}
         customUILeft={customToolbarUI}
         customUIRight={
           changes.length > 0 ? (

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -4073,6 +4073,7 @@ export type QcCompletesConnection = {
 
 export type Query = {
   __typename?: "Query";
+  allAnchorSeqDateByPatientId: Array<AnchorSeqDateByPatientId>;
   bamCompletes: Array<BamComplete>;
   bamCompletesAggregate: BamCompleteAggregateSelection;
   bamCompletesConnection: BamCompletesConnection;
@@ -11333,6 +11334,20 @@ export type UpdateDashboardSamplesMutation = {
   } | null> | null;
 };
 
+export type AllAnchorSeqDateByPatientIdQueryVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type AllAnchorSeqDateByPatientIdQuery = {
+  __typename?: "Query";
+  allAnchorSeqDateByPatientId: Array<{
+    __typename?: "AnchorSeqDateByPatientId";
+    MRN: string;
+    DMP_PATIENT_ID: string;
+    ANCHOR_SEQUENCING_DATE: string;
+  }>;
+};
+
 export const DashboardSamplePartsFragmentDoc = gql`
   fragment DashboardSampleParts on DashboardSample {
     smileSampleId
@@ -11842,4 +11857,63 @@ export type UpdateDashboardSamplesMutationResult =
 export type UpdateDashboardSamplesMutationOptions = Apollo.BaseMutationOptions<
   UpdateDashboardSamplesMutation,
   UpdateDashboardSamplesMutationVariables
+>;
+export const AllAnchorSeqDateByPatientIdDocument = gql`
+  query AllAnchorSeqDateByPatientId {
+    allAnchorSeqDateByPatientId {
+      MRN
+      DMP_PATIENT_ID
+      ANCHOR_SEQUENCING_DATE
+    }
+  }
+`;
+
+/**
+ * __useAllAnchorSeqDateByPatientIdQuery__
+ *
+ * To run a query within a React component, call `useAllAnchorSeqDateByPatientIdQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAllAnchorSeqDateByPatientIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useAllAnchorSeqDateByPatientIdQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useAllAnchorSeqDateByPatientIdQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    AllAnchorSeqDateByPatientIdQuery,
+    AllAnchorSeqDateByPatientIdQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    AllAnchorSeqDateByPatientIdQuery,
+    AllAnchorSeqDateByPatientIdQueryVariables
+  >(AllAnchorSeqDateByPatientIdDocument, options);
+}
+export function useAllAnchorSeqDateByPatientIdLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    AllAnchorSeqDateByPatientIdQuery,
+    AllAnchorSeqDateByPatientIdQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    AllAnchorSeqDateByPatientIdQuery,
+    AllAnchorSeqDateByPatientIdQueryVariables
+  >(AllAnchorSeqDateByPatientIdDocument, options);
+}
+export type AllAnchorSeqDateByPatientIdQueryHookResult = ReturnType<
+  typeof useAllAnchorSeqDateByPatientIdQuery
+>;
+export type AllAnchorSeqDateByPatientIdLazyQueryHookResult = ReturnType<
+  typeof useAllAnchorSeqDateByPatientIdLazyQuery
+>;
+export type AllAnchorSeqDateByPatientIdQueryResult = Apollo.QueryResult<
+  AllAnchorSeqDateByPatientIdQuery,
+  AllAnchorSeqDateByPatientIdQueryVariables
 >;

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -4128,6 +4128,10 @@ export type Query = {
   temposConnection: TemposConnection;
 };
 
+export type QueryAllAnchorSeqDateByPatientIdArgs = {
+  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+};
+
 export type QueryBamCompletesArgs = {
   options?: InputMaybe<BamCompleteOptions>;
   where?: InputMaybe<BamCompleteWhere>;
@@ -11335,7 +11339,7 @@ export type UpdateDashboardSamplesMutation = {
 };
 
 export type AllAnchorSeqDateByPatientIdQueryVariables = Exact<{
-  [key: string]: never;
+  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
 }>;
 
 export type AllAnchorSeqDateByPatientIdQuery = {
@@ -11859,8 +11863,8 @@ export type UpdateDashboardSamplesMutationOptions = Apollo.BaseMutationOptions<
   UpdateDashboardSamplesMutationVariables
 >;
 export const AllAnchorSeqDateByPatientIdDocument = gql`
-  query AllAnchorSeqDateByPatientId {
-    allAnchorSeqDateByPatientId {
+  query AllAnchorSeqDateByPatientId($phiEnabled: Boolean = false) {
+    allAnchorSeqDateByPatientId(phiEnabled: $phiEnabled) {
       MRN
       DMP_PATIENT_ID
       ANCHOR_SEQUENCING_DATE
@@ -11880,6 +11884,7 @@ export const AllAnchorSeqDateByPatientIdDocument = gql`
  * @example
  * const { data, loading, error } = useAllAnchorSeqDateByPatientIdQuery({
  *   variables: {
+ *      phiEnabled: // value for 'phiEnabled'
  *   },
  * });
  */

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -3,12 +3,7 @@ import {
   useDashboardCohortsLazyQuery,
 } from "../../generated/graphql";
 import { Dispatch, SetStateAction, useState } from "react";
-import {
-  MAX_ROWS_EXPORT,
-  MAX_ROWS_EXPORT_WARNING,
-  wesSampleColDefs,
-  cohortColDefs,
-} from "../../shared/helpers";
+import { wesSampleColDefs, cohortColDefs } from "../../shared/helpers";
 import { useParams } from "react-router-dom";
 import RecordsList from "../../components/RecordsList";
 import { AlertModal } from "../../components/AlertModal";
@@ -50,13 +45,7 @@ export default function CohortsPage({
         setUserSearchVal={setUserSearchVal}
         showDownloadModal={showDownloadModal}
         setShowDownloadModal={setShowDownloadModal}
-        handleDownload={(recordCount: number) => {
-          if (recordCount && recordCount > MAX_ROWS_EXPORT) {
-            setAlertModal({ show: true, ...MAX_ROWS_EXPORT_WARNING });
-          } else {
-            setShowDownloadModal(true);
-          }
-        }}
+        handleDownload={() => setShowDownloadModal(true)}
         samplesColDefs={wesSampleColDefs}
         sampleContexts={
           sampleQueryParamValue

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -41,7 +41,7 @@ export default function PatientsPage({
   setUserEmail,
 }: IPatientsPageProps) {
   const params = useParams();
-  const [queryAllSeqDates, {}] = useAllAnchorSeqDateByPatientIdLazyQuery();
+  const [queryAllSeqDates] = useAllAnchorSeqDateByPatientIdLazyQuery();
 
   const [userSearchVal, setUserSearchVal] = useState<string>("");
   const [showDownloadModal, setShowDownloadModal] = useState(false);

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -159,7 +159,6 @@ export default function PatientsPage({
               return result.data?.allAnchorSeqDateByPatientId;
             },
             disabled: !phiEnabled,
-            // TODO: fix styling of the tooltip icon
             tooltip:
               "You must enable PHI and log in to export anchor sequencing dates",
           },

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -158,7 +158,7 @@ export default function PatientsPage({
               });
               return result.data?.allAnchorSeqDateByPatientId;
             },
-            disabled: !phiEnabled,
+            disabled: !phiEnabled || !userEmail,
             tooltip:
               "You must enable PHI and log in to export anchor sequencing dates",
           },

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -153,9 +153,15 @@ export default function PatientsPage({
             label: "Export all anchor dates for clinical cohort",
             columnDefs: allAnchorSeqDateColDefs,
             customLoader: async () => {
-              const result = await queryAllSeqDates();
+              const result = await queryAllSeqDates({
+                variables: { phiEnabled: phiEnabled },
+              });
               return result.data?.allAnchorSeqDateByPatientId;
             },
+            disabled: !phiEnabled,
+            // TODO: fix styling of the tooltip icon
+            tooltip:
+              "You must enable PHI and log in to export anchor sequencing dates",
           },
         ]}
       />

--- a/frontend/src/pages/requests/RequestsPage.tsx
+++ b/frontend/src/pages/requests/RequestsPage.tsx
@@ -3,12 +3,7 @@ import {
   useDashboardRequestsLazyQuery,
 } from "../../generated/graphql";
 import { useState } from "react";
-import {
-  MAX_ROWS_EXPORT,
-  MAX_ROWS_EXPORT_WARNING,
-  requestColDefs,
-  sampleColDefs,
-} from "../../shared/helpers";
+import { requestColDefs, sampleColDefs } from "../../shared/helpers";
 import { useParams } from "react-router-dom";
 import RecordsList from "../../components/RecordsList";
 import { AlertModal } from "../../components/AlertModal";
@@ -42,13 +37,7 @@ export default function RequestsPage() {
         setUserSearchVal={setUserSearchVal}
         showDownloadModal={showDownloadModal}
         setShowDownloadModal={setShowDownloadModal}
-        handleDownload={(recordCount: number) => {
-          if (recordCount && recordCount > MAX_ROWS_EXPORT) {
-            setAlertModal({ show: true, ...MAX_ROWS_EXPORT_WARNING });
-          } else {
-            setShowDownloadModal(true);
-          }
-        }}
+        handleDownload={() => setShowDownloadModal(true)}
         samplesColDefs={sampleColDefs}
         sampleContexts={
           sampleQueryParamValue

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -126,7 +126,7 @@ export default function SamplesPage() {
           </ButtonGroup>
         </>
       }
-      exportDropdownItems={[
+      addlExportDropdownItems={[
         {
           label: "Export in Phenotype format for dbGaP",
           columnDefs: DbGapPhenotypeColumns,

--- a/frontend/src/shared/components/Toolbar.tsx
+++ b/frontend/src/shared/components/Toolbar.tsx
@@ -7,6 +7,7 @@ import { Dispatch, SetStateAction } from "react";
 import { CustomTooltip } from "./CustomToolTip";
 import { ColDef } from "ag-grid-community";
 import InfoIcon from "@material-ui/icons/InfoOutlined";
+import { IExportDropdownItem } from "../../components/RecordsList";
 
 export function LoadingSpinner() {
   return (
@@ -33,11 +34,9 @@ interface IToolbarProps {
   onDownload: () => void;
   customUILeft?: JSX.Element;
   customUIRight?: JSX.Element;
-  exportDropdownItems?: Array<{
-    label: string;
-    columnDefs: ColDef[];
-  }>;
+  exportDropdownItems?: IExportDropdownItem[];
   setColumnDefsForExport?: Dispatch<SetStateAction<ColDef[]>>;
+  setSelectedExportItem?: Dispatch<SetStateAction<IExportDropdownItem | null>>;
 }
 
 export function Toolbar({
@@ -51,6 +50,7 @@ export function Toolbar({
   customUIRight,
   exportDropdownItems,
   setColumnDefsForExport,
+  setSelectedExportItem,
 }: IToolbarProps) {
   return (
     <Row className={classNames("d-flex align-items-center tableControlsRow")}>
@@ -105,14 +105,26 @@ export function Toolbar({
 
       <Col className={"text-end"}>
         <Dropdown as={ButtonGroup}>
-          <Button onClick={onDownload} size={"sm"}>
+          <Button
+            onClick={() => {
+              if (setSelectedExportItem) setSelectedExportItem(null);
+              onDownload();
+            }}
+            size={"sm"}
+          >
             Export as TSV
           </Button>
           {exportDropdownItems?.length && setColumnDefsForExport && (
             <>
               <Dropdown.Toggle size="sm" split id="dropdown-split-basic" />
               <Dropdown.Menu>
-                <Dropdown.Item as="button" onClick={onDownload}>
+                <Dropdown.Item
+                  as="button"
+                  onClick={() => {
+                    if (setSelectedExportItem) setSelectedExportItem(null);
+                    onDownload();
+                  }}
+                >
                   Export as TSV
                 </Dropdown.Item>
                 {exportDropdownItems.map((item) => (
@@ -120,8 +132,10 @@ export function Toolbar({
                     as="button"
                     onClick={() => {
                       setColumnDefsForExport(item.columnDefs);
+                      if (setSelectedExportItem) setSelectedExportItem(item);
                       onDownload();
                     }}
+                    key={item.label}
                   >
                     {item.label}
                   </Dropdown.Item>

--- a/frontend/src/shared/components/Toolbar.tsx
+++ b/frontend/src/shared/components/Toolbar.tsx
@@ -128,7 +128,7 @@ export function Toolbar({
                   Export as TSV
                 </Dropdown.Item>
                 {exportDropdownItems.map((item) => (
-                  <div className="d-flex align-items-center">
+                  <div key={item.label} className="d-flex align-items-center">
                     <Dropdown.Item
                       as="button"
                       onClick={() => {
@@ -136,7 +136,6 @@ export function Toolbar({
                         if (setSelectedExportItem) setSelectedExportItem(item);
                         onDownload();
                       }}
-                      key={item.label}
                       disabled={item.disabled}
                     >
                       {item.label}
@@ -144,7 +143,14 @@ export function Toolbar({
                     {item.tooltip && (
                       <CustomTooltip
                         icon={
-                          <InfoIcon style={{ fontSize: 15, color: "grey" }} />
+                          <InfoIcon
+                            style={{
+                              fontSize: 15,
+                              color: "grey",
+                              marginRight: 10,
+                              marginLeft: 5,
+                            }}
+                          />
                         }
                       >
                         {item.tooltip}

--- a/frontend/src/shared/components/Toolbar.tsx
+++ b/frontend/src/shared/components/Toolbar.tsx
@@ -128,17 +128,29 @@ export function Toolbar({
                   Export as TSV
                 </Dropdown.Item>
                 {exportDropdownItems.map((item) => (
-                  <Dropdown.Item
-                    as="button"
-                    onClick={() => {
-                      setColumnDefsForExport(item.columnDefs);
-                      if (setSelectedExportItem) setSelectedExportItem(item);
-                      onDownload();
-                    }}
-                    key={item.label}
-                  >
-                    {item.label}
-                  </Dropdown.Item>
+                  <div className="d-flex align-items-center">
+                    <Dropdown.Item
+                      as="button"
+                      onClick={() => {
+                        setColumnDefsForExport(item.columnDefs);
+                        if (setSelectedExportItem) setSelectedExportItem(item);
+                        onDownload();
+                      }}
+                      key={item.label}
+                      disabled={item.disabled}
+                    >
+                      {item.label}
+                    </Dropdown.Item>
+                    {item.tooltip && (
+                      <CustomTooltip
+                        icon={
+                          <InfoIcon style={{ fontSize: 15, color: "grey" }} />
+                        }
+                      >
+                        {item.tooltip}
+                      </CustomTooltip>
+                    )}
+                  </div>
                 ))}
               </Dropdown.Menu>
             </>

--- a/frontend/src/shared/components/Toolbar.tsx
+++ b/frontend/src/shared/components/Toolbar.tsx
@@ -7,7 +7,7 @@ import { Dispatch, SetStateAction } from "react";
 import { CustomTooltip } from "./CustomToolTip";
 import { ColDef } from "ag-grid-community";
 import InfoIcon from "@material-ui/icons/InfoOutlined";
-import { IExportDropdownItem } from "../../components/RecordsList";
+import { IExportDropdownItem } from "../helpers";
 
 export function LoadingSpinner() {
   return (

--- a/frontend/src/shared/components/Toolbar.tsx
+++ b/frontend/src/shared/components/Toolbar.tsx
@@ -34,7 +34,7 @@ interface IToolbarProps {
   onDownload: () => void;
   customUILeft?: JSX.Element;
   customUIRight?: JSX.Element;
-  exportDropdownItems?: IExportDropdownItem[];
+  addlExportDropdownItems?: IExportDropdownItem[];
   setColumnDefsForExport?: Dispatch<SetStateAction<ColDef[]>>;
   setSelectedExportItem?: Dispatch<SetStateAction<IExportDropdownItem | null>>;
 }
@@ -48,7 +48,7 @@ export function Toolbar({
   onDownload,
   customUILeft,
   customUIRight,
-  exportDropdownItems,
+  addlExportDropdownItems,
   setColumnDefsForExport,
   setSelectedExportItem,
 }: IToolbarProps) {
@@ -114,7 +114,7 @@ export function Toolbar({
           >
             Export as TSV
           </Button>
-          {exportDropdownItems?.length && setColumnDefsForExport && (
+          {addlExportDropdownItems?.length && setColumnDefsForExport && (
             <>
               <Dropdown.Toggle size="sm" split id="dropdown-split-basic" />
               <Dropdown.Menu>
@@ -127,7 +127,7 @@ export function Toolbar({
                 >
                   Export as TSV
                 </Dropdown.Item>
-                {exportDropdownItems.map((item) => (
+                {addlExportDropdownItems.map((item) => (
                   <div key={item.label} className="d-flex align-items-center">
                     <Dropdown.Item
                       as="button"

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -1273,3 +1273,11 @@ export function getColumnFilters(
 }
 
 export const CACHE_BLOCK_SIZE = 500; // number of rows to fetch at a time
+
+export interface IExportDropdownItem {
+  label: string;
+  columnDefs: ColDef[];
+  customLoader?: () => Promise<any>;
+  disabled?: boolean;
+  tooltip?: string;
+}

--- a/frontend/src/shared/helpers.tsx
+++ b/frontend/src/shared/helpers.tsx
@@ -15,6 +15,7 @@ import moment from "moment";
 import _ from "lodash";
 import { RecordValidation } from "../components/RecordValidation";
 import {
+  AnchorSeqDateByPatientId,
   DashboardCohort,
   DashboardPatient,
   DashboardRecordColumnFilter,
@@ -322,6 +323,21 @@ export const patientColDefs: ColDef<DashboardPatient>[] = [
     field: "smilePatientId",
     headerName: "SMILE Patient ID",
     hide: true,
+  },
+];
+
+export const allAnchorSeqDateColDefs: ColDef<AnchorSeqDateByPatientId>[] = [
+  {
+    field: "MRN",
+    headerName: "Patient MRN",
+  },
+  {
+    field: "DMP_PATIENT_ID",
+    headerName: "DMP Patient ID",
+  },
+  {
+    field: "ANCHOR_SEQUENCING_DATE",
+    headerName: "Anchor Sequencing Date",
   },
 ];
 
@@ -1257,12 +1273,3 @@ export function getColumnFilters(
 }
 
 export const CACHE_BLOCK_SIZE = 500; // number of rows to fetch at a time
-
-export const MAX_ROWS_EXPORT = 10000;
-
-export const MAX_ROWS_EXPORT_WARNING = {
-  title: "Warning",
-  content:
-    "You can only download up to 10,000 rows of data at a time. Please refine your search and try again. " +
-    "If you need the full dataset, contact the SMILE team at cmosmile@mskcc.org.",
-};

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -4127,6 +4127,10 @@ export type Query = {
   temposConnection: TemposConnection;
 };
 
+export type QueryAllAnchorSeqDateByPatientIdArgs = {
+  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+};
+
 export type QueryBamCompletesArgs = {
   options?: InputMaybe<BamCompleteOptions>;
   where?: InputMaybe<BamCompleteWhere>;
@@ -11334,7 +11338,7 @@ export type UpdateDashboardSamplesMutation = {
 };
 
 export type AllAnchorSeqDateByPatientIdQueryVariables = Exact<{
-  [key: string]: never;
+  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
 }>;
 
 export type AllAnchorSeqDateByPatientIdQuery = {
@@ -11619,8 +11623,8 @@ export type UpdateDashboardSamplesMutationOptions = Apollo.BaseMutationOptions<
   UpdateDashboardSamplesMutationVariables
 >;
 export const AllAnchorSeqDateByPatientIdDocument = gql`
-  query AllAnchorSeqDateByPatientId {
-    allAnchorSeqDateByPatientId {
+  query AllAnchorSeqDateByPatientId($phiEnabled: Boolean = false) {
+    allAnchorSeqDateByPatientId(phiEnabled: $phiEnabled) {
       MRN
       DMP_PATIENT_ID
       ANCHOR_SEQUENCING_DATE

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -4072,6 +4072,7 @@ export type QcCompletesConnection = {
 
 export type Query = {
   __typename?: "Query";
+  allAnchorSeqDateByPatientId: Array<AnchorSeqDateByPatientId>;
   bamCompletes: Array<BamComplete>;
   bamCompletesAggregate: BamCompleteAggregateSelection;
   bamCompletesConnection: BamCompletesConnection;
@@ -11332,6 +11333,20 @@ export type UpdateDashboardSamplesMutation = {
   } | null> | null;
 };
 
+export type AllAnchorSeqDateByPatientIdQueryVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type AllAnchorSeqDateByPatientIdQuery = {
+  __typename?: "Query";
+  allAnchorSeqDateByPatientId: Array<{
+    __typename?: "AnchorSeqDateByPatientId";
+    MRN: string;
+    DMP_PATIENT_ID: string;
+    ANCHOR_SEQUENCING_DATE: string;
+  }>;
+};
+
 export const DashboardSamplePartsFragmentDoc = gql`
   fragment DashboardSampleParts on DashboardSample {
     smileSampleId
@@ -11602,4 +11617,17 @@ export type UpdateDashboardSamplesMutationResult =
 export type UpdateDashboardSamplesMutationOptions = Apollo.BaseMutationOptions<
   UpdateDashboardSamplesMutation,
   UpdateDashboardSamplesMutationVariables
+>;
+export const AllAnchorSeqDateByPatientIdDocument = gql`
+  query AllAnchorSeqDateByPatientId {
+    allAnchorSeqDateByPatientId {
+      MRN
+      DMP_PATIENT_ID
+      ANCHOR_SEQUENCING_DATE
+    }
+  }
+`;
+export type AllAnchorSeqDateByPatientIdQueryResult = Apollo.QueryResult<
+  AllAnchorSeqDateByPatientIdQuery,
+  AllAnchorSeqDateByPatientIdQueryVariables
 >;

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -16,6 +16,7 @@ import {
   buildPatientsQueryBody,
   buildPatientsQueryFinal,
   mapPhiToPatientsData,
+  queryAllAnchorSeqDateByPatientId,
   queryAnchorSeqDatesByPatientId,
   queryDashboardPatients,
   queryPatientIdsTriplets,
@@ -70,11 +71,6 @@ function canSearchPhiData({
   searchVals?: string[] | null;
   searchValsIsRequired?: boolean;
 }) {
-  console.log("canSearchPhiData called with:", {
-    phiEnabled,
-    searchVals,
-    searchValsIsRequired,
-  });
   if (searchValsIsRequired) {
     return phiEnabled && Array.isArray(searchVals) && searchVals.length > 0;
   }
@@ -248,6 +244,10 @@ export async function buildCustomSchema(ogm: OGM) {
         });
       },
 
+      async allAnchorSeqDateByPatientId() {
+        return await queryAllAnchorSeqDateByPatientId();
+      },
+
       async dashboardCohorts(
         _source: undefined,
         {
@@ -313,18 +313,6 @@ export async function buildCustomSchema(ogm: OGM) {
           samplesCypherQuery,
           oncotreeCache,
         });
-      },
-
-      async allAnchorSeqDateByPatientId() {
-        const query = `
-          SELECT
-            MRN,
-            DMP_PATIENT_ID,
-            ANCHOR_SEQUENCING_DATE
-          FROM
-            ${props.databricks_seq_dates_by_patient_table}
-        `;
-        return await queryDatabricks<AnchorSeqDateByPatientId>(query);
       },
     },
 

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -46,6 +46,7 @@ const request = require("request-promise-native");
 import { AuthenticationError, ForbiddenError } from "apollo-server-express";
 import { applyMiddleware } from "graphql-middleware";
 import { IMiddlewareResolver } from "graphql-middleware/dist/types";
+import { queryDatabricks } from "../utils/databricks";
 
 const KEYCLOAK_PHI_ACCESS_GROUP = "mrn-search";
 
@@ -259,6 +260,18 @@ export async function buildCustomSchema(ogm: OGM) {
           samplesCypherQuery,
           oncotreeCache,
         });
+      },
+
+      async allAnchorSeqDateByPatientId() {
+        const query = `
+          SELECT
+            MRN,
+            DMP_PATIENT_ID,
+            ANCHOR_SEQUENCING_DATE
+          FROM
+            ${props.databricks_seq_dates_by_patient_table}
+        `;
+        return await queryDatabricks<AnchorSeqDateByPatientId>(query);
       },
     },
 

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -53,6 +53,7 @@ const KEYCLOAK_PHI_ACCESS_GROUP = "mrn-search";
 type AuthMiddleware = {
   Query: {
     dashboardPatients: IMiddlewareResolver;
+    allAnchorSeqDateByPatientId: IMiddlewareResolver;
   };
 };
 
@@ -63,23 +64,33 @@ type AuthMiddleware = {
 function canSearchPhiData({
   phiEnabled,
   searchVals,
+  searchValsIsRequired = true,
 }: {
   phiEnabled?: boolean | null;
   searchVals?: string[] | null;
+  searchValsIsRequired?: boolean;
 }) {
-  return phiEnabled && Array.isArray(searchVals) && searchVals.length > 0;
+  console.log("canSearchPhiData called with:", {
+    phiEnabled,
+    searchVals,
+    searchValsIsRequired,
+  });
+  if (searchValsIsRequired) {
+    return phiEnabled && Array.isArray(searchVals) && searchVals.length > 0;
+  }
+  return phiEnabled;
 }
 
 export async function buildCustomSchema(ogm: OGM) {
   const authenticationMiddleware: AuthMiddleware = {
     Query: {
-      dashboardPatients: async (
+      async dashboardPatients(
         resolve,
         parent,
         args: QueryDashboardPatientsArgs,
         context: ApolloServerContext,
         info
-      ) => {
+      ) {
         if (
           canSearchPhiData({
             phiEnabled: args.phiEnabled,
@@ -93,23 +104,65 @@ export async function buildCustomSchema(ogm: OGM) {
         }
         return await resolve(parent, args, context, info);
       },
-    },
-  };
 
-  const authorizationMiddleware: AuthMiddleware = {
-    Query: {
-      dashboardPatients: async (
+      async allAnchorSeqDateByPatientId(
         resolve,
         parent,
         args: QueryDashboardPatientsArgs,
         context: ApolloServerContext,
         info
-      ) => {
+      ) {
+        if (
+          !canSearchPhiData({
+            phiEnabled: args.phiEnabled,
+            searchValsIsRequired: false,
+          }) ||
+          !context.req.isAuthenticated()
+        ) {
+          throw new AuthenticationError(
+            "You must be logged in to access this resource."
+          );
+        }
+        return await resolve(parent, args, context, info);
+      },
+    },
+  };
+
+  const authorizationMiddleware: AuthMiddleware = {
+    Query: {
+      async dashboardPatients(
+        resolve,
+        parent,
+        args: QueryDashboardPatientsArgs,
+        context: ApolloServerContext,
+        info
+      ) {
         if (
           canSearchPhiData({
             phiEnabled: args.phiEnabled,
             searchVals: args.searchVals,
           }) &&
+          !context.req.user.groups.includes(KEYCLOAK_PHI_ACCESS_GROUP)
+        ) {
+          throw new ForbiddenError(
+            "You do not have permission to access this resource. Please contact the SMILE team for assistance."
+          );
+        }
+        return await resolve(parent, args, context, info);
+      },
+
+      async allAnchorSeqDateByPatientId(
+        resolve,
+        parent,
+        args: QueryDashboardPatientsArgs,
+        context: ApolloServerContext,
+        info
+      ) {
+        if (
+          !canSearchPhiData({
+            phiEnabled: args.phiEnabled,
+            searchValsIsRequired: false,
+          }) ||
           !context.req.user.groups.includes(KEYCLOAK_PHI_ACCESS_GROUP)
         ) {
           throw new ForbiddenError(

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -47,7 +47,6 @@ const request = require("request-promise-native");
 import { AuthenticationError, ForbiddenError } from "apollo-server-express";
 import { applyMiddleware } from "graphql-middleware";
 import { IMiddlewareResolver } from "graphql-middleware/dist/types";
-import { queryDatabricks } from "../utils/databricks";
 
 const KEYCLOAK_PHI_ACCESS_GROUP = "mrn-search";
 

--- a/graphql-server/src/schemas/queries/patients.ts
+++ b/graphql-server/src/schemas/queries/patients.ts
@@ -290,3 +290,15 @@ export function mapPhiToPatientsData({
     };
   });
 }
+
+export async function queryAllAnchorSeqDateByPatientId() {
+  const query = `
+    SELECT
+      MRN,
+      DMP_PATIENT_ID,
+      ANCHOR_SEQUENCING_DATE
+    FROM
+      ${props.databricks_seq_dates_by_patient_table}
+  `;
+  return await queryDatabricks<AnchorSeqDateByPatientId>(query);
+}

--- a/graphql-server/src/utils/databricks.ts
+++ b/graphql-server/src/utils/databricks.ts
@@ -68,7 +68,6 @@ export async function warmUpDatabricksTables() {
       );
       await queryOperation.fetchAll();
       await queryOperation.close();
-      console.info(`Warmed up Databricks table: ${table}`); // TODO: delete this after PR is approved
     }
 
     await session.close();

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -217,7 +217,9 @@ const QUERY_TYPEDEFS = gql`
       offset: Int!
     ): [DashboardSample!]!
 
-    allAnchorSeqDateByPatientId: [AnchorSeqDateByPatientId!]!
+    allAnchorSeqDateByPatientId(
+      phiEnabled: Boolean
+    ): [AnchorSeqDateByPatientId!]!
   }
 `;
 

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -216,6 +216,8 @@ const QUERY_TYPEDEFS = gql`
       limit: Int!
       offset: Int!
     ): [DashboardSample!]!
+
+    allAnchorSeqDateByPatientId: [AnchorSeqDateByPatientId!]!
   }
 `;
 

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -33,9 +33,9 @@ const SAMPLE_FIELDS = `
 
   # (s:Sample)-[:HAS_METADATA]->(sm:SampleMetadata)
   ## Root-level fields
-  primaryId: String!
+  primaryId: String
   cmoSampleName: String
-  importDate: String!
+  importDate: String
   cmoPatientId: String
   investigatorSampleId: String
   sampleType: String

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -37792,6 +37792,30 @@
         "description": null,
         "fields": [
           {
+            "name": "allAnchorSeqDateByPatientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AnchorSeqDateByPatientId",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "bamCompletes",
             "description": null,
             "args": [

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -37794,7 +37794,20 @@
           {
             "name": "allAnchorSeqDateByPatientId",
             "description": null,
-            "args": [],
+            "args": [
+              {
+                "name": "phiEnabled",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -238,3 +238,11 @@ mutation UpdateDashboardSamples(
     ...DashboardDbGapParts
   }
 }
+
+query AllAnchorSeqDateByPatientId {
+  allAnchorSeqDateByPatientId {
+    MRN
+    DMP_PATIENT_ID
+    ANCHOR_SEQUENCING_DATE
+  }
+}

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -239,8 +239,8 @@ mutation UpdateDashboardSamples(
   }
 }
 
-query AllAnchorSeqDateByPatientId {
-  allAnchorSeqDateByPatientId {
+query AllAnchorSeqDateByPatientId($phiEnabled: Boolean = false) {
+  allAnchorSeqDateByPatientId(phiEnabled: $phiEnabled) {
     MRN
     DMP_PATIENT_ID
     ANCHOR_SEQUENCING_DATE


### PR DESCRIPTION
This PR also changed the following:

* Removed the export limit that was previously 10,000 records
* By default, the export's format matches the AG Grid's table. This PR added the ability to define a custom export handler to download data in a different format

![CleanShot 2025-07-25 at 11 56 05](https://github.com/user-attachments/assets/e4bcffd8-d257-4eae-a589-0d9d6b897be9)

Tested:

- [x] Exporting all anchor sequencing dates
- [x] Confirmed that the above requires logging in to work
- [x] Exporting from the dashboard when the results are >10,000 records

[#1597](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1597)