### PR TITLE
Fix filter tabs on the Samples page

### DIFF
--- a/frontend/src/components/SamplesList.tsx
+++ b/frontend/src/components/SamplesList.tsx
@@ -98,6 +98,12 @@ export default function SamplesList({
   const [columnDefsForExport, setColumnDefsForExport] =
     useState<ColDef[]>(columnDefs);
 
+  // Keep displayed and exported column definitions in sync with the filter tabs
+  useEffect(() => {
+    setColDefs(columnDefs);
+    setColumnDefsForExport(columnDefs);
+  }, [columnDefs]);
+
   const gridRef = useRef<AgGridReactType>(null);
   const params = useParams();
   const hasParams = Object.keys(params).length > 0;


### PR DESCRIPTION
Fix filter tabs on the Samples page that are no longer in sync with `SamplesList` component due to #236.

### Preview

Before: changing tabs does not update the columns nor the data
https://github-production-user-asset-6210df.s3.amazonaws.com/86090707/475108904-ad278ce7-41c1-4658-b0d5-a9df700704d0.mp4

After: changing tabs update the columns and the data
https://github-production-user-asset-6210df.s3.amazonaws.com/86090707/475108917-b680b038-81b7-489f-be57-d9033cbe154d.mp4