### PR TITLE
Fix sample updates not fully submitted between searches

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,19 +21,23 @@ export default function App() {
         <BrowserRouter>
           <NavBar />
           <Routes>
-            <Route path="/" element={<RequestsPage />}>
-              <Route path={`:${ROUTE_PARAMS.requests}`} />
-            </Route>
-            <Route path="/requests/" element={<RequestsPage />}>
-              <Route path={`:${ROUTE_PARAMS.requests}`} />
-            </Route>
-            <Route path="/patients/" element={<PatientsPage />}>
-              <Route path={`:${ROUTE_PARAMS.patients}`} />
-            </Route>
+            <Route path="/" element={<RequestsPage />} />
+            <Route path="/requests/" element={<RequestsPage />} />
+            <Route
+              path={`/requests/:${ROUTE_PARAMS.requests}`}
+              element={<RequestsPage />}
+            />
+            <Route path="/patients/" element={<PatientsPage />} />
+            <Route
+              path={`/patients/:${ROUTE_PARAMS.patients}`}
+              element={<PatientsPage />}
+            />
             <Route path="/samples" element={<SamplesPage />} />
-            <Route path="/cohorts/" element={<CohortsPage />}>
-              <Route path={`:${ROUTE_PARAMS.cohorts}`} />
-            </Route>
+            <Route path="/cohorts/" element={<CohortsPage />} />
+            <Route
+              path={`/cohorts/:${ROUTE_PARAMS.cohorts}`}
+              element={<CohortsPage />}
+            />
             <Route path="/auth/login-success" element={<LoginSuccessPage />} />
           </Routes>
         </BrowserRouter>

--- a/frontend/src/hooks/useCellChanges.ts
+++ b/frontend/src/hooks/useCellChanges.ts
@@ -173,7 +173,8 @@ export function useCellChanges({
 
     // Submit changes to the GraphQL server
     let newDashboardSamples: Array<DashboardSampleInput> = [];
-    samples.forEach((s) => {
+    changes.forEach((change) => {
+      const s: DashboardSample = change.rowNode.data;
       if (s.primaryId && s.primaryId in changesByPrimaryId) {
         const newDashboardSample = {
           ...s,

--- a/frontend/src/hooks/useCellChanges.ts
+++ b/frontend/src/hooks/useCellChanges.ts
@@ -164,35 +164,15 @@ export function useCellChanges({
   }
 
   async function handleSubmitUpdates() {
-    if (!samples || samples.length === 0) {
-      console.error("No samples available to update.");
+    if (changes.length === 0) {
+      console.error("No changes available to submit.");
       return;
     }
 
     const changesByPrimaryId = groupChangesByPrimaryId(changes);
+    const newDashboardSamples = buildNewDashboardSamples(changesByPrimaryId);
 
-    // Submit changes to the GraphQL server
-    let newDashboardSamples: Array<DashboardSampleInput> = [];
-    changes.forEach((change) => {
-      const s: DashboardSample = change.rowNode.data;
-      if (s.primaryId && s.primaryId in changesByPrimaryId) {
-        const newDashboardSample = {
-          ...s,
-          revisable: false,
-          changedFieldNames: Object.keys(changesByPrimaryId[s.primaryId]),
-        };
-
-        for (const [fieldName, newValue] of Object.entries(
-          changesByPrimaryId[s.primaryId]
-        )) {
-          if (fieldName in s) {
-            (newDashboardSample as any)[fieldName] = newValue;
-          }
-        }
-        delete newDashboardSample.__typename;
-        newDashboardSamples.push(newDashboardSample);
-      }
-    });
+    // Send to GraphQL server to publish
     updateDashboardSamplesMutation({
       variables: { newDashboardSamples },
     });
@@ -202,12 +182,18 @@ export function useCellChanges({
     // AG Grid's Server-Side data model. e.g. GraphQL's optimistic response only returns
     // the updated data, while AG Grid expects the datasource == the entire dataset.)
     const optimisticSamples = samples!.map((s) => {
-      if (s.primaryId != null && s.primaryId in changesByPrimaryId) {
+      const changesForSample =
+        s.primaryId != null ? changesByPrimaryId.get(s.primaryId) : undefined;
+      if (changesForSample) {
+        const changedFields = changesForSample.reduce((acc, change) => {
+          acc[change.fieldName] = change.newValue;
+          return acc;
+        }, {} as Record<string, any>);
         return {
           ...s,
+          ...changedFields,
           revisable: false,
           importDate: formatCellDate(new Date()) as string,
-          ...changesByPrimaryId[s.primaryId],
         };
       }
       return s;
@@ -252,20 +238,35 @@ export function useCellChanges({
   };
 }
 
-type ChangesByPrimaryId = {
-  [primaryId: string]: {
-    [fieldName: string]: string;
-  };
-};
-
 function groupChangesByPrimaryId(changes: SampleChange[]) {
-  const changesByPrimaryId: ChangesByPrimaryId = {};
-  for (const { primaryId, fieldName, newValue } of changes) {
-    if (changesByPrimaryId[primaryId]) {
-      changesByPrimaryId[primaryId][fieldName] = newValue;
-    } else {
-      changesByPrimaryId[primaryId] = { [fieldName]: newValue };
+  const changesByPrimaryId = new Map<string, Array<SampleChange>>();
+  for (const change of changes) {
+    if (!changesByPrimaryId.has(change.primaryId)) {
+      changesByPrimaryId.set(change.primaryId, []);
     }
+    changesByPrimaryId.get(change.primaryId)!.push(change);
   }
   return changesByPrimaryId;
+}
+
+function buildNewDashboardSamples(
+  changesByPrimaryId: Map<string, Array<SampleChange>>
+) {
+  const newDashboardSamplesByPrimaryId = new Map<
+    string,
+    DashboardSampleInput
+  >();
+  changesByPrimaryId.forEach((changes, primaryId) => {
+    const sampleData = { ...changes[0].rowNode.data };
+    for (const change of changes) {
+      (sampleData as any)[change.fieldName] = change.newValue;
+    }
+    delete sampleData.__typename;
+    newDashboardSamplesByPrimaryId.set(primaryId, {
+      ...sampleData,
+      revisable: false,
+      changedFieldNames: changes.map((c) => c.fieldName),
+    });
+  });
+  return Array.from(newDashboardSamplesByPrimaryId.values());
 }


### PR DESCRIPTION
## Description

- Fix the buggy behavior where "editing sample A -> searching -> editing sample B -> submitting updates" only results in the update of sample B
- Side quest: fix console error React Router's console error when entering views like the Request Samples, Patient Samples, etc.

[#1580](https://app.zenhub.com/workspaces/smile-scrum-5fcfa28a4ccc1600165347b6/issues/gh/mskcc/smile-server/1580)

## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [ ] Searching for a single term or multiple terms returns relevant results
- [ ] Searching in PHI mode returns results with PHI columns
- [ ] Filtering columns returns the results matching the filter
- [ ] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [ ] Clicking "Download as TSV"
- [ ] Searching for some terms then clicking "Download as TSV"
- [ ] Filtering a column then clicking "Download as TSV"
- [ ] Search in PHI mode then clicking "Download as TSV"
- [ ] Clicking the dropdown download option <download option name>

#### AG Grid interactions

- [x] [Samples page] Editing a cell updates the value as expected
- [x] [Samples page] Pasting data into the grid works as expected
- [x] Editing a cell in a non-editable row/column is prevented
- [ ] Column sorting in ascending and descending order works as expected
- [ ] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [ ] [Samples page] Cell changes confirmation modal appears and works as expected
- [ ] [Requests page] Validation errors are displayed in the Record Validation modal
- [ ] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [ ] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [ ] The GraphQL types that are auto-generated via `yarn run codegen`
- [ ] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
