### PR TITLE
Add tooltips to select whole exome sample columns

### DIFF
--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -40,7 +40,6 @@ const defaultColDef: ColDef = {
   resizable: true,
   editable: false,
   headerComponentParams: createCustomHeader(lockIcon),
-  valueFormatter: (params) => (params.value === "null" ? "" : params.value),
   tooltipValueGetter: (params: ITooltipParams) => getTooltipValue(params),
 };
 

--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -35,12 +35,21 @@ function getTooltipValue(params: ITooltipParams) {
   }
 }
 
+export function AgGridCustomTooltip(props: ITooltipParams) {
+  return (
+    <div className="ag-custom-tooltip">
+      <span>{props.value}</span>
+    </div>
+  );
+}
+
 const defaultColDef: ColDef = {
   sortable: true,
   resizable: true,
   editable: false,
   headerComponentParams: createCustomHeader(lockIcon),
   tooltipValueGetter: (params: ITooltipParams) => getTooltipValue(params),
+  tooltipComponent: AgGridCustomTooltip,
 };
 
 interface EditableGridProps {

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -55,11 +55,6 @@ $standardMargin: 10px;
   cursor: not-allowed;
 }
 
-/* Prevent overlapping with the 🚫 icon */
-.ag-tooltip {
-  transform: translate(15px, -40px);
-}
-
 .costCenter-validation-error {
   color: #fa0400 !important;
 }

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -150,3 +150,20 @@ $standardMargin: 10px;
 .popupTableHeight {
   height: calc(100vh - 270px);
 }
+
+// Enable the use of new lines (`\n`) in column headers
+// https://stackoverflow.com/a/57214867
+.ag-header-cell-label .ag-header-cell-text {
+  white-space: pre-wrap !important;
+}
+
+// Prevent column header icons from shrinking when the column width is too small
+.ag-header-cell svg {
+  min-width: 16px;
+  min-height: 16px;
+  width: 16px !important;
+  height: 16px !important;
+  flex-shrink: 0 !important;
+  vertical-align: middle;
+  display: inline-block;
+}

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -100,12 +100,17 @@ $standardMargin: 10px;
   min-width: 100%;
 }
 
-.tooltip-styles {
-  background-color: #f8f8f8;
-  font-size: large;
-  padding: 12px;
-  border: 1px solid rgb(198, 197, 214);
+.ag-custom-tooltip {
+  padding: 6px;
+  background-color: white;
+  border: 1px solid lightgray;
+  max-width: 300px;
   border-radius: 4px;
+
+  span {
+    color: black;
+    font-size: 12px;
+  }
 }
 
 .ag-rich-select-list {

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -159,11 +159,5 @@ $standardMargin: 10px;
 
 // Prevent column header icons from shrinking when the column width is too small
 .ag-header-cell svg {
-  min-width: 16px;
-  min-height: 16px;
-  width: 16px !important;
-  height: 16px !important;
-  flex-shrink: 0 !important;
-  vertical-align: middle;
-  display: inline-block;
+  flex-shrink: 0;
 }

--- a/frontend/src/pages/samples/config.tsx
+++ b/frontend/src/pages/samples/config.tsx
@@ -567,7 +567,7 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
     headerTooltip:
       "Indicates whether MAF generation was successful. Valid for tumor samples only. For the MSK WES Repository cohort we only included samples with a MAF Complete Status of 'Pass' as well as QC Complete Result of 'Pass' or 'Warn'",
     headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
-    width: 270,
+    width: 285,
     wrapHeaderText: true,
   },
   {

--- a/frontend/src/pages/samples/config.tsx
+++ b/frontend/src/pages/samples/config.tsx
@@ -457,12 +457,18 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
   {
     field: "initialPipelineRunDate",
     headerName: "Initial Pipeline Run Date",
+    headerTooltip:
+      "Date the sample is delivered in a cohort for the first time",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
     valueFormatter: (params) => formatCellDate(params.value) ?? "",
     ...getAgGridDateColFilterConfigs(),
+    width: 250,
   },
   {
     field: "embargoDate",
     headerName: "Embargo Date",
+    headerTooltip: "Calculated date; 18 months after Initial Pipeline Run Date",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
     valueFormatter: (params) => formatCellDate(params.value) ?? "",
     ...getAgGridDateColFilterConfigs({
       // embargoDate is 18 months ahead of initialPipelineRunDate
@@ -492,6 +498,7 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
         return isInvalidCostCenter(params.colDef.field!, params.value);
       },
     },
+    width: 250,
   },
   {
     field: "billedBy",
@@ -502,10 +509,15 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
   {
     field: "custodianInformation",
     headerName: "Data Custodian",
+    headerTooltip: "Lab Head Name from IGO Request .json OR added by PM",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
   },
   {
     field: "accessLevel",
     headerName: "Access Level",
+    headerTooltip:
+      "Indicates data availability of sample. Default is MSK Embargo for 18 months after Initial Pipeline Run Date, changes to MSK Public after.",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
   },
   {
     field: "sampleType",
@@ -518,44 +530,60 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
   {
     field: "bamCompleteDate",
     headerName: "Latest BAM Complete Date",
+    headerTooltip: "Most recent date the BAM generation tasks were run",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
     valueFormatter: (params) => formatCellDate(params.value) ?? "",
     ...getAgGridDateColFilterConfigs(),
+    width: 270,
   },
   {
     field: "bamCompleteStatus",
     headerName: "BAM Complete Status",
+    headerTooltip: "Indicates whether BAM generation was successful",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
+    width: 240,
   },
   {
     field: "mafCompleteDate",
     headerName: "Latest MAF Complete Date",
+    headerTooltip:
+      "Most recent date the MAF generation tasks were run. Valid for tumor samples only",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
     valueFormatter: (params) => formatCellDate(params.value) ?? "",
     ...getAgGridDateColFilterConfigs(),
+    width: 270,
   },
   {
     field: "mafCompleteNormalPrimaryId",
     headerName: "MAF Complete Normal Primary ID",
+    headerTooltip:
+      "Primary ID of Normal sample that tumor was paired with, for MAF generation",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
+    width: 310,
   },
   {
     field: "mafCompleteStatus",
-    headerName: "MAF Complete Status",
-  },
-  {
-    field: "qcCompleteDate",
-    headerName: "Latest QC Complete Date",
-    valueFormatter: (params) => formatCellDate(params.value) ?? "",
-    ...getAgGridDateColFilterConfigs(),
+    headerName: "MAF Complete Status/Data Eligible for Sharing",
+    headerTooltip:
+      "Indicates whether MAF generation was successful. Valid for tumor samples only. For the MSK WES Repository cohort we only included samples with a MAF Complete Status of 'Pass' as well as QC Complete Result of 'Pass' or 'Warn'",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
+    width: 400,
   },
   {
     field: "qcCompleteResult",
     headerName: "QC Complete Result",
+    headerTooltip:
+      "Indicates whether the QC metrics passed the TEMPO pipeline thresholds",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
+    width: 230,
   },
   {
     field: "qcCompleteReason",
     headerName: "QC Complete Reason",
-  },
-  {
-    field: "qcCompleteStatus",
-    headerName: "QC Complete Status",
+    headerTooltip:
+      "For samples with a QC Complete Result of 'Fail' or 'Warn', indicates reason for that status",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
+    width: 230,
   },
   {
     field: "genePanel",
@@ -576,6 +604,7 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
   {
     field: "cancerTypeDetailed",
     headerName: "Cancer Type Detailed",
+    width: 220,
   },
   {
     field: "tissueLocation",
@@ -584,6 +613,7 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
   {
     field: "sampleCategory",
     headerName: "SMILE Sample Category",
+    width: 230,
   },
   {
     field: "platform",
@@ -592,6 +622,23 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
   {
     field: "instrumentModel",
     headerName: "INSTRUMENT_MODEL",
+    width: 220,
+  },
+  {
+    field: "qcCompleteDate",
+    headerName: "Latest QC Complete Date",
+    headerTooltip: "Most recent date the QC tasks were run",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
+    valueFormatter: (params) => formatCellDate(params.value) ?? "",
+    ...getAgGridDateColFilterConfigs(),
+    width: 260,
+  },
+  {
+    field: "qcCompleteStatus",
+    headerName: "QC Complete Status",
+    headerTooltip: "Indicates whether QC analysis tasks were completed",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
+    width: 220,
   },
 ];
 

--- a/frontend/src/pages/samples/config.tsx
+++ b/frontend/src/pages/samples/config.tsx
@@ -563,11 +563,12 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
   },
   {
     field: "mafCompleteStatus",
-    headerName: "MAF Complete Status/Data Eligible for Sharing",
+    headerName: "MAF Complete Status \n(Data Eligible for Sharing)",
     headerTooltip:
       "Indicates whether MAF generation was successful. Valid for tumor samples only. For the MSK WES Repository cohort we only included samples with a MAF Complete Status of 'Pass' as well as QC Complete Result of 'Pass' or 'Warn'",
     headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
-    width: 400,
+    width: 270,
+    wrapHeaderText: true,
   },
   {
     field: "qcCompleteResult",


### PR DESCRIPTION
## Description

- Add tooltips to select whole exome sample columns
- Move "Latest QC Complete Date" and "QC Complete Status" columns to the most right of the view (confirmed with Pav)

[#1631](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1631)

## Manual testing checklist

Check off items under the affected features below.

> [!NOTE]
> This PR only affects the UI and none of the functionalities below. I've tested to confirm that the tooltip appears and shows the expected text for each of the affected column header.

### Frontend

#### Searching & filtering

- [ ] Searching for a single term or multiple terms returns relevant results
- [ ] Searching in PHI mode returns results with PHI columns
- [ ] Filtering columns returns the results matching the filter
- [ ] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [ ] Clicking "Download as TSV"
- [ ] Searching for some terms then clicking "Download as TSV"
- [ ] Filtering a column then clicking "Download as TSV"
- [ ] Search in PHI mode then clicking "Download as TSV"
- [ ] Clicking the dropdown download option <download option name>

#### AG Grid interactions

- [ ] [Samples page] Editing a cell updates the value as expected
- [ ] [Samples page] Pasting data into the grid works as expected
- [ ] Editing a cell in a non-editable row/column is prevented
- [ ] Column sorting in ascending and descending order works as expected
- [ ] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [ ] [Samples page] Cell changes confirmation modal appears and works as expected
- [ ] [Requests page] Validation errors are displayed in the Record Validation modal
- [ ] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [ ] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [ ] The GraphQL types that are auto-generated via `yarn run codegen`
- [ ] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
