### PR TITLE
Dev changelog and sample history support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,7 @@ Confirm that these download actions return a TSV file with the expected columns 
 - [ ] Search in PHI mode then clicking "Download as TSV"
 - [ ] Clicking the dropdown download option <download option name>
 - [ ] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
+- [ ] Downloads work when viewing Sample Metadata History
 
 #### AG Grid interactions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,95 @@
+# SMILE Dashboard - AI Agent Instructions
+
+## Architecture Overview
+
+SMILE Dashboard is a **full-stack TypeScript monorepo** with a React frontend and GraphQL backend:
+- **Frontend** ([frontend/](frontend/)): React 17 + AG Grid + Apollo Client, serves on `localhost:3006`
+- **Backend** ([graphql-server/](graphql-server/)): Apollo GraphQL server + Neo4j OGM, serves on `localhost:4000`
+- **GraphQL Operations** ([graphql/](graphql/)): Shared query/mutation definitions, code-generated via `graphql-codegen`
+
+The backend connects to **Neo4j** (primary database) and **Databricks** (for secondary queries). Data flows: Neo4j → GraphQL Schema → Apollo Cache → AG Grid Tables.
+
+## Key Technologies & Patterns
+
+### Backend Architecture (`graphql-server/`)
+- **Schema Generation**: Neo4j introspection + custom schemas merged via `@graphql-tools/schema`
+- **Data Access**: Neo4j OGM for queries, Databricks SDK for external analytics
+- **Middleware Stack**: Express → Keycloak auth → Session management → Routes → Apollo
+- **Caching**: Node-cache with TTLs (1-hour blocks of 500 records for client-side pagination)
+
+**Important Pattern**: Query builders live in [graphql-server/src/schemas/queries/](graphql-server/src/schemas/queries/) (e.g., `samples.ts`, `patients.ts`). They export `queryDashboard*` functions, `buildQueryBody`, and Cypher builders consumed by cache.
+
+### Frontend Data Fetching ([frontend/src/hooks/useFetchData.ts](frontend/src/hooks/useFetchData.ts))
+- **Server-side pagination** via AG Grid's `IServerSideDatasource`: lazy-loaded in 500-record blocks
+- **Dynamic filtering/sorting**: Passed as GraphQL variables, NOT query rewrites
+- **PHI toggle**: Global context controls whether sensitive columns render (no data masking—visibility only)
+
+### Code Generation
+Run `yarn codegen` to regenerate types from GraphQL schema into `**/generated/graphql.ts`. **Always commit generated files**. Backend must be running for schema introspection to work.
+
+## Development Workflows
+
+### Setup & Local Development
+```bash
+# Root: Install all workspaces
+yarn
+
+# Backend setup
+export NODE_TLS_REJECT_UNAUTHORIZED=0
+export SMILE_CONFIG_HOME=[config dir] SMILE_DATA_HOME=[data dir]
+cd graphql-server && cp src/env/application.properties.EXAMPLE src/env/application.properties
+# Edit application.properties with Neo4j and Databricks credentials
+
+# Frontend setup
+cd frontend && cp .env.example .env
+# Update URLs if using HTTPS certificates
+
+# Run both
+yarn dev:backend  # Terminal 1, localhost:4000
+yarn dev:frontend # Terminal 2, localhost:3006
+```
+
+### Build & Deployment
+- **Backend compile**: `yarn build:backend` → `graphql-server/dist`
+- **Frontend build**: `yarn build` (from frontend/) → static assets
+- **Docker images**: `Dockerfile` (frontend) and `graphql-server/Dockerfile`
+- **Pre-commit hook**: Auto-formats changed files via Prettier
+
+## Critical Patterns
+
+### Query Symmetry
+Requests, Patients, Samples, Cohorts pages share identical query/filter architecture. When adding features:
+1. Extend Neo4j schema or Cypher queries in [graphql-server/src/schemas/queries/](graphql-server/src/schemas/queries/)
+2. Regenerate GraphQL types (`yarn codegen`)
+3. Extend filter config in [frontend/src/pages/*/config.tsx](frontend/src/pages/) (defines column names, filter types)
+4. Update `useFetchData` hook only if introducing new variable structures
+
+### PHI and Record Contexts
+- **PHI fields** (e.g., patient ID, MRN) render conditionally via `PhiEnabledContext` + column visibility toggles
+- **Record Contexts** filter by `genePanel`, `baitSet`, etc.—defined as arrays in cache constants (e.g., `WES_SAMPLE_CONTEXT`), passed to queries
+- **Never mask PHI data**—only control visibility via React conditional rendering
+
+### Session & Authentication
+- Keycloak integration in [graphql-server/src/middlewares/configureSession.ts](graphql-server/src/middlewares/configureSession.ts)
+- User email/groups extracted from JWT token, attached to GraphQL context
+- OpenID client auto-handles token refresh
+
+## Common Development Tasks
+
+- **Add a new column**: Update Neo4j properties → codegen → add to page config → extend filter builder if searchable
+- **Fix a data type**: Edit `graphql-server/src/schemas/custom.ts` or Neo4j schema → update `graphql/operations.graphql` → update `graphql-server/src/utils/typeDefs.ts` → `yarn codegen` → update frontend types
+- **Optimize slow queries**: Profile via Neo4j Browser, add indexes, adjust `CACHE_BLOCK_SIZE` (currently 500) if needed
+- **Debug AG Grid rendering**: Check `frontend/src/configs/gridIcons.tsx` for cell component overrides, verify column definitions in page config
+
+## File Organization Reference
+
+- **Backend queries**: `graphql-server/src/schemas/queries/{samples,patients,requests,cohorts}.ts`
+- **Frontend pages**: `frontend/src/pages/{requests,patients,samples,cohorts}/`
+- **Shared GraphQL operations**: `graphql/operations.graphql`
+- **Utility libraries**: Backend utilities in `graphql-server/src/utils/`, frontend in `frontend/src/utils/`
+
+## Performance Notes
+
+- Client-side pagination block size: 500 records (hardcoded in cache + frontend config—keep in sync)
+- Cache TTL: 1 hour for most data, 1 day for OncoTree + demographics
+- Frontend caches GraphQL responses via Apollo's in-memory cache; no explicit eviction needed

--- a/frontend/public/assets/css/style.css
+++ b/frontend/public/assets/css/style.css
@@ -1253,3 +1253,9 @@ h6 {
   font-size: 13px;
   color: #012970;
 }
+
+.changelog-alert {
+  flex-basis: 100%;
+  text-align: right;
+  color: red;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,10 @@ export default function App() {
               element={<PatientsPage />}
             />
             <Route path="/samples" element={<SamplesPage />} />
+            <Route
+              path={`/samples/:${ROUTE_PARAMS.samples}`}
+              element={<SamplesPage />}
+            />
             <Route path="/cohorts/" element={<CohortsPage />} />
             <Route
               path={`/cohorts/:${ROUTE_PARAMS.cohorts}`}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route, BrowserRouter } from "react-router-dom";
 import { LoginSuccessPage } from "./pages/auth/LoginSuccessPage";
+import { LoggingOutPage } from "./pages/auth/LoggingOutPage";
 import { SamplesPage } from "./pages/samples/SamplesPage";
 import { NavBar } from "./components/NavBar";
 import { Providers } from "./components/Providers";
@@ -7,6 +8,7 @@ import { WarningModal } from "./components/WarningModal";
 import { RequestsPage } from "./pages/requests/RequestsPage";
 import { PatientsPage } from "./pages/patients/PatientsPage";
 import { CohortsPage } from "./pages/cohorts/CohortsPage";
+import { ProtectedRoute } from "./components/ProtectedRoute";
 import { ROUTE_PARAMS } from "./configs/shared";
 
 // Required imports for AG Grid tables to render correctly
@@ -37,12 +39,24 @@ export default function App() {
               path={`/samples/:${ROUTE_PARAMS.samples}`}
               element={<SamplesPage />}
             />
-            <Route path="/cohorts/" element={<CohortsPage />} />
+            <Route
+              path="/cohorts/"
+              element={
+                <ProtectedRoute>
+                  <CohortsPage />
+                </ProtectedRoute>
+              }
+            />
             <Route
               path={`/cohorts/:${ROUTE_PARAMS.cohorts}`}
-              element={<CohortsPage />}
+              element={
+                <ProtectedRoute>
+                  <CohortsPage />
+                </ProtectedRoute>
+              }
             />
             <Route path="/auth/login-success" element={<LoginSuccessPage />} />
+            <Route path="/auth/logging-out" element={<LoggingOutPage />} />
           </Routes>
         </BrowserRouter>
 

--- a/frontend/src/components/CellChangesContainer.tsx
+++ b/frontend/src/components/CellChangesContainer.tsx
@@ -1,7 +1,8 @@
-import { Button, Modal } from "react-bootstrap";
+import { Button, Form, Modal } from "react-bootstrap";
 import { AgGridReact } from "ag-grid-react";
 import { RecordChange } from "../types/shared";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
+import { NO_CHANGELOG_WARNING } from "../configs/shared";
 
 const updateModalColumnDefs = [
   { field: "recordId", rowGroup: true, hide: true },
@@ -21,7 +22,7 @@ interface CellChangesContainerProps {
   cellChangesHandlers: {
     handleDiscardChanges: () => void;
     handleConfirmUpdates: () => void;
-    handleSubmitUpdates: () => void;
+    handleSubmitUpdates: (author: string, reasonForChange: string) => void;
     showUpdateModal: boolean;
     setShowUpdateModal: Dispatch<SetStateAction<boolean>>;
   };
@@ -38,11 +39,17 @@ export function CellChangesContainer({
   },
   isSampleLevelChanges,
 }: CellChangesContainerProps) {
+  const [changelog, setChangelog] = useState("");
+  const [authorChangelog, setAuthorChangelog] = useState("");
+
   if (isSampleLevelChanges) {
     autoGroupColumnDef.headerName = "Primary ID";
   } else {
     autoGroupColumnDef.headerName = "Cohort ID";
   }
+
+  const disableSubmitUpdates =
+    changelog.trim() === "" || authorChangelog.trim() === "";
 
   function handleUpdateModalHide() {
     setShowUpdateModal(false);
@@ -90,6 +97,26 @@ export function CellChangesContainer({
                 groupDefaultExpanded={1}
               />
             </div>
+            <Form.Group className="d-flex align-items-center mt-3">
+              <Form.Label className="mb-0 me-2 text-nowrap">
+                Reason for Change:
+              </Form.Label>
+              <Form.Control
+                type="text"
+                size="sm"
+                className="me-3"
+                value={changelog}
+                onChange={(e) => setChangelog(e.target.value)}
+              />
+              <Form.Label className="mb-0 me-2 text-nowrap">Author:</Form.Label>
+              <Form.Control
+                style={{ width: "30%" }}
+                type="text"
+                size="sm"
+                value={authorChangelog}
+                onChange={(e) => setAuthorChangelog(e.target.value)}
+              />
+            </Form.Group>
           </Modal.Body>
 
           <Modal.Footer>
@@ -99,9 +126,16 @@ export function CellChangesContainer({
             >
               Cancel
             </Button>
-            <Button className="btn btn-success" onClick={handleSubmitUpdates}>
+            <Button
+              className="btn btn-success"
+              onClick={() => handleSubmitUpdates(authorChangelog, changelog)}
+              disabled={disableSubmitUpdates}
+            >
               Submit Updates
             </Button>
+            {disableSubmitUpdates && (
+              <span className="changelog-alert">{NO_CHANGELOG_WARNING}</span>
+            )}
           </Modal.Footer>
         </Modal>
       )}

--- a/frontend/src/components/CellChangesContainer.tsx
+++ b/frontend/src/components/CellChangesContainer.tsx
@@ -49,7 +49,8 @@ export function CellChangesContainer({
   }
 
   const disableSubmitUpdates =
-    changelog.trim() === "" || authorChangelog.trim() === "";
+    isSampleLevelChanges &&
+    (changelog.trim() === "" || authorChangelog.trim() === "");
 
   function handleUpdateModalHide() {
     setShowUpdateModal(false);
@@ -97,26 +98,30 @@ export function CellChangesContainer({
                 groupDefaultExpanded={1}
               />
             </div>
-            <Form.Group className="d-flex align-items-center mt-3">
-              <Form.Label className="mb-0 me-2 text-nowrap">
-                Reason for Change:
-              </Form.Label>
-              <Form.Control
-                type="text"
-                size="sm"
-                className="me-3"
-                value={changelog}
-                onChange={(e) => setChangelog(e.target.value)}
-              />
-              <Form.Label className="mb-0 me-2 text-nowrap">Author:</Form.Label>
-              <Form.Control
-                style={{ width: "30%" }}
-                type="text"
-                size="sm"
-                value={authorChangelog}
-                onChange={(e) => setAuthorChangelog(e.target.value)}
-              />
-            </Form.Group>
+            {isSampleLevelChanges && (
+              <Form.Group className="d-flex align-items-center mt-3">
+                <Form.Label className="mb-0 me-2 text-nowrap">
+                  Reason for Change:
+                </Form.Label>
+                <Form.Control
+                  type="text"
+                  size="sm"
+                  className="me-3"
+                  value={changelog}
+                  onChange={(e) => setChangelog(e.target.value)}
+                />
+                <Form.Label className="mb-0 me-2 text-nowrap">
+                  Author:
+                </Form.Label>
+                <Form.Control
+                  style={{ width: "30%" }}
+                  type="text"
+                  size="sm"
+                  value={authorChangelog}
+                  onChange={(e) => setAuthorChangelog(e.target.value)}
+                />
+              </Form.Group>
+            )}
           </Modal.Body>
 
           <Modal.Footer>

--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -12,6 +12,7 @@ import { RecordChange } from "../types/shared";
 import { CACHE_BLOCK_SIZE } from "../configs/shared";
 import { allEditableFields } from "../pages/samples/config";
 import { CohortBuilderSample } from "./CohortBuilderContainer";
+import { useUserEmail } from "../contexts/UserEmailContext";
 
 function getTooltipValue(params: ITooltipParams) {
   if (!params.colDef || !("field" in params.colDef)) return undefined;
@@ -30,6 +31,12 @@ function getTooltipValue(params: ITooltipParams) {
     params.data?.sampleCategory === "clinical"
   ) {
     return "Clinical samples are not editable";
+  }
+  if (allEditableFields.has(field!) && !params.context?.userEmail) {
+    if (field === "billed") {
+      return "Click to log in and mark sample as billed";
+    }
+    return "Must be logged in to make changes to sample data";
   }
   if (!allEditableFields.has(field!)) {
     return "This column is read-only";
@@ -92,6 +99,7 @@ export function DataGrid({
   onSelectionChanged,
 }: DataGridProps) {
   const navigate = useNavigate();
+  const { userEmail } = useUserEmail();
 
   // ensures that records removed from CohortBuilder table also updates selection in main DataGrid table
   useEffect(() => {
@@ -189,6 +197,7 @@ export function DataGrid({
         context={{
           getChanges: () => changes,
           navigateFunction: navigate,
+          userEmail,
         }}
         rowClassRules={{
           unlocked: (params) => params.data?.revisable === true,

--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -2,6 +2,7 @@ import { AgGridReact } from "ag-grid-react";
 import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
 import { RefObject, ClipboardEvent, useEffect } from "react";
 import {
+  CellDoubleClickedEvent,
   CellEditRequestEvent,
   ColDef,
   ITooltipParams,
@@ -82,6 +83,7 @@ interface DataGridPropsBase {
       | CohortBuilderSample[]
       | ((prev: CohortBuilderSample[]) => CohortBuilderSample[])
   ) => void;
+  onCellDoubleClicked?: (params: CellDoubleClickedEvent) => void;
 }
 
 type DataGridProps = DataGridPropsBase &
@@ -97,6 +99,7 @@ export function DataGrid({
   handlePaste,
   selectedRowIds,
   onSelectionChanged,
+  onCellDoubleClicked,
 }: DataGridProps) {
   const navigate = useNavigate();
   const { userEmail } = useUserEmail();
@@ -204,6 +207,7 @@ export function DataGrid({
           locked: (params) => params.data?.revisable === false,
         }}
         onCellEditRequest={handleCellEditRequest}
+        onCellDoubleClicked={onCellDoubleClicked}
         readOnlyEdit={true}
         tooltipShowDelay={0}
         tooltipHideDelay={60000}

--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -169,6 +169,8 @@ export function DataGrid({
       ? params.data.igoRequestId
       : params.data.smilePatientId
       ? params.data.smilePatientId
+      : params.data.recordId
+      ? params.data.recordId
       : undefined;
   };
 

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,5 +1,5 @@
 import { Nav } from "react-bootstrap";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useUserEmail } from "../contexts/UserEmailContext";
 import { usePhiEnabled } from "../contexts/PhiEnabledContext";
 import { openLoginPopup } from "../utils/openLoginPopup";
@@ -8,15 +8,10 @@ import { getUserEmail } from "../utils/getUserEmail";
 export function NavBar() {
   const { userEmail, setUserEmail } = useUserEmail();
   const { setPhiEnabled } = usePhiEnabled();
+  const navigate = useNavigate();
 
   function handleLogout() {
-    fetch(`${process.env.REACT_APP_EXPRESS_SERVER_ORIGIN}/auth/logout`, {
-      method: "POST",
-      credentials: "include",
-      mode: "no-cors",
-    });
-    setUserEmail(undefined);
-    setPhiEnabled(false);
+    navigate("/auth/logging-out");
   }
 
   async function handleLogin() {

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -2,6 +2,8 @@ import { Nav } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { useUserEmail } from "../contexts/UserEmailContext";
 import { usePhiEnabled } from "../contexts/PhiEnabledContext";
+import { openLoginPopup } from "../utils/openLoginPopup";
+import { getUserEmail } from "../utils/getUserEmail";
 
 export function NavBar() {
   const { userEmail, setUserEmail } = useUserEmail();
@@ -15,6 +17,29 @@ export function NavBar() {
     });
     setUserEmail(undefined);
     setPhiEnabled(false);
+  }
+
+  async function handleLogin() {
+    let currUserEmail = userEmail;
+    if (!currUserEmail) {
+      currUserEmail = await new Promise<string | undefined>((resolve) => {
+        window.addEventListener("message", handleLogin);
+
+        function handleLogin(event: MessageEvent) {
+          if (event.data === "success") {
+            getUserEmail().then((email) => {
+              window.removeEventListener("message", handleLogin);
+              resolve(email);
+            });
+          }
+        }
+
+        openLoginPopup();
+      });
+
+      if (!currUserEmail) return;
+      setUserEmail(currUserEmail);
+    }
   }
 
   return (
@@ -42,7 +67,7 @@ export function NavBar() {
             Cohorts
           </Link>
         </Nav>
-        {userEmail && (
+        {userEmail ? (
           <div className="ms-auto d-none d-md-flex">
             <p className="m-auto">Logged in as {userEmail}</p>
             <button
@@ -51,6 +76,16 @@ export function NavBar() {
               onClick={handleLogout}
             >
               Logout
+            </button>
+          </div>
+        ) : (
+          <div className="ms-auto d-none d-md-flex">
+            <button
+              type="button"
+              className="btn btn-outline-primary btn-sm m-3"
+              onClick={handleLogin}
+            >
+              Login
             </button>
           </div>
         )}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,25 @@
+import { ReactNode, useEffect } from "react";
+import { useUserEmail } from "../contexts/UserEmailContext";
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+}
+
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { userEmail, isLoadingUserEmail } = useUserEmail();
+
+  useEffect(() => {
+    if (!isLoadingUserEmail && !userEmail) {
+      const returnTo = encodeURIComponent(
+        window.location.pathname + window.location.search
+      );
+      window.location.href = `${process.env.REACT_APP_EXPRESS_SERVER_ORIGIN}/auth/login?returnTo=${returnTo}`;
+    }
+  }, [isLoadingUserEmail, userEmail]);
+
+  if (isLoadingUserEmail || !userEmail) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/Providers.tsx
+++ b/frontend/src/components/Providers.tsx
@@ -13,7 +13,10 @@ const apolloCache = new InMemoryCache({
       },
     },
     DashboardSample: {
-      keyFields: ["smileSampleId"],
+      // History records share the same smileSampleId but differ by importDate,
+      // so we include importDate as a secondary key to prevent Apollo from
+      // collapsing all history versions into a single normalized cache entry.
+      keyFields: ["smileSampleId", "recordId"],
     },
   },
 });

--- a/frontend/src/components/SamplesModal.tsx
+++ b/frontend/src/components/SamplesModal.tsx
@@ -242,12 +242,11 @@ export function SampleHistoryModal({
   });
 
   // always hide history column since this modal is specifically for viewing sample history and the history column doesn't add value in this context
-  if (gridRef.current && gridRef.current.columnApi) {
-    gridRef.current.columnApi.setColumnsVisible(
-      ["history", "historicalCmoSampleNames"],
-      false
-    );
-  }
+  const historyFilteredColDefs = colDefs.filter(
+    (colDef) =>
+      colDef.field !== "historicalCmoSampleNames" &&
+      colDef.headerName !== "View History"
+  );
 
   if (error) {
     return <ErrorMessage error={error} />;
@@ -277,7 +276,7 @@ export function SampleHistoryModal({
 
       <DataGrid
         gridRef={gridRef}
-        colDefs={colDefs}
+        colDefs={historyFilteredColDefs}
         refreshData={refreshData}
         selectedRowIds={[]}
         onSelectionChanged={() => {}}

--- a/frontend/src/components/SamplesModal.tsx
+++ b/frontend/src/components/SamplesModal.tsx
@@ -28,6 +28,7 @@ import { DownloadModal } from "./DownloadModal";
 import { ColDef } from "ag-grid-community";
 import { POLL_INTERVAL, ROUTE_PARAMS } from "../configs/shared";
 import { RecordChange } from "../types/shared";
+import { useCellDoubleClicked } from "../hooks/useCellDoubleClicked";
 
 const QUERY_NAME = "dashboardSamples";
 const INTIAL_SORT_FIELD_NAME = "importDate";
@@ -50,6 +51,7 @@ export function SamplesModal({
   const [colDefs, setColDefs] = useState(sampleColDefs);
   const parentRecordId = useParams()[ROUTE_PARAMS[parentRecordName]];
   const gridRef = useRef<AgGridReactType<DashboardSample>>(null);
+  const { handleCellDoubleClicked } = useCellDoubleClicked();
 
   const {
     refreshData,
@@ -171,6 +173,7 @@ export function SamplesModal({
         handlePaste={handlePaste}
         selectedRowIds={[]}
         onSelectionChanged={() => {}}
+        onCellDoubleClicked={handleCellDoubleClicked}
       />
 
       {isDownloading && <DownloadModal />}

--- a/frontend/src/components/SamplesModal.tsx
+++ b/frontend/src/components/SamplesModal.tsx
@@ -2,7 +2,9 @@ import { Dispatch, ReactNode, SetStateAction, useRef, useState } from "react";
 import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
 import { useNavigate, useParams } from "react-router-dom";
 import {
+  DashboardRecordContext,
   DashboardSample,
+  useDashboardSampleHistoryLazyQuery,
   useDashboardSamplesLazyQuery,
 } from "../generated/graphql";
 import { useFetchData } from "../hooks/useFetchData";
@@ -176,11 +178,119 @@ export function SamplesModal({
   );
 }
 
+const HISTORY_QUERY_NAME = "dashboardSampleHistory";
+const HISTORY_INITIAL_SORT_FIELD_NAME = "importDate";
+
+interface SampleHistoryModalProps {
+  sampleColDefs: Array<ColDef>;
+  /** { fieldName: 'smileSampleId', values: [$smileSampleId] } */
+  recordContext: DashboardRecordContext;
+  parentRecordName: keyof typeof ROUTE_PARAMS;
+}
+
+/**
+ * Displays a paginated, read-only table of all SampleMetadata versions for a
+ * single sample. Uses `useDashboardSampleHistoryLazyQuery` directly because the
+ * history resolver takes `smileSampleId` instead of the `recordContexts` /
+ * `searchVals` interface accepted by `useFetchData`.
+ */
+export function SampleHistoryModal({
+  sampleColDefs,
+  recordContext,
+  parentRecordName,
+}: SampleHistoryModalProps) {
+  const [userSearchVal, setUserSearchVal] = useState(
+    recordContext.values?.[0] ?? ""
+  );
+  const [colDefs, setColDefs] = useState(sampleColDefs);
+  const gridRef = useRef<AgGridReactType<DashboardSample>>(null);
+  const [changes, setChanges] = useState<Array<RecordChange>>([]);
+
+  const { refreshData, recordCount, isLoading, error, data, fetchMore } =
+    useFetchData({
+      useRecordsLazyQuery: useDashboardSampleHistoryLazyQuery,
+      queryName: HISTORY_QUERY_NAME,
+      initialSortFieldName: HISTORY_INITIAL_SORT_FIELD_NAME,
+      gridRef,
+      userSearchVal,
+      pollInterval: POLL_INTERVAL,
+    });
+
+  const firstRecord = data?.[HISTORY_QUERY_NAME]?.[0] as
+    | DashboardSample
+    | undefined;
+  const displayText = `${firstRecord?.primaryId ?? "sample"} metadata history`;
+
+  const { isDownloading, handleDownload, getCurrentData } =
+    useDownload<DashboardSample>({
+      gridRef,
+      downloadFileName: `${
+        firstRecord?.primaryId ?? "sample"
+      }_metadata_history`,
+      fetchMore,
+      userSearchVal,
+      recordCount,
+      queryName: HISTORY_QUERY_NAME,
+    });
+
+  const downloadOptions = buildDownloadOptions({
+    getCurrentData,
+    currentColDefs: colDefs,
+  });
+
+  // always hide history column since this modal is specifically for viewing sample history and the history column doesn't add value in this context
+  if (gridRef.current && gridRef.current.columnApi) {
+    gridRef.current.columnApi.setColumnsVisible(
+      ["history", "historicalCmoSampleNames"],
+      false
+    );
+  }
+
+  if (error) {
+    return <ErrorMessage error={error} />;
+  }
+
+  return (
+    <ModalContainerWithClosingWarning
+      changes={changes}
+      setChanges={setChanges}
+      parentRecordName={parentRecordName}
+      displayText={displayText}
+    >
+      <Toolbar>
+        <Col />
+
+        <Col md="auto" className="d-flex gap-3 align-items-center">
+          {isLoading && <span>Loading...</span>}
+        </Col>
+
+        <Col className="text-end">
+          <DownloadButton
+            downloadOptions={downloadOptions}
+            onDownload={handleDownload}
+          />
+        </Col>
+      </Toolbar>
+
+      <DataGrid
+        gridRef={gridRef}
+        colDefs={colDefs}
+        refreshData={refreshData}
+        selectedRowIds={[]}
+        onSelectionChanged={() => {}}
+      />
+
+      {isDownloading && <DownloadModal />}
+    </ModalContainerWithClosingWarning>
+  );
+}
+
 interface ModalContainerProps {
   changes: Array<RecordChange>;
   setChanges: Dispatch<SetStateAction<Array<RecordChange>>>;
   parentRecordName: keyof typeof ROUTE_PARAMS;
   children: ReactNode;
+  displayText?: string;
 }
 
 function ModalContainerWithClosingWarning({
@@ -188,6 +298,7 @@ function ModalContainerWithClosingWarning({
   setChanges,
   parentRecordName,
   children,
+  displayText,
 }: ModalContainerProps) {
   const navigate = useNavigate();
   const parentRecordId = useParams()[ROUTE_PARAMS[parentRecordName]];
@@ -211,15 +322,15 @@ function ModalContainerWithClosingWarning({
     navigate(`/${parentRecordName}`);
   }
 
+  const parentRecordType = parentRecordName.slice(0, -1);
+  const defaultDisplayText = `${parentRecordType} ${parentRecordId}'s samples`;
+  const modalDisplayText = displayText ?? defaultDisplayText;
   return (
     <>
       {/* Modal for displaying the data grid */}
       <Modal show={true} dialogClassName="modal-90w" onHide={handleModalClose}>
         <Modal.Header closeButton>
-          <Title>{`Viewing ${parentRecordName.slice(
-            0,
-            -1
-          )} ${parentRecordId}'s samples`}</Title>
+          <Title>{`Viewing ${modalDisplayText}`}</Title>
         </Modal.Header>
         <Modal.Body>
           <div className="popupHeight d-flex flex-column">{children}</div>

--- a/frontend/src/configs/shared.tsx
+++ b/frontend/src/configs/shared.tsx
@@ -18,6 +18,7 @@ export const ROUTE_PARAMS = {
   requests: "igoRequestId",
   patients: "patientId",
   cohorts: "cohortId",
+  samples: "smileSampleId",
 } as const;
 
 export function getPhiColDefProps({

--- a/frontend/src/configs/shared.tsx
+++ b/frontend/src/configs/shared.tsx
@@ -60,3 +60,6 @@ export const POLLING_PAUSE_AFTER_UPDATE = 12000; // 12s
 export const INVALID_COST_CENTER_WARNING =
   "Please update your Cost Center/Fund Number input as #####/##### " +
   "(5 digits, a forward slash, then 5 digits). For example: 12345/12345.";
+
+export const NO_CHANGELOG_WARNING =
+  "Please update Reason for Change and Author fields.";

--- a/frontend/src/contexts/UserEmailContext.tsx
+++ b/frontend/src/contexts/UserEmailContext.tsx
@@ -12,6 +12,7 @@ import { getUserEmail } from "../utils/getUserEmail";
 interface UserEmailContextType {
   userEmail: string | undefined;
   setUserEmail: Dispatch<SetStateAction<string | undefined>>;
+  isLoadingUserEmail: boolean;
 }
 
 const UserEmailContext = createContext<UserEmailContextType | undefined>(
@@ -20,17 +21,21 @@ const UserEmailContext = createContext<UserEmailContextType | undefined>(
 
 export function UserEmailProvider({ children }: { children: ReactNode }) {
   const [userEmail, setUserEmail] = useState<string | undefined>(undefined);
+  const [isLoadingUserEmail, setIsLoadingUserEmail] = useState(true);
 
   useEffect(() => {
     async function getAndSetUserEmail() {
       const currentUserEmail = await getUserEmail();
       setUserEmail(currentUserEmail);
+      setIsLoadingUserEmail(false);
     }
     getAndSetUserEmail();
   }, []);
 
   return (
-    <UserEmailContext.Provider value={{ userEmail, setUserEmail }}>
+    <UserEmailContext.Provider
+      value={{ userEmail, setUserEmail, isLoadingUserEmail }}
+    >
       {children}
     </UserEmailContext.Provider>
   );

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1543,6 +1543,7 @@ export type DashboardSample = {
   cancerType?: Maybe<Scalars["String"]>;
   cancerTypeDetailed?: Maybe<Scalars["String"]>;
   cfDNA2dBarcode?: Maybe<Scalars["String"]>;
+  changelog?: Maybe<Scalars["String"]>;
   cmoPatientId?: Maybe<Scalars["String"]>;
   cmoSampleName?: Maybe<Scalars["String"]>;
   collectionYear?: Maybe<Scalars["String"]>;
@@ -1605,6 +1606,7 @@ export type DashboardSampleInput = {
   cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
   cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
   changedFieldNames: Array<Scalars["String"]>;
+  changelog?: InputMaybe<Scalars["String"]>;
   cmoPatientId?: InputMaybe<Scalars["String"]>;
   cmoSampleName?: InputMaybe<Scalars["String"]>;
   collectionYear?: InputMaybe<Scalars["String"]>;
@@ -11524,6 +11526,7 @@ export type DashboardSamplesQuery = {
     platform?: string | null;
     igoSampleStatus?: string | null;
     dmpRecommendedCoverage?: string | null;
+    changelog?: string | null;
     validationReport?: string | null;
     validationStatus?: boolean | null;
     cancerType?: string | null;
@@ -11587,6 +11590,7 @@ export type DashboardSampleMetadataPartsFragment = {
   platform?: string | null;
   igoSampleStatus?: string | null;
   dmpRecommendedCoverage?: string | null;
+  changelog?: string | null;
   validationReport?: string | null;
   validationStatus?: boolean | null;
   cancerType?: string | null;
@@ -11687,6 +11691,7 @@ export type UpdateDashboardSamplesMutation = {
     platform?: string | null;
     igoSampleStatus?: string | null;
     dmpRecommendedCoverage?: string | null;
+    changelog?: string | null;
     validationReport?: string | null;
     validationStatus?: boolean | null;
     cancerType?: string | null;
@@ -11820,6 +11825,7 @@ export const DashboardSampleMetadataPartsFragmentDoc = gql`
     platform
     igoSampleStatus
     dmpRecommendedCoverage
+    changelog
     validationReport
     validationStatus
     cancerType

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1436,7 +1436,6 @@ export type DashboardCohort = {
   _total?: Maybe<Scalars["Int"]>;
   _uniqueSampleCount?: Maybe<Scalars["Int"]>;
   billed?: Maybe<Scalars["String"]>;
-  changelog?: Maybe<Scalars["String"]>;
   cohortId: Scalars["String"];
   endUsers?: Maybe<Scalars["String"]>;
   importDate?: Maybe<Scalars["String"]>;
@@ -11480,7 +11479,6 @@ export type DashboardCohortsQuery = {
     type?: string | null;
     pipelineVersion?: string | null;
     searchableSampleIds?: string | null;
-    changelog?: string | null;
     _total?: number | null;
     _uniqueSampleCount?: number | null;
   }>;
@@ -11849,7 +11847,6 @@ export type UpdateTempoCohortMutation = {
     type?: string | null;
     pipelineVersion?: string | null;
     searchableSampleIds?: string | null;
-    changelog?: string | null;
     _total?: number | null;
     _uniqueSampleCount?: number | null;
   } | null;
@@ -12196,7 +12193,6 @@ export const DashboardCohortsDocument = gql`
       type
       pipelineVersion
       searchableSampleIds
-      changelog
       _total
       _uniqueSampleCount
     }
@@ -12625,7 +12621,6 @@ export const UpdateTempoCohortDocument = gql`
       type
       pipelineVersion
       searchableSampleIds
-      changelog
       _total
       _uniqueSampleCount
     }

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1576,6 +1576,7 @@ export type DashboardSample = {
   qcCompleteStatus?: Maybe<Scalars["String"]>;
   race?: Maybe<Scalars["String"]>;
   recipe?: Maybe<Scalars["String"]>;
+  recordId: Scalars["String"];
   revisable?: Maybe<Scalars["Boolean"]>;
   sampleCategory: Scalars["String"];
   sampleClass?: Maybe<Scalars["String"]>;
@@ -1639,6 +1640,7 @@ export type DashboardSampleInput = {
   qcCompleteStatus?: InputMaybe<Scalars["String"]>;
   race?: InputMaybe<Scalars["String"]>;
   recipe?: InputMaybe<Scalars["String"]>;
+  recordId: Scalars["String"];
   revisable?: InputMaybe<Scalars["Boolean"]>;
   sampleCategory: Scalars["String"];
   sampleClass?: InputMaybe<Scalars["String"]>;
@@ -4258,6 +4260,7 @@ export type Query = {
   dashboardCohorts: Array<DashboardCohort>;
   dashboardPatients: Array<DashboardPatient>;
   dashboardRequests: Array<DashboardRequest>;
+  dashboardSampleHistory: Array<DashboardSample>;
   dashboardSamples: Array<DashboardSample>;
   dbGaps: Array<DbGap>;
   dbGapsAggregate: DbGapAggregateSelection;
@@ -4374,6 +4377,13 @@ export type QueryDashboardRequestsArgs = {
   limit: Scalars["Int"];
   offset: Scalars["Int"];
   searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  sort: DashboardRecordSort;
+};
+
+export type QueryDashboardSampleHistoryArgs = {
+  limit: Scalars["Int"];
+  offset: Scalars["Int"];
+  searchVals: Array<Scalars["String"]>;
   sort: DashboardRecordSort;
 };
 
@@ -11500,6 +11510,78 @@ export type DashboardSamplesQuery = {
     smileSampleId: string;
     revisable?: boolean | null;
     sampleCategory: string;
+    recordId: string;
+    primaryId?: string | null;
+    cmoSampleName?: string | null;
+    importDate?: string | null;
+    cmoPatientId?: string | null;
+    investigatorSampleId?: string | null;
+    sampleType?: string | null;
+    species?: string | null;
+    genePanel?: string | null;
+    baitSet?: string | null;
+    preservation?: string | null;
+    tumorOrNormal?: string | null;
+    sampleClass?: string | null;
+    oncotreeCode?: string | null;
+    collectionYear?: string | null;
+    sampleOrigin?: string | null;
+    tissueLocation?: string | null;
+    sex?: string | null;
+    cfDNA2dBarcode?: string | null;
+    recipe?: string | null;
+    altId?: string | null;
+    analyteType?: string | null;
+    historicalCmoSampleNames?: string | null;
+    instrumentModel?: string | null;
+    platform?: string | null;
+    igoSampleStatus?: string | null;
+    dmpRecommendedCoverage?: string | null;
+    changelog?: string | null;
+    validationReport?: string | null;
+    validationStatus?: boolean | null;
+    cancerType?: string | null;
+    cancerTypeDetailed?: string | null;
+    igoDeliveryDate?: string | null;
+    billed?: boolean | null;
+    costCenter?: string | null;
+    billedBy?: string | null;
+    custodianInformation?: string | null;
+    accessLevel?: string | null;
+    initialPipelineRunDate?: string | null;
+    embargoDate?: string | null;
+    bamCompleteDate?: string | null;
+    bamCompleteStatus?: string | null;
+    mafCompleteDate?: string | null;
+    mafCompleteNormalPrimaryId?: string | null;
+    mafCompleteStatus?: string | null;
+    qcCompleteDate?: string | null;
+    qcCompleteResult?: string | null;
+    qcCompleteReason?: string | null;
+    qcCompleteStatus?: string | null;
+    sampleCohortIds?: string | null;
+    dbGapStudy?: string | null;
+    irbConsentProtocol?: string | null;
+    dmpPatientAlias?: string | null;
+  }>;
+};
+
+export type DashboardSampleHistoryQueryVariables = Exact<{
+  searchVals: Array<Scalars["String"]> | Scalars["String"];
+  sort: DashboardRecordSort;
+  limit: Scalars["Int"];
+  offset: Scalars["Int"];
+}>;
+
+export type DashboardSampleHistoryQuery = {
+  __typename?: "Query";
+  dashboardSampleHistory: Array<{
+    __typename?: "DashboardSample";
+    _total?: number | null;
+    smileSampleId: string;
+    revisable?: boolean | null;
+    sampleCategory: string;
+    recordId: string;
     primaryId?: string | null;
     cmoSampleName?: string | null;
     importDate?: string | null;
@@ -11564,6 +11646,7 @@ export type DashboardSamplePartsFragment = {
 
 export type DashboardSampleMetadataPartsFragment = {
   __typename?: "DashboardSample";
+  recordId: string;
   primaryId?: string | null;
   cmoSampleName?: string | null;
   importDate?: string | null;
@@ -11665,6 +11748,7 @@ export type UpdateDashboardSamplesMutation = {
     smileSampleId: string;
     revisable?: boolean | null;
     sampleCategory: string;
+    recordId: string;
     primaryId?: string | null;
     cmoSampleName?: string | null;
     importDate?: string | null;
@@ -11799,6 +11883,7 @@ export const DashboardSamplePartsFragmentDoc = gql`
 `;
 export const DashboardSampleMetadataPartsFragmentDoc = gql`
   fragment DashboardSampleMetadataParts on DashboardSample {
+    recordId
     primaryId
     cmoSampleName
     importDate
@@ -12262,6 +12347,87 @@ export type DashboardSamplesLazyQueryHookResult = ReturnType<
 export type DashboardSamplesQueryResult = Apollo.QueryResult<
   DashboardSamplesQuery,
   DashboardSamplesQueryVariables
+>;
+export const DashboardSampleHistoryDocument = gql`
+  query DashboardSampleHistory(
+    $searchVals: [String!]!
+    $sort: DashboardRecordSort!
+    $limit: Int!
+    $offset: Int!
+  ) {
+    dashboardSampleHistory(
+      searchVals: $searchVals
+      sort: $sort
+      limit: $limit
+      offset: $offset
+    ) {
+      ...DashboardSampleParts
+      ...DashboardSampleMetadataParts
+      ...DashboardTempoParts
+      ...DashboardDbGapParts
+      ...DashboardPatientParts
+      _total
+    }
+  }
+  ${DashboardSamplePartsFragmentDoc}
+  ${DashboardSampleMetadataPartsFragmentDoc}
+  ${DashboardTempoPartsFragmentDoc}
+  ${DashboardDbGapPartsFragmentDoc}
+  ${DashboardPatientPartsFragmentDoc}
+`;
+
+/**
+ * __useDashboardSampleHistoryQuery__
+ *
+ * To run a query within a React component, call `useDashboardSampleHistoryQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDashboardSampleHistoryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useDashboardSampleHistoryQuery({
+ *   variables: {
+ *      searchVals: // value for 'searchVals'
+ *      sort: // value for 'sort'
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
+ *   },
+ * });
+ */
+export function useDashboardSampleHistoryQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    DashboardSampleHistoryQuery,
+    DashboardSampleHistoryQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    DashboardSampleHistoryQuery,
+    DashboardSampleHistoryQueryVariables
+  >(DashboardSampleHistoryDocument, options);
+}
+export function useDashboardSampleHistoryLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    DashboardSampleHistoryQuery,
+    DashboardSampleHistoryQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    DashboardSampleHistoryQuery,
+    DashboardSampleHistoryQueryVariables
+  >(DashboardSampleHistoryDocument, options);
+}
+export type DashboardSampleHistoryQueryHookResult = ReturnType<
+  typeof useDashboardSampleHistoryQuery
+>;
+export type DashboardSampleHistoryLazyQueryHookResult = ReturnType<
+  typeof useDashboardSampleHistoryLazyQuery
+>;
+export type DashboardSampleHistoryQueryResult = Apollo.QueryResult<
+  DashboardSampleHistoryQuery,
+  DashboardSampleHistoryQueryVariables
 >;
 export const UpdateDashboardSamplesDocument = gql`
   mutation UpdateDashboardSamples(

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1436,6 +1436,7 @@ export type DashboardCohort = {
   _total?: Maybe<Scalars["Int"]>;
   _uniqueSampleCount?: Maybe<Scalars["Int"]>;
   billed?: Maybe<Scalars["String"]>;
+  changelog?: Maybe<Scalars["String"]>;
   cohortId: Scalars["String"];
   endUsers?: Maybe<Scalars["String"]>;
   importDate?: Maybe<Scalars["String"]>;
@@ -1455,6 +1456,7 @@ export type DashboardCohortInput = {
   _uniqueSampleCount?: InputMaybe<Scalars["Int"]>;
   billed?: InputMaybe<Scalars["String"]>;
   changedFieldNames: Array<Scalars["String"]>;
+  changelog?: InputMaybe<Scalars["String"]>;
   cohortId: Scalars["String"];
   endUsers?: InputMaybe<Scalars["String"]>;
   importDate?: InputMaybe<Scalars["String"]>;
@@ -11478,6 +11480,7 @@ export type DashboardCohortsQuery = {
     type?: string | null;
     pipelineVersion?: string | null;
     searchableSampleIds?: string | null;
+    changelog?: string | null;
     _total?: number | null;
     _uniqueSampleCount?: number | null;
   }>;
@@ -11846,6 +11849,7 @@ export type UpdateTempoCohortMutation = {
     type?: string | null;
     pipelineVersion?: string | null;
     searchableSampleIds?: string | null;
+    changelog?: string | null;
     _total?: number | null;
     _uniqueSampleCount?: number | null;
   } | null;
@@ -12192,6 +12196,7 @@ export const DashboardCohortsDocument = gql`
       type
       pipelineVersion
       searchableSampleIds
+      changelog
       _total
       _uniqueSampleCount
     }
@@ -12620,6 +12625,7 @@ export const UpdateTempoCohortDocument = gql`
       type
       pipelineVersion
       searchableSampleIds
+      changelog
       _total
       _uniqueSampleCount
     }

--- a/frontend/src/hooks/useCellChanges.ts
+++ b/frontend/src/hooks/useCellChanges.ts
@@ -24,6 +24,7 @@ import {
   POLLING_PAUSE_AFTER_UPDATE,
 } from "../configs/shared";
 import { formatCohortUsersString } from "../utils/formatCohortUsersString";
+import _ from "lodash";
 
 interface UseCellChangesParams {
   gridRef: RefObject<AgGridReactType<any>>;
@@ -178,13 +179,33 @@ export function useCellChanges({
     }
   }
 
-  async function handleSubmitUpdates() {
+  async function handleSubmitUpdates(author: string, reasonForChange: string) {
     if (changes.length === 0) {
       console.error("No changes available to submit.");
       return;
     }
 
-    const changesByRecordId = groupChangesByRecordId(changes);
+    const formattedChangelog = `${author}: ${reasonForChange}`;
+    const recordIds = _.uniq(changes.map((c) => c.recordId));
+
+    const changesWithReason = [...changes];
+
+    recordIds.forEach((r) => {
+      const change = changes.find((c) => c.recordId === r);
+      if (!change) {
+        return;
+      }
+
+      changesWithReason.push({
+        recordId: r,
+        fieldName: "changelog",
+        oldValue: change.rowNode.data.changelog,
+        newValue: formattedChangelog,
+        rowNode: change.rowNode,
+      });
+    });
+
+    const changesByRecordId = groupChangesByRecordId(changesWithReason);
     if (isSampleLevelChanges) {
       const newDashboardSamples = buildNewDashboardSamples(changesByRecordId);
 

--- a/frontend/src/hooks/useCellChanges.ts
+++ b/frontend/src/hooks/useCellChanges.ts
@@ -158,7 +158,12 @@ export function useCellChanges({
   async function handlePaste(e: ClipboardEvent<HTMLDivElement>) {
     if (!handleCellEditRequest) return;
     try {
-      await handleAgGridPaste({ e, gridRef, handleCellEditRequest });
+      await handleAgGridPaste({
+        e,
+        gridRef,
+        handleCellEditRequest,
+        context: { userEmail },
+      });
     } catch (error) {
       if (error instanceof Error) {
         setWarningModalContent(error.message);

--- a/frontend/src/hooks/useCellChanges.ts
+++ b/frontend/src/hooks/useCellChanges.ts
@@ -1,4 +1,4 @@
-import { RefObject, ClipboardEvent, useState } from "react";
+import { RefObject, ClipboardEvent, useState, useEffect } from "react";
 import { useUserEmail } from "../contexts/UserEmailContext";
 import { useWarningModal } from "../contexts/WarningContext";
 import {
@@ -49,6 +49,15 @@ export function useCellChanges({
   const [updateDashboardSamplesMutation] = useUpdateDashboardSamplesMutation();
   const [updateTempoCohortMutation] = useUpdateTempoCohortMutation();
   const [showUpdateModal, setShowUpdateModal] = useState(false);
+
+  // Discard unsaved changes when the user logs out.
+  // Intentionally excludes `changes` and `handleDiscardChanges` from deps —
+  // this should only fire on logout, not on every change.
+  useEffect(() => {
+    if (!userEmail && changes.length > 0) {
+      handleDiscardChanges();
+    } // eslint-disable-next-line
+  }, [userEmail]);
 
   async function handleCellEditRequest(params: CellEditRequestEvent) {
     const recordId = isSampleLevelChanges

--- a/frontend/src/hooks/useCellChanges.ts
+++ b/frontend/src/hooks/useCellChanges.ts
@@ -185,25 +185,27 @@ export function useCellChanges({
       return;
     }
 
-    const formattedChangelog = `${author}: ${reasonForChange}`;
     const recordIds = _.uniq(changes.map((c) => c.recordId));
 
     const changesWithReason = [...changes];
 
-    recordIds.forEach((r) => {
-      const change = changes.find((c) => c.recordId === r);
-      if (!change) {
-        return;
-      }
+    if (isSampleLevelChanges) {
+      const formattedChangelog = `${author}: ${reasonForChange}`;
+      recordIds.forEach((r) => {
+        const change = changes.find((c) => c.recordId === r);
+        if (!change) {
+          return;
+        }
 
-      changesWithReason.push({
-        recordId: r,
-        fieldName: "changelog",
-        oldValue: change.rowNode.data.changelog,
-        newValue: formattedChangelog,
-        rowNode: change.rowNode,
+        changesWithReason.push({
+          recordId: r,
+          fieldName: "changelog",
+          oldValue: change.rowNode.data.changelog,
+          newValue: formattedChangelog,
+          rowNode: change.rowNode,
+        });
       });
-    });
+    }
 
     const changesByRecordId = groupChangesByRecordId(changesWithReason);
     if (isSampleLevelChanges) {

--- a/frontend/src/hooks/useCellChanges.ts
+++ b/frontend/src/hooks/useCellChanges.ts
@@ -6,7 +6,6 @@ import {
   IServerSideGetRowsParams,
 } from "ag-grid-community";
 import { getUserEmail } from "../utils/getUserEmail";
-import { openLoginPopup } from "../utils/openLoginPopup";
 import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
 import {
   DashboardCohort,
@@ -17,6 +16,7 @@ import {
   useUpdateTempoCohortMutation,
 } from "../generated/graphql";
 import { handleAgGridPaste } from "../utils/handleAgGridPaste";
+import { awaitLoginPopup } from "../utils/awaitLoginPopup";
 import { RecordChange } from "../types/shared";
 import { formatCellDate, isInvalidCostCenter } from "../utils/agGrid";
 import {
@@ -88,21 +88,7 @@ export function useCellChanges({
       let currUserEmail = userEmail;
 
       if (!currUserEmail) {
-        currUserEmail = await new Promise<string | undefined>((resolve) => {
-          window.addEventListener("message", handleLogin);
-
-          function handleLogin(event: MessageEvent) {
-            if (event.data === "success") {
-              getUserEmail().then((email) => {
-                window.removeEventListener("message", handleLogin);
-                resolve(email);
-              });
-            }
-          }
-
-          openLoginPopup();
-        });
-
+        currUserEmail = await awaitLoginPopup();
         if (!currUserEmail) return;
         setUserEmail(currUserEmail);
       }

--- a/frontend/src/hooks/useCellDoubleClicked.ts
+++ b/frontend/src/hooks/useCellDoubleClicked.ts
@@ -1,0 +1,56 @@
+import { CellDoubleClickedEvent } from "ag-grid-community";
+import { useUserEmail } from "../contexts/UserEmailContext";
+import { allEditableFields } from "../pages/samples/config";
+import { awaitLoginPopup } from "../utils/awaitLoginPopup";
+
+/**
+ * Returns a `handleCellDoubleClicked` handler for AG Grid tables that contain
+ * auth-gated editable sample cells.
+ *
+ * When an unauthenticated user double-clicks a cell that would be editable once
+ * logged in, a login popup is shown. After a successful login the cell is
+ * started in edit mode programmatically so the user can proceed without having
+ * to double-click again.
+ *
+ * Cells that are skipped (no popup shown):
+ * - User is already logged in
+ * - "billed" field — it has its own login prompt inside handleCellEditRequest
+ * - Clinical samples (never editable)
+ * - Non-revisable samples
+ * - Columns not in allEditableFields
+ */
+export function useCellDoubleClicked() {
+  const { userEmail, setUserEmail } = useUserEmail();
+
+  async function handleCellDoubleClicked(params: CellDoubleClickedEvent) {
+    if (userEmail) return;
+
+    const field = params.colDef.field;
+    if (!field) return;
+
+    // "billed" has its own login prompt inside handleCellEditRequest
+    const wouldBeEditable =
+      field !== "billed" &&
+      params.data?.sampleCategory !== "clinical" &&
+      allEditableFields.has(field) &&
+      params.data?.revisable === true;
+
+    if (!wouldBeEditable) return;
+
+    const loggedInEmail = await awaitLoginPopup();
+    if (!loggedInEmail) return;
+
+    setUserEmail(loggedInEmail);
+
+    // Wait for React to re-render with the updated userEmail in the grid context
+    // so that colDef.editable returns true before we start editing programmatically.
+    setTimeout(() => {
+      params.api.startEditingCell({
+        rowIndex: params.rowIndex!,
+        colKey: field,
+      });
+    }, 0);
+  }
+
+  return { handleCellDoubleClicked };
+}

--- a/frontend/src/pages/auth/LoggingOutPage.tsx
+++ b/frontend/src/pages/auth/LoggingOutPage.tsx
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useUserEmail } from "../../contexts/UserEmailContext";
+import { usePhiEnabled } from "../../contexts/PhiEnabledContext";
+
+const REDIRECT_DELAY_MS = 3000;
+
+export function LoggingOutPage() {
+  const { setUserEmail } = useUserEmail();
+  const { setPhiEnabled } = usePhiEnabled();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetch(`${process.env.REACT_APP_EXPRESS_SERVER_ORIGIN}/auth/logout`, {
+      method: "POST",
+      credentials: "include",
+      mode: "no-cors",
+    });
+    setUserEmail(undefined);
+    setPhiEnabled(false);
+
+    const timer = setTimeout(() => {
+      navigate("/");
+    }, REDIRECT_DELAY_MS);
+
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "80vh",
+        gap: "1rem",
+      }}
+    >
+      <h3>Logging out...</h3>
+      <p className="text-muted">
+        You will be redirected to the Requests page shortly.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/cohorts/config.tsx
+++ b/frontend/src/pages/cohorts/config.tsx
@@ -134,7 +134,10 @@ export function setupEditableCohortFields(
         return changedValue !== undefined;
       },
       cursorNotAllowed: (params: CellClassParams) => {
-        return !editableFieldsList.has(params.colDef.field!);
+        return (
+          !params.context?.userEmail ||
+          !editableFieldsList.has(params.colDef.field!)
+        );
       },
     };
 
@@ -171,7 +174,10 @@ export function setupEditableCohortFields(
     }
 
     colDef.editable = (params) => {
-      return editableFieldsList.has(params.colDef.field!);
+      return (
+        params.context?.userEmail &&
+        editableFieldsList.has(params.colDef.field!)
+      );
     };
   });
 }

--- a/frontend/src/pages/patients/PatientsPage.tsx
+++ b/frontend/src/pages/patients/PatientsPage.tsx
@@ -14,6 +14,7 @@ import {
   buildDownloadOptions,
   patientColDefs,
   phiModeSwitchTooltipContent,
+  PHI_FIELDS,
 } from "./config";
 import { Col } from "react-bootstrap";
 import { ErrorMessage } from "../../components/ErrorMessage";
@@ -33,12 +34,6 @@ import { useUserEmail } from "../../contexts/UserEmailContext";
 const QUERY_NAME = "dashboardPatients";
 const INITIAL_SORT_FIELD_NAME = "importDate";
 const RECORD_NAME = "patients";
-const PHI_FIELDS = new Set([
-  "mrn",
-  "anchorSequencingDate",
-  "anchorOncotreeCode",
-  "race",
-]);
 
 export function PatientsPage() {
   const [userSearchVal, setUserSearchVal] = useState("");
@@ -83,6 +78,12 @@ export function PatientsPage() {
       userSearchVal,
     });
 
+  // When not logged in, remove PHI columns from the ColDefs entirely so they
+  // don't appear in AG Grid's column menu or any other UI surface.
+  const authFilteredColDefs = userEmail
+    ? colDefs
+    : colDefs.filter((col) => !PHI_FIELDS.has(col.field!));
+
   if (error) {
     return <ErrorMessage error={error} />;
   }
@@ -119,7 +120,7 @@ export function PatientsPage() {
 
       <DataGrid
         gridRef={gridRef}
-        colDefs={colDefs}
+        colDefs={authFilteredColDefs}
         refreshData={refreshData}
         selectedRowIds={[]}
         onSelectionChanged={() => {}}

--- a/frontend/src/pages/patients/config.tsx
+++ b/frontend/src/pages/patients/config.tsx
@@ -17,6 +17,16 @@ import { DownloadOption } from "../../hooks/useDownload";
 import { BuildDownloadOptionsParamsBase } from "../../types/shared";
 import { LazyQueryExecFunction } from "@apollo/client";
 
+/**
+ * Auth-gated fields.
+ */
+export const PHI_FIELDS = new Set([
+  "mrn",
+  "anchorSequencingDate",
+  "anchorOncotreeCode",
+  "race",
+]);
+
 export const allAnchorSeqDateColDefs: Array<ColDef<AnchorSeqDateData>> = [
   {
     field: "MRN",

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -36,6 +36,7 @@ import { NoteAddOutlined } from "@material-ui/icons";
 import { SampleHistoryModal } from "../../components/SamplesModal";
 import { useParams } from "react-router-dom";
 import { useUserEmail } from "../../contexts/UserEmailContext";
+import { useCellDoubleClicked } from "../../hooks/useCellDoubleClicked";
 
 const QUERY_NAME = "dashboardSamples";
 const INITIAL_SORT_FIELD_NAME = "importDate";
@@ -59,6 +60,7 @@ export function SamplesPage() {
     filterButtonOptions[0].label
   );
   const { userEmail } = useUserEmail();
+  const { handleCellDoubleClicked } = useCellDoubleClicked();
 
   const isWesAndLoggedIn = selectedFilterLabel === "WES" && !!userEmail;
   const disableCohortBuildling = !isWesAndLoggedIn;
@@ -218,6 +220,7 @@ export function SamplesPage() {
         handlePaste={handlePaste}
         selectedRowIds={selectedRowIds}
         onSelectionChanged={setSelectedRowIds}
+        onCellDoubleClicked={handleCellDoubleClicked}
       />
 
       {isDownloading && <DownloadModal />}

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -15,6 +15,8 @@ import {
   filterButtonsTooltipContent,
   phiModeSwitchTooltipContent,
   sampleColDefs,
+  BILLING_FIELDS,
+  PHI_FIELDS,
 } from "./config";
 import { Button, Col } from "react-bootstrap";
 import { FilterButtons } from "../../components/FilterButtons";
@@ -41,7 +43,6 @@ import { useCellDoubleClicked } from "../../hooks/useCellDoubleClicked";
 const QUERY_NAME = "dashboardSamples";
 const INITIAL_SORT_FIELD_NAME = "importDate";
 const RECORD_NAME = "samples";
-const PHI_FIELDS = new Set(["sequencingDate", "molecularAccessionNumber"]);
 
 export function SamplesPage() {
   const [userSearchVal, setUserSearchVal] = useState("");
@@ -59,7 +60,7 @@ export function SamplesPage() {
   const [selectedFilterLabel, setSelectedFilterLabel] = useState(
     filterButtonOptions[0].label
   );
-  const { userEmail } = useUserEmail();
+  const { userEmail, isLoadingUserEmail } = useUserEmail();
   const { handleCellDoubleClicked } = useCellDoubleClicked();
 
   const isWesAndLoggedIn = selectedFilterLabel === "WES" && !!userEmail;
@@ -133,13 +134,28 @@ export function SamplesPage() {
     currentColDefs: colDefs,
   });
 
+  // Show/hide billing fields based on auth state.
+  // Runs on login/logout; skips while auth state is still being determined.
+  useEffect(() => {
+    if (isLoadingUserEmail) return;
+    setColDefs((prev) =>
+      prev.map((col) =>
+        BILLING_FIELDS.has(col.field!) ? { ...col, hide: !userEmail } : col
+      )
+    );
+  }, [userEmail, isLoadingUserEmail]);
+
   function handleFilterButtonClick(filterButtonLabel: string) {
     setSelectedFilterLabel(filterButtonLabel);
 
     const selectedFilterButtonOption = filterButtonOptions.find(
       (option) => option.label === filterButtonLabel
     );
-    setColDefs(selectedFilterButtonOption!.colDefs);
+    // Apply current auth state to billing fields when colDefs are reset by a filter change
+    const newColDefs = selectedFilterButtonOption!.colDefs.map((col) =>
+      BILLING_FIELDS.has(col.field!) ? { ...col, hide: !userEmail } : col
+    );
+    setColDefs(newColDefs);
     setRecordContexts(selectedFilterButtonOption!.recordContexts);
     refreshData();
   }

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -14,6 +14,7 @@ import {
   filterButtonOptions,
   filterButtonsTooltipContent,
   phiModeSwitchTooltipContent,
+  sampleColDefs,
 } from "./config";
 import { Button, Col } from "react-bootstrap";
 import { FilterButtons } from "../../components/FilterButtons";
@@ -26,12 +27,14 @@ import { useTogglePhiColumnsVisibility } from "../../hooks/useTogglePhiColumns";
 import { useCellChanges } from "../../hooks/useCellChanges";
 import { CellChangesContainer } from "../../components/CellChangesContainer";
 import { DataGridLayout } from "../../components/DataGridLayout";
-import { POLL_INTERVAL } from "../../configs/shared";
+import { POLL_INTERVAL, ROUTE_PARAMS } from "../../configs/shared";
 import {
   CohortBuilderContainer,
   CohortBuilderSample,
 } from "../../components/CohortBuilderContainer";
 import { NoteAddOutlined } from "@material-ui/icons";
+import { SampleHistoryModal } from "../../components/SamplesModal";
+import { useParams } from "react-router-dom";
 
 const QUERY_NAME = "dashboardSamples";
 const INITIAL_SORT_FIELD_NAME = "importDate";
@@ -40,6 +43,8 @@ const PHI_FIELDS = new Set(["sequencingDate", "molecularAccessionNumber"]);
 
 export function SamplesPage() {
   const [userSearchVal, setUserSearchVal] = useState("");
+  const hasParams = Object.keys(useParams()).length > 0;
+  const smileSampleId = useParams()[ROUTE_PARAMS.samples];
   const [colDefs, setColDefs] = useState(filterButtonOptions[0].colDefs);
   const [recordContexts, setRecordContexts] = useState(
     filterButtonOptions[0].recordContexts
@@ -217,6 +222,17 @@ export function SamplesPage() {
           selectedRowIds={selectedRowIds}
           setSelectedRowIds={setSelectedRowIds}
           setShowSelectedPopup={setShowSelectedPopup}
+        />
+      )}
+
+      {hasParams && smileSampleId && (
+        <SampleHistoryModal
+          sampleColDefs={sampleColDefs}
+          recordContext={{
+            fieldName: "smileSampleId",
+            values: [smileSampleId],
+          }}
+          parentRecordName="samples"
         />
       )}
     </DataGridLayout>

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -60,7 +60,7 @@ export function SamplesPage() {
   const [selectedFilterLabel, setSelectedFilterLabel] = useState(
     filterButtonOptions[0].label
   );
-  const { userEmail, isLoadingUserEmail } = useUserEmail();
+  const { userEmail } = useUserEmail();
   const { handleCellDoubleClicked } = useCellDoubleClicked();
 
   const isWesAndLoggedIn = selectedFilterLabel === "WES" && !!userEmail;
@@ -134,28 +134,13 @@ export function SamplesPage() {
     currentColDefs: colDefs,
   });
 
-  // Show/hide billing fields based on auth state.
-  // Runs on login/logout; skips while auth state is still being determined.
-  useEffect(() => {
-    if (isLoadingUserEmail) return;
-    setColDefs((prev) =>
-      prev.map((col) =>
-        BILLING_FIELDS.has(col.field!) ? { ...col, hide: !userEmail } : col
-      )
-    );
-  }, [userEmail, isLoadingUserEmail]);
-
   function handleFilterButtonClick(filterButtonLabel: string) {
     setSelectedFilterLabel(filterButtonLabel);
 
     const selectedFilterButtonOption = filterButtonOptions.find(
       (option) => option.label === filterButtonLabel
     );
-    // Apply current auth state to billing fields when colDefs are reset by a filter change
-    const newColDefs = selectedFilterButtonOption!.colDefs.map((col) =>
-      BILLING_FIELDS.has(col.field!) ? { ...col, hide: !userEmail } : col
-    );
-    setColDefs(newColDefs);
+    setColDefs(selectedFilterButtonOption!.colDefs);
     setRecordContexts(selectedFilterButtonOption!.recordContexts);
     refreshData();
   }
@@ -166,6 +151,16 @@ export function SamplesPage() {
       phiFields: PHI_FIELDS,
       userSearchVal,
     });
+
+  // When not logged in, remove PHI and billing columns from the ColDefs entirely
+  // so they don't appear in AG Grid's column menu or any other UI surface.
+  // When logged in, pass the full ColDefs (PHI visibility is then controlled by
+  // the phiEnabled + search toggle; billing columns are always visible).
+  const authFilteredColDefs = userEmail
+    ? colDefs
+    : colDefs.filter(
+        (col) => !PHI_FIELDS.has(col.field!) && !BILLING_FIELDS.has(col.field!)
+      );
 
   if (error) {
     return <ErrorMessage error={error} />;
@@ -229,7 +224,7 @@ export function SamplesPage() {
       </Toolbar>
       <DataGrid
         gridRef={gridRef}
-        colDefs={colDefs}
+        colDefs={authFilteredColDefs}
         refreshData={refreshData}
         changes={changes}
         handleCellEditRequest={handleCellEditRequest}

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -35,6 +35,7 @@ import {
 import { NoteAddOutlined } from "@material-ui/icons";
 import { SampleHistoryModal } from "../../components/SamplesModal";
 import { useParams } from "react-router-dom";
+import { useUserEmail } from "../../contexts/UserEmailContext";
 
 const QUERY_NAME = "dashboardSamples";
 const INITIAL_SORT_FIELD_NAME = "importDate";
@@ -54,8 +55,25 @@ export function SamplesPage() {
     []
   );
   const [showSelectedPopup, setShowSelectedPopup] = useState(false);
-  const [disableCohortBuildling, setDisableCohortBuildling] = useState(true);
-  const [includeDemographics, setIncludeDemographics] = useState(false);
+  const [selectedFilterLabel, setSelectedFilterLabel] = useState(
+    filterButtonOptions[0].label
+  );
+  const { userEmail } = useUserEmail();
+
+  const isWesAndLoggedIn = selectedFilterLabel === "WES" && !!userEmail;
+  const disableCohortBuildling = !isWesAndLoggedIn;
+  const includeDemographics = isWesAndLoggedIn;
+
+  // Reset cohort builder when transitioning from enabled to disabled
+  const prevIsWesAndLoggedIn = useRef(isWesAndLoggedIn);
+  useEffect(() => {
+    if (prevIsWesAndLoggedIn.current && !isWesAndLoggedIn) {
+      gridRef.current?.api?.deselectAll();
+      setSelectedRowIds([]);
+      setShowSelectedPopup(false);
+    }
+    prevIsWesAndLoggedIn.current = isWesAndLoggedIn;
+  }, [isWesAndLoggedIn]);
 
   const {
     refreshData,
@@ -114,19 +132,7 @@ export function SamplesPage() {
   });
 
   function handleFilterButtonClick(filterButtonLabel: string) {
-    if (filterButtonLabel === "WES") {
-      setDisableCohortBuildling(false);
-      setIncludeDemographics(true);
-    } else {
-      // reset everything if not WES or cohort builder disabled
-      if (gridRef.current) {
-        gridRef.current.api.deselectAll();
-      }
-      setSelectedRowIds([]);
-      setShowSelectedPopup(false);
-      setDisableCohortBuildling(true);
-      setIncludeDemographics(false);
-    }
+    setSelectedFilterLabel(filterButtonLabel);
 
     const selectedFilterButtonOption = filterButtonOptions.find(
       (option) => option.label === filterButtonLabel

--- a/frontend/src/pages/samples/config.tsx
+++ b/frontend/src/pages/samples/config.tsx
@@ -100,7 +100,6 @@ const ACCESS_SAMPLE_CONTEXT: Array<DashboardRecordContext> = [
 
 export const sampleColDefs: Array<ColDef<DashboardSample>> = [
   {
-    field: "history",
     headerName: "View History",
     cellRenderer: (params: ICellRendererParams<DashboardSample>) => {
       return (
@@ -477,7 +476,6 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
     headerComponentParams: createCustomHeader(""),
   },
   {
-    field: "history",
     headerName: "View History",
     cellRenderer: (params: ICellRendererParams<DashboardSample>) => {
       return (
@@ -583,7 +581,6 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
   {
     field: "billed",
     headerName: "Billed",
-    hide: true,
     editable: true,
     cellEditor: "agRichSelectCellEditor",
     cellEditorPopup: true,
@@ -599,7 +596,6 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
   {
     field: "costCenter",
     headerName: "Cost Center/Fund Number",
-    hide: true,
     cellClassRules: {
       "costCenter-validation-error": (params: CellClassParams) => {
         return isInvalidCostCenter(params.colDef.field!, params.value);
@@ -762,7 +758,6 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
 
 const accessSampleColDefs: Array<ColDef<DashboardSample>> = [
   {
-    field: "history",
     headerName: "View History",
     cellRenderer: (params: ICellRendererParams<DashboardSample>) => {
       return (

--- a/frontend/src/pages/samples/config.tsx
+++ b/frontend/src/pages/samples/config.tsx
@@ -33,6 +33,7 @@ import {
   RecordChange,
 } from "../../types/shared";
 import { DownloadOption } from "../../hooks/useDownload";
+import { Button } from "react-bootstrap";
 
 const WES_SAMPLE_CONTEXT: Array<DashboardRecordContext> = [
   {
@@ -86,6 +87,30 @@ const ACCESS_SAMPLE_CONTEXT: Array<DashboardRecordContext> = [
 ];
 
 export const sampleColDefs: Array<ColDef<DashboardSample>> = [
+  {
+    field: "history",
+    headerName: "View History",
+    cellRenderer: (params: ICellRendererParams<DashboardSample>) => {
+      return (
+        <div style={{ display: "flex", alignItems: "center", height: "100%" }}>
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={() => {
+              if (params.data?.smileSampleId !== undefined) {
+                params.context.navigateFunction(
+                  `/samples/${params.data.smileSampleId}`
+                );
+              }
+            }}
+          >
+            View
+          </Button>
+        </div>
+      );
+    },
+    sortable: false,
+  },
   {
     field: "primaryId",
     headerName: "Primary ID",
@@ -348,7 +373,6 @@ export const sampleColDefs: Array<ColDef<DashboardSample>> = [
       "Mandatory description of reason for making changes to sample metadata (used for auditing purposes).",
     headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
     maxWidth: 600,
-    ...multiLineColDef,
   },
 ];
 
@@ -439,6 +463,30 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
     hide: true,
     width: 120,
     headerComponentParams: createCustomHeader(""),
+  },
+  {
+    field: "history",
+    headerName: "View History",
+    cellRenderer: (params: ICellRendererParams<DashboardSample>) => {
+      return (
+        <div style={{ display: "flex", alignItems: "center", height: "100%" }}>
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={() => {
+              if (params.data?.smileSampleId !== undefined) {
+                params.context.navigateFunction(
+                  `/samples/${params.data.smileSampleId}`
+                );
+              }
+            }}
+          >
+            View
+          </Button>
+        </div>
+      );
+    },
+    sortable: false,
   },
   {
     field: "primaryId",
@@ -699,6 +747,30 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
 ];
 
 const accessSampleColDefs: Array<ColDef<DashboardSample>> = [
+  {
+    field: "history",
+    headerName: "View History",
+    cellRenderer: (params: ICellRendererParams<DashboardSample>) => {
+      return (
+        <div style={{ display: "flex", alignItems: "center", height: "100%" }}>
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={() => {
+              if (params.data?.smileSampleId !== undefined) {
+                params.context.navigateFunction(
+                  `/samples/${params.data.smileSampleId}`
+                );
+              }
+            }}
+          >
+            View
+          </Button>
+        </div>
+      );
+    },
+    sortable: false,
+  },
   {
     field: "primaryId",
     headerName: "Primary ID",

--- a/frontend/src/pages/samples/config.tsx
+++ b/frontend/src/pages/samples/config.tsx
@@ -341,6 +341,15 @@ export const sampleColDefs: Array<ColDef<DashboardSample>> = [
     field: "sampleCategory",
     headerName: "SMILE Sample Category",
   },
+  {
+    field: "changelog",
+    headerName: "Reason for Change",
+    headerTooltip:
+      "Mandatory description of reason for making changes to sample metadata (used for auditing purposes).",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
+    maxWidth: 600,
+    ...multiLineColDef,
+  },
 ];
 
 const dbGapPhenotypeColumns: Array<ColDef<DashboardSample>> = [

--- a/frontend/src/pages/samples/config.tsx
+++ b/frontend/src/pages/samples/config.tsx
@@ -35,6 +35,18 @@ import {
 import { DownloadOption } from "../../hooks/useDownload";
 import { Button } from "react-bootstrap";
 
+/**
+ * Auth-gated fields.
+ */
+export const BILLING_FIELDS = new Set(["billed", "costCenter"]);
+export const PHI_FIELDS = new Set([
+  "sequencingDate",
+  "molecularAccessionNumber",
+]);
+
+/**
+ * Applies the context in which sample records are filtered for SamplesPage.
+ */
 const WES_SAMPLE_CONTEXT: Array<DashboardRecordContext> = [
   {
     fieldName: "genePanel",
@@ -571,6 +583,7 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
   {
     field: "billed",
     headerName: "Billed",
+    hide: true,
     editable: true,
     cellEditor: "agRichSelectCellEditor",
     cellEditorPopup: true,
@@ -586,6 +599,7 @@ export const wesSampleColDefs: Array<ColDef<DashboardSample>> = [
   {
     field: "costCenter",
     headerName: "Cost Center/Fund Number",
+    hide: true,
     cellClassRules: {
       "costCenter-validation-error": (params: CellClassParams) => {
         return isInvalidCostCenter(params.colDef.field!, params.value);

--- a/frontend/src/pages/samples/config.tsx
+++ b/frontend/src/pages/samples/config.tsx
@@ -955,6 +955,7 @@ export function setupEditableSampleFields(
       },
       cursorNotAllowed: (params: CellClassParams) => {
         return (
+          (!params.context?.userEmail && params.colDef.field !== "billed") ||
           params.data?.sampleCategory === "clinical" ||
           !editableFieldsList.has(params.colDef.field!)
         );
@@ -995,6 +996,7 @@ export function setupEditableSampleFields(
 
     colDef.editable = (params) => {
       return (
+        (params.context?.userEmail || params.colDef.field === "billed") &&
         params.data?.sampleCategory !== "clinical" &&
         editableFieldsList.has(params.colDef.field!) &&
         params.data?.revisable === true

--- a/frontend/src/utils/awaitLoginPopup.ts
+++ b/frontend/src/utils/awaitLoginPopup.ts
@@ -1,0 +1,24 @@
+import { openLoginPopup } from "./openLoginPopup";
+import { getUserEmail } from "./getUserEmail";
+
+/**
+ * Opens the Keycloak login popup and resolves with the logged-in user's email
+ * once the popup reports a successful login. Resolves with undefined if the
+ * popup is closed without a successful login.
+ */
+export async function awaitLoginPopup(): Promise<string | undefined> {
+  return new Promise<string | undefined>((resolve) => {
+    window.addEventListener("message", handleLoginMessage);
+
+    function handleLoginMessage(event: MessageEvent) {
+      if (event.data === "success") {
+        getUserEmail().then((email) => {
+          window.removeEventListener("message", handleLoginMessage);
+          resolve(email);
+        });
+      }
+    }
+
+    openLoginPopup();
+  });
+}

--- a/frontend/src/utils/handleAgGridPaste.ts
+++ b/frontend/src/utils/handleAgGridPaste.ts
@@ -21,10 +21,12 @@ export async function handleAgGridPaste({
   e,
   gridRef,
   handleCellEditRequest,
+  context,
 }: {
   e: React.ClipboardEvent<HTMLDivElement>;
   gridRef: React.RefObject<AgGridReactType>;
   handleCellEditRequest: (params: CellEditRequestEvent) => Promise<void>;
+  context?: Record<string, any>;
 }) {
   e.preventDefault();
   if (!gridRef.current || !gridRef.current.api) return;
@@ -69,6 +71,7 @@ export async function handleAgGridPaste({
         rowIndex: pasteArea.rowIndices[r],
         colId,
         newValue: clipboardValue,
+        context,
       });
     }
   } else {
@@ -80,6 +83,7 @@ export async function handleAgGridPaste({
           rowIndex: pasteArea.rowIndices[r],
           colId: pasteArea.colIds[c],
           newValue: clipboardData[r][c],
+          context,
         });
       }
     }
@@ -129,12 +133,14 @@ export async function updateCell({
   rowIndex,
   colId,
   newValue,
+  context,
 }: {
   gridApi: GridApi;
   handleCellEditRequest: (params: CellEditRequestEvent) => Promise<void>;
   rowIndex: number;
   colId: string;
   newValue: any;
+  context?: Record<string, any>;
 }) {
   const node = gridApi.getDisplayedRowAtIndex(rowIndex);
   const data = node?.data;
@@ -142,7 +148,7 @@ export async function updateCell({
   if (
     !data ||
     !colDef ||
-    !cellIsEditable({ colDef, data, node } as EditableCallbackParams)
+    !cellIsEditable({ colDef, data, node, context } as EditableCallbackParams)
   ) {
     return;
   }
@@ -152,6 +158,7 @@ export async function updateCell({
     colDef,
     oldValue: data[colId],
     newValue,
+    context,
   } as CellEditRequestEvent);
 }
 

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1542,6 +1542,7 @@ export type DashboardSample = {
   cancerType?: Maybe<Scalars["String"]>;
   cancerTypeDetailed?: Maybe<Scalars["String"]>;
   cfDNA2dBarcode?: Maybe<Scalars["String"]>;
+  changelog?: Maybe<Scalars["String"]>;
   cmoPatientId?: Maybe<Scalars["String"]>;
   cmoSampleName?: Maybe<Scalars["String"]>;
   collectionYear?: Maybe<Scalars["String"]>;
@@ -1604,6 +1605,7 @@ export type DashboardSampleInput = {
   cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
   cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
   changedFieldNames: Array<Scalars["String"]>;
+  changelog?: InputMaybe<Scalars["String"]>;
   cmoPatientId?: InputMaybe<Scalars["String"]>;
   cmoSampleName?: InputMaybe<Scalars["String"]>;
   collectionYear?: InputMaybe<Scalars["String"]>;
@@ -11523,6 +11525,7 @@ export type DashboardSamplesQuery = {
     platform?: string | null;
     igoSampleStatus?: string | null;
     dmpRecommendedCoverage?: string | null;
+    changelog?: string | null;
     validationReport?: string | null;
     validationStatus?: boolean | null;
     cancerType?: string | null;
@@ -11586,6 +11589,7 @@ export type DashboardSampleMetadataPartsFragment = {
   platform?: string | null;
   igoSampleStatus?: string | null;
   dmpRecommendedCoverage?: string | null;
+  changelog?: string | null;
   validationReport?: string | null;
   validationStatus?: boolean | null;
   cancerType?: string | null;
@@ -11686,6 +11690,7 @@ export type UpdateDashboardSamplesMutation = {
     platform?: string | null;
     igoSampleStatus?: string | null;
     dmpRecommendedCoverage?: string | null;
+    changelog?: string | null;
     validationReport?: string | null;
     validationStatus?: boolean | null;
     cancerType?: string | null;
@@ -11819,6 +11824,7 @@ export const DashboardSampleMetadataPartsFragmentDoc = gql`
     platform
     igoSampleStatus
     dmpRecommendedCoverage
+    changelog
     validationReport
     validationStatus
     cancerType

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1575,6 +1575,7 @@ export type DashboardSample = {
   qcCompleteStatus?: Maybe<Scalars["String"]>;
   race?: Maybe<Scalars["String"]>;
   recipe?: Maybe<Scalars["String"]>;
+  recordId: Scalars["String"];
   revisable?: Maybe<Scalars["Boolean"]>;
   sampleCategory: Scalars["String"];
   sampleClass?: Maybe<Scalars["String"]>;
@@ -1638,6 +1639,7 @@ export type DashboardSampleInput = {
   qcCompleteStatus?: InputMaybe<Scalars["String"]>;
   race?: InputMaybe<Scalars["String"]>;
   recipe?: InputMaybe<Scalars["String"]>;
+  recordId: Scalars["String"];
   revisable?: InputMaybe<Scalars["Boolean"]>;
   sampleCategory: Scalars["String"];
   sampleClass?: InputMaybe<Scalars["String"]>;
@@ -4257,6 +4259,7 @@ export type Query = {
   dashboardCohorts: Array<DashboardCohort>;
   dashboardPatients: Array<DashboardPatient>;
   dashboardRequests: Array<DashboardRequest>;
+  dashboardSampleHistory: Array<DashboardSample>;
   dashboardSamples: Array<DashboardSample>;
   dbGaps: Array<DbGap>;
   dbGapsAggregate: DbGapAggregateSelection;
@@ -4373,6 +4376,13 @@ export type QueryDashboardRequestsArgs = {
   limit: Scalars["Int"];
   offset: Scalars["Int"];
   searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  sort: DashboardRecordSort;
+};
+
+export type QueryDashboardSampleHistoryArgs = {
+  limit: Scalars["Int"];
+  offset: Scalars["Int"];
+  searchVals: Array<Scalars["String"]>;
   sort: DashboardRecordSort;
 };
 
@@ -11499,6 +11509,78 @@ export type DashboardSamplesQuery = {
     smileSampleId: string;
     revisable?: boolean | null;
     sampleCategory: string;
+    recordId: string;
+    primaryId?: string | null;
+    cmoSampleName?: string | null;
+    importDate?: string | null;
+    cmoPatientId?: string | null;
+    investigatorSampleId?: string | null;
+    sampleType?: string | null;
+    species?: string | null;
+    genePanel?: string | null;
+    baitSet?: string | null;
+    preservation?: string | null;
+    tumorOrNormal?: string | null;
+    sampleClass?: string | null;
+    oncotreeCode?: string | null;
+    collectionYear?: string | null;
+    sampleOrigin?: string | null;
+    tissueLocation?: string | null;
+    sex?: string | null;
+    cfDNA2dBarcode?: string | null;
+    recipe?: string | null;
+    altId?: string | null;
+    analyteType?: string | null;
+    historicalCmoSampleNames?: string | null;
+    instrumentModel?: string | null;
+    platform?: string | null;
+    igoSampleStatus?: string | null;
+    dmpRecommendedCoverage?: string | null;
+    changelog?: string | null;
+    validationReport?: string | null;
+    validationStatus?: boolean | null;
+    cancerType?: string | null;
+    cancerTypeDetailed?: string | null;
+    igoDeliveryDate?: string | null;
+    billed?: boolean | null;
+    costCenter?: string | null;
+    billedBy?: string | null;
+    custodianInformation?: string | null;
+    accessLevel?: string | null;
+    initialPipelineRunDate?: string | null;
+    embargoDate?: string | null;
+    bamCompleteDate?: string | null;
+    bamCompleteStatus?: string | null;
+    mafCompleteDate?: string | null;
+    mafCompleteNormalPrimaryId?: string | null;
+    mafCompleteStatus?: string | null;
+    qcCompleteDate?: string | null;
+    qcCompleteResult?: string | null;
+    qcCompleteReason?: string | null;
+    qcCompleteStatus?: string | null;
+    sampleCohortIds?: string | null;
+    dbGapStudy?: string | null;
+    irbConsentProtocol?: string | null;
+    dmpPatientAlias?: string | null;
+  }>;
+};
+
+export type DashboardSampleHistoryQueryVariables = Exact<{
+  searchVals: Array<Scalars["String"]> | Scalars["String"];
+  sort: DashboardRecordSort;
+  limit: Scalars["Int"];
+  offset: Scalars["Int"];
+}>;
+
+export type DashboardSampleHistoryQuery = {
+  __typename?: "Query";
+  dashboardSampleHistory: Array<{
+    __typename?: "DashboardSample";
+    _total?: number | null;
+    smileSampleId: string;
+    revisable?: boolean | null;
+    sampleCategory: string;
+    recordId: string;
     primaryId?: string | null;
     cmoSampleName?: string | null;
     importDate?: string | null;
@@ -11563,6 +11645,7 @@ export type DashboardSamplePartsFragment = {
 
 export type DashboardSampleMetadataPartsFragment = {
   __typename?: "DashboardSample";
+  recordId: string;
   primaryId?: string | null;
   cmoSampleName?: string | null;
   importDate?: string | null;
@@ -11664,6 +11747,7 @@ export type UpdateDashboardSamplesMutation = {
     smileSampleId: string;
     revisable?: boolean | null;
     sampleCategory: string;
+    recordId: string;
     primaryId?: string | null;
     cmoSampleName?: string | null;
     importDate?: string | null;
@@ -11798,6 +11882,7 @@ export const DashboardSamplePartsFragmentDoc = gql`
 `;
 export const DashboardSampleMetadataPartsFragmentDoc = gql`
   fragment DashboardSampleMetadataParts on DashboardSample {
+    recordId
     primaryId
     cmoSampleName
     importDate
@@ -12053,6 +12138,37 @@ export const DashboardSamplesDocument = gql`
 export type DashboardSamplesQueryResult = Apollo.QueryResult<
   DashboardSamplesQuery,
   DashboardSamplesQueryVariables
+>;
+export const DashboardSampleHistoryDocument = gql`
+  query DashboardSampleHistory(
+    $searchVals: [String!]!
+    $sort: DashboardRecordSort!
+    $limit: Int!
+    $offset: Int!
+  ) {
+    dashboardSampleHistory(
+      searchVals: $searchVals
+      sort: $sort
+      limit: $limit
+      offset: $offset
+    ) {
+      ...DashboardSampleParts
+      ...DashboardSampleMetadataParts
+      ...DashboardTempoParts
+      ...DashboardDbGapParts
+      ...DashboardPatientParts
+      _total
+    }
+  }
+  ${DashboardSamplePartsFragmentDoc}
+  ${DashboardSampleMetadataPartsFragmentDoc}
+  ${DashboardTempoPartsFragmentDoc}
+  ${DashboardDbGapPartsFragmentDoc}
+  ${DashboardPatientPartsFragmentDoc}
+`;
+export type DashboardSampleHistoryQueryResult = Apollo.QueryResult<
+  DashboardSampleHistoryQuery,
+  DashboardSampleHistoryQueryVariables
 >;
 export const UpdateDashboardSamplesDocument = gql`
   mutation UpdateDashboardSamples(

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1435,6 +1435,7 @@ export type DashboardCohort = {
   _total?: Maybe<Scalars["Int"]>;
   _uniqueSampleCount?: Maybe<Scalars["Int"]>;
   billed?: Maybe<Scalars["String"]>;
+  changelog?: Maybe<Scalars["String"]>;
   cohortId: Scalars["String"];
   endUsers?: Maybe<Scalars["String"]>;
   importDate?: Maybe<Scalars["String"]>;
@@ -1454,6 +1455,7 @@ export type DashboardCohortInput = {
   _uniqueSampleCount?: InputMaybe<Scalars["Int"]>;
   billed?: InputMaybe<Scalars["String"]>;
   changedFieldNames: Array<Scalars["String"]>;
+  changelog?: InputMaybe<Scalars["String"]>;
   cohortId: Scalars["String"];
   endUsers?: InputMaybe<Scalars["String"]>;
   importDate?: InputMaybe<Scalars["String"]>;
@@ -11477,6 +11479,7 @@ export type DashboardCohortsQuery = {
     type?: string | null;
     pipelineVersion?: string | null;
     searchableSampleIds?: string | null;
+    changelog?: string | null;
     _total?: number | null;
     _uniqueSampleCount?: number | null;
   }>;
@@ -11845,6 +11848,7 @@ export type UpdateTempoCohortMutation = {
     type?: string | null;
     pipelineVersion?: string | null;
     searchableSampleIds?: string | null;
+    changelog?: string | null;
     _total?: number | null;
     _uniqueSampleCount?: number | null;
   } | null;
@@ -12088,6 +12092,7 @@ export const DashboardCohortsDocument = gql`
       type
       pipelineVersion
       searchableSampleIds
+      changelog
       _total
       _uniqueSampleCount
     }
@@ -12235,6 +12240,7 @@ export const UpdateTempoCohortDocument = gql`
       type
       pipelineVersion
       searchableSampleIds
+      changelog
       _total
       _uniqueSampleCount
     }

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1435,7 +1435,6 @@ export type DashboardCohort = {
   _total?: Maybe<Scalars["Int"]>;
   _uniqueSampleCount?: Maybe<Scalars["Int"]>;
   billed?: Maybe<Scalars["String"]>;
-  changelog?: Maybe<Scalars["String"]>;
   cohortId: Scalars["String"];
   endUsers?: Maybe<Scalars["String"]>;
   importDate?: Maybe<Scalars["String"]>;
@@ -11479,7 +11478,6 @@ export type DashboardCohortsQuery = {
     type?: string | null;
     pipelineVersion?: string | null;
     searchableSampleIds?: string | null;
-    changelog?: string | null;
     _total?: number | null;
     _uniqueSampleCount?: number | null;
   }>;
@@ -11848,7 +11846,6 @@ export type UpdateTempoCohortMutation = {
     type?: string | null;
     pipelineVersion?: string | null;
     searchableSampleIds?: string | null;
-    changelog?: string | null;
     _total?: number | null;
     _uniqueSampleCount?: number | null;
   } | null;
@@ -12092,7 +12089,6 @@ export const DashboardCohortsDocument = gql`
       type
       pipelineVersion
       searchableSampleIds
-      changelog
       _total
       _uniqueSampleCount
     }
@@ -12240,7 +12236,6 @@ export const UpdateTempoCohortDocument = gql`
       type
       pipelineVersion
       searchableSampleIds
-      changelog
       _total
       _uniqueSampleCount
     }

--- a/graphql-server/src/routes/auth/callback.ts
+++ b/graphql-server/src/routes/auth/callback.ts
@@ -5,10 +5,34 @@ const passport = require("passport");
  * This second passport.authenticate() serves a distinct function from the one called by logInRoute.
  * It lets Keycloak respond to the above authentication request, following the OpenID protocol.
  * If successful, Passport adds `user` and `isAuthenticated()` to the `req` object.
+ *
+ * After login, the user is redirected to `session.returnTo` (set by logInRoute when a protected
+ * page initiates the login flow) or falls back to `/auth/login-success` for the popup login flow.
  */
 export function callbackRoute(req: any, res: any, next: any) {
-  passport.authenticate("oidc", {
-    successRedirect: `${REACT_APP_REACT_SERVER_ORIGIN}/auth/login-success`,
-    failureRedirect: "/",
+  passport.authenticate("oidc", (err: any, user: any) => {
+    if (err || !user) {
+      return res.redirect("/");
+    }
+
+    // Read returnTo before req.logIn() — Passport 0.6+ regenerates the session
+    // on login (session fixation prevention), which would destroy session data.
+    const returnTo = req.session.returnTo as string | undefined;
+
+    req.logIn(user, (loginErr: any) => {
+      if (loginErr) {
+        return next(loginErr);
+      }
+
+      const redirectUrl =
+        returnTo && returnTo.startsWith("/")
+          ? `${REACT_APP_REACT_SERVER_ORIGIN}${returnTo}`
+          : `${REACT_APP_REACT_SERVER_ORIGIN}/auth/login-success`;
+
+      req.session.save((saveErr: any) => {
+        if (saveErr) return next(saveErr);
+        return res.redirect(redirectUrl);
+      });
+    });
   })(req, res, next);
 }

--- a/graphql-server/src/routes/auth/login.ts
+++ b/graphql-server/src/routes/auth/login.ts
@@ -2,7 +2,19 @@ const passport = require("passport");
 
 /**
  * Initiate the authentication request.
+ * If a `returnTo` query parameter is provided (a relative path), it is stored
+ * in the session so the callback can redirect the user back there after login.
+ * The session is explicitly saved before initiating the OIDC redirect to ensure
+ * the value is persisted in the store before the browser leaves the page.
  */
 export function logInRoute(req: any, res: any, next: any) {
+  const returnTo = req.query.returnTo;
+  if (returnTo && typeof returnTo === "string" && returnTo.startsWith("/")) {
+    req.session.returnTo = returnTo;
+    req.session.save(() => {
+      passport.authenticate("oidc")(req, res, next);
+    });
+    return;
+  }
   passport.authenticate("oidc")(req, res, next);
 }

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -73,6 +73,7 @@ type AuthMiddleware = {
     dashboardPatients: IMiddlewareResolver;
     allAnchorSeqDateData: IMiddlewareResolver;
     allBlockedCohortIds: IMiddlewareResolver;
+    dashboardCohorts: IMiddlewareResolver;
   };
 };
 
@@ -161,8 +162,34 @@ export async function buildCustomSchema(ogm: OGM) {
         return await resolve(parent, args, context, info);
       },
 
-      async allBlockedCohortIds() {
-        return queryAllBlockedCohortIds();
+      async allBlockedCohortIds(
+        resolve,
+        parent,
+        args,
+        context: ApolloServerContext,
+        info
+      ) {
+        if (!context.req.isAuthenticated()) {
+          throw new AuthenticationError(
+            "You must be logged in to access this resource."
+          );
+        }
+        return await resolve(parent, args, context, info);
+      },
+
+      async dashboardCohorts(
+        resolve,
+        parent,
+        args,
+        context: ApolloServerContext,
+        info
+      ) {
+        if (!context.req.isAuthenticated()) {
+          throw new AuthenticationError(
+            "You must be logged in to access this resource."
+          );
+        }
+        return await resolve(parent, args, context, info);
       },
     },
   };
@@ -232,8 +259,12 @@ export async function buildCustomSchema(ogm: OGM) {
         return await resolve(parent, args, context, info);
       },
 
-      async allBlockedCohortIds() {
-        return queryAllBlockedCohortIds();
+      async allBlockedCohortIds(resolve, parent, args, context, info) {
+        return await resolve(parent, args, context, info);
+      },
+
+      async dashboardCohorts(resolve, parent, args, context, info) {
+        return await resolve(parent, args, context, info);
       },
     },
   };

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -547,6 +547,9 @@ async function updateSampleMetadataPromises(
           newDashboardSample[key as keyof DashboardSampleInput];
       }
     });
+    // promote changelog to additional properties in sample manifest
+    sampleManifest.additionalProperties.changelog =
+      newDashboardSample.changelog || "";
 
     // Ensure validator and label generator use latest status data added during validation
     delete sampleManifest.status;
@@ -672,6 +675,7 @@ const EDITABLE_SAMPLEMETADATA_FIELDS = new Set([
   "sampleOrigin",
   "tissueLocation",
   "sex",
+  "changelog",
 ]);
 
 const EDITABLE_TEMPO_FIELDS = new Set([

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -29,6 +29,7 @@ import {
   queryDashboardCohorts,
 } from "./queries/cohorts";
 import {
+  buildSampleMetadataHistoryQueryBody,
   buildSamplesQueryBody,
   buildSamplesQueryFinal,
   getAddlOtCodesMatchingCtOrCtdVals,
@@ -466,6 +467,36 @@ export async function buildCustomSchema(ogm: OGM) {
         return mapPhiToSamplesData({
           samplesData,
           seqDatesBySampleId,
+        });
+      },
+
+      async dashboardSampleHistory(
+        _source: undefined,
+        { searchVals, sort, limit, offset }: QueryDashboardSamplesArgs,
+        { inMemoryCache }: ApolloServerContext
+      ) {
+        const oncotreeCache = inMemoryCache.get(
+          ONCOTREE_CACHE_KEY
+        ) as OncotreeCache;
+        const patientDemographicsCache = inMemoryCache.get(
+          PATIENT_DEMOGRAPHICS_CACHE_KEY
+        ) as PatientDemographicsCache;
+
+        const queryBody = buildSampleMetadataHistoryQueryBody({
+          smileSampleId: searchVals ? searchVals[0] : "",
+        });
+
+        const samplesCypherQuery = buildSamplesQueryFinal({
+          queryBody,
+          sort,
+          limit,
+          offset,
+        });
+
+        return await queryDashboardSamples({
+          samplesCypherQuery,
+          oncotreeCache,
+          patientDemographicsCache,
         });
       },
     },

--- a/graphql-server/src/schemas/queries/samples.ts
+++ b/graphql-server/src/schemas/queries/samples.ts
@@ -61,6 +61,7 @@ const FIELDS_TO_SEARCH = [
   "sampleCohortIds",
   "igoDeliveryDate",
   "dmpRecommendedCoverage",
+  "changelog",
 ];
 
 export function buildSamplesQueryBody({

--- a/graphql-server/src/schemas/queries/samples.ts
+++ b/graphql-server/src/schemas/queries/samples.ts
@@ -303,7 +303,8 @@ export function buildSamplesQueryBody({
       latestQC[0] AS latestQC,
       coalesce(apoc.text.join([id IN sampleCohortIds WHERE id IS NOT NULL], ', '), '') AS sampleCohortIds,
       apoc.convert.fromJsonMap(latestSm.cmoSampleIdFields) AS cmoSampleIdFields,
-      apoc.convert.fromJsonMap(latestSm.additionalProperties).recommended_coverage AS dmpRecommendedCoverage
+      apoc.convert.fromJsonMap(latestSm.additionalProperties).recommended_coverage AS dmpRecommendedCoverage,
+      apoc.convert.fromJsonMap(latestSm.additionalProperties).changelog AS changelog
 
       ${bamCompleteDateColFilter && `WHERE ${bamCompleteDateColFilter}`}
       ${mafCompleteDateColFilter && `WHERE ${mafCompleteDateColFilter}`}
@@ -325,6 +326,7 @@ export function buildSamplesQueryBody({
       sampleCohortIds,
       cmoSampleIdFields,
       dmpRecommendedCoverage,
+      changelog,
       d,
       r,
 
@@ -371,6 +373,7 @@ export function buildSamplesQueryBody({
         validationStatus: latestSt.validationStatus,
         igoSampleStatus: apoc.convert.fromJsonMap(latestSm.additionalProperties).igoSampleStatus,
         dmpRecommendedCoverage: dmpRecommendedCoverage,
+        changelog: changelog,
 
         smileTempoId: t.smileTempoId,
         billed: t.billed,
@@ -518,6 +521,7 @@ export type SampleDataForCacheUpdate = Record<
     | "historicalCmoSampleNames"
     | "importDate"
     | "revisable"
+    | "changelog"
   >
 >;
 
@@ -559,7 +563,8 @@ export async function querySelectSampleDataForCacheUpdate(
       latestSm.cmoSampleName AS cmoSampleName,
       apoc.date.format(latestSm.importDate, 'ms', 'yyyy-MM-dd') AS importDate,
       historicalCmoSampleNames,
-      s.revisable AS revisable
+      s.revisable AS revisable,
+      apoc.convert.fromJsonMap(latestSm.additionalProperties).changelog AS changelog
   `;
 
   const session = neo4jDriver.session();

--- a/graphql-server/src/schemas/queries/samples.ts
+++ b/graphql-server/src/schemas/queries/samples.ts
@@ -196,7 +196,16 @@ export function buildSamplesQueryBody({
 
     WITH
       s,
-      latestSm[0] AS latestSm,
+      latestSm[0] AS latestSm
+    
+    // Filters for either the WES Samples or Request Samples view, if applicable
+    ${genePanelContext && `WHERE ${genePanelContext}`}
+    ${baitSetContext && `OR ${baitSetContext}`}
+    ${requestContext && `WHERE ${requestContext}`}
+
+    WITH 
+      s,
+      latestSm,
       COLLECT {
       	MATCH (s)-[:HAS_METADATA]->(sm:SampleMetadata)
         WITH
@@ -219,12 +228,6 @@ export function buildSamplesQueryBody({
           ]
         ),
       ", ") AS historicalCmoSampleNames
-
-    // Filters for either the WES Samples or Request Samples view, if applicable
-    ${genePanelContext && `WHERE ${genePanelContext}`}
-    ${baitSetContext && `OR ${baitSetContext}`}
-
-    ${requestContext && `WHERE ${requestContext}`}
 
     // Get SampleMetadata's Status
     OPTIONAL MATCH (latestSm)-[:HAS_STATUS]->(st:Status)
@@ -339,6 +342,7 @@ export function buildSamplesQueryBody({
 
     WITH
       ({
+        recordId: s.smileSampleId,
         smileSampleId: s.smileSampleId,
         revisable: s.revisable,
         sampleCategory: s.sampleCategory,
@@ -404,6 +408,160 @@ export function buildSamplesQueryBody({
   `;
 
   return samplesQueryBody;
+}
+
+/**
+ * Builds a Cypher query body that returns one DashboardSample per SampleMetadata version
+ * for a given sample, representing its full versioned metadata history.
+ * Unlike buildSamplesQueryBody (which returns only latestSm), this iterates over all
+ * SampleMetadata nodes associated with the sample.
+ */
+export function buildSampleMetadataHistoryQueryBody({
+  smileSampleId,
+}: {
+  smileSampleId: string;
+}) {
+  const sampleMetadataHistoryQueryBody = `
+    // Get Sample and all SampleMetadata (versioned history)
+    MATCH (s:Sample {smileSampleId: '${smileSampleId}'})-[:HAS_METADATA]->(sm:SampleMetadata)
+
+    // Get each SampleMetadata's Status
+    OPTIONAL MATCH (sm)-[:HAS_STATUS]->(st:Status)
+
+    // Get Patient info
+    OPTIONAL MATCH (s)<-[:HAS_SAMPLE]-(p:Patient)<-[:IS_ALIAS]-(pa:PatientAlias)
+    WITH
+      s,
+      sm,
+      st,
+      head([pa IN collect(pa) WHERE pa.namespace = 'dmpId' | pa.value]) AS dmpPatientAlias
+
+    // Get Tempo data
+    OPTIONAL MATCH (s)-[:HAS_TEMPO]->(t:Tempo)
+    WITH
+      s,
+      sm,
+      st,
+      dmpPatientAlias,
+      t,
+      COLLECT {
+        OPTIONAL MATCH (t)-[:HAS_EVENT]->(bc:BamComplete)
+        RETURN bc ORDER BY bc.date DESC LIMIT 1
+      } AS latestBC,
+      COLLECT {
+        OPTIONAL MATCH (t)-[:HAS_EVENT]->(mc:MafComplete)
+        RETURN mc ORDER BY mc.date DESC LIMIT 1
+      } AS latestMC,
+      COLLECT {
+        OPTIONAL MATCH (t)-[:HAS_EVENT]->(qc:QcComplete)
+        RETURN qc ORDER BY qc.date DESC LIMIT 1
+      } AS latestQC,
+      COLLECT {
+        OPTIONAL MATCH (s)<-[:HAS_COHORT_SAMPLE]-(c:Cohort)
+        RETURN DISTINCT c.cohortId
+      } AS sampleCohortIds
+
+    WITH
+      s,
+      sm,
+      st,
+      dmpPatientAlias,
+      t,
+      latestBC[0] AS latestBC,
+      latestMC[0] AS latestMC,
+      latestQC[0] AS latestQC,
+      coalesce(apoc.text.join([id IN sampleCohortIds WHERE id IS NOT NULL], ', '), '') AS sampleCohortIds,
+      apoc.convert.fromJsonMap(sm.cmoSampleIdFields) AS cmoSampleIdFields,
+      apoc.convert.fromJsonMap(sm.additionalProperties).recommended_coverage AS dmpRecommendedCoverage,
+      apoc.convert.fromJsonMap(sm.additionalProperties).changelog AS changelog
+
+    // Get DbGap data
+    OPTIONAL MATCH (s)-[:HAS_DBGAP]->(d:DbGap)
+    OPTIONAL MATCH (r:Request)-[:HAS_SAMPLE]->(s)
+    WITH
+      s,
+      sm,
+      st,
+      dmpPatientAlias,
+      t,
+      latestBC,
+      latestMC,
+      latestQC,
+      sampleCohortIds,
+      cmoSampleIdFields,
+      dmpRecommendedCoverage,
+      changelog,
+      d,
+      r,
+
+    CASE s.sampleCategory
+      WHEN "research" THEN r.igoDeliveryDate
+      ELSE null
+    END AS igoDeliveryDate
+
+    WITH
+      ({
+        recordId: elementId(sm),
+        smileSampleId: s.smileSampleId,
+        revisable: s.revisable,
+        sampleCategory: s.sampleCategory,
+        igoDeliveryDate: apoc.date.format(igoDeliveryDate, 'ms', 'yyyy-MM-dd'),
+
+        primaryId: sm.primaryId,
+        cmoSampleName: sm.cmoSampleName,
+        importDate: apoc.date.format(sm.importDate, 'ms', 'yyyy-MM-dd HH:mm'),
+        validationReport: st.validationReport,
+        validationStatus: st.validationStatus,
+        cmoPatientId: sm.cmoPatientId,
+        investigatorSampleId: sm.investigatorSampleId,
+        sampleType: sm.sampleType,
+        species: sm.species,
+        genePanel: sm.genePanel,
+        baitSet: sm.baitSet,
+        preservation: sm.preservation,
+        tumorOrNormal: sm.tumorOrNormal,
+        sampleClass: sm.sampleClass,
+        oncotreeCode: sm.oncotreeCode,
+        collectionYear: sm.collectionYear,
+        sampleOrigin: sm.sampleOrigin,
+        tissueLocation: sm.tissueLocation,
+        sex: sm.sex,
+        cfDNA2dBarcode: sm.cfDNA2dBarcode,
+        libraries: sm.libraries,
+        recipe: cmoSampleIdFields.recipe,
+        analyteType: cmoSampleIdFields.naToExtract,
+        altId: apoc.convert.fromJsonMap(sm.additionalProperties).altId,
+        igoSampleStatus: apoc.convert.fromJsonMap(sm.additionalProperties).igoSampleStatus,
+        dmpRecommendedCoverage: dmpRecommendedCoverage,
+        changelog: changelog,
+
+        smileTempoId: t.smileTempoId,
+        billed: t.billed,
+        costCenter: t.costCenter,
+        billedBy: t.billedBy,
+        custodianInformation: t.custodianInformation,
+        accessLevel: t.accessLevel,
+        initialPipelineRunDate: t.initialPipelineRunDate,
+        embargoDate: t.embargoDate,
+        bamCompleteDate: latestBC.date,
+        bamCompleteStatus: latestBC.status,
+        mafCompleteDate: latestMC.date,
+        mafCompleteNormalPrimaryId: latestMC.normalPrimaryId,
+        mafCompleteStatus: latestMC.status,
+        qcCompleteDate: latestQC.date,
+        qcCompleteResult: latestQC.result,
+        qcCompleteReason: latestQC.reason,
+        qcCompleteStatus: latestQC.status,
+        sampleCohortIds: sampleCohortIds,
+
+        dbGapStudy: d.dbGapStudy,
+        irbConsentProtocol: d.irbConsentProtocol,
+
+        dmpPatientAlias: dmpPatientAlias
+      }) AS tempNode
+  `;
+
+  return sampleMetadataHistoryQueryBody;
 }
 
 function buildCypherPredicateFromContext({

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -60,6 +60,7 @@ const SAMPLE_FIELDS = `
   platform: String
   igoSampleStatus: String
   dmpRecommendedCoverage: String
+  changelog: String
   ## (sm:SampleMetadata)-[:HAS_STATUS]->(s:Status)
   validationReport: String
   validationStatus: Boolean

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -181,7 +181,6 @@ const QUERY_RESULT_TYPEDEFS = gql`
     type: String
     pipelineVersion: String
     searchableSampleIds: String
-    changelog: String
     _total: Int
     _uniqueSampleCount: Int
   }

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -181,6 +181,7 @@ const QUERY_RESULT_TYPEDEFS = gql`
     type: String
     pipelineVersion: String
     searchableSampleIds: String
+    changelog: String
     _total: Int
     _uniqueSampleCount: Int
   }
@@ -300,6 +301,7 @@ const MUTATION_TYPEDEFS = gql`
     type: String
     pipelineVersion: String
     searchableSampleIds: String
+    changelog: String
     _total: Int
     _uniqueSampleCount: Int
   }

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -26,6 +26,9 @@ const GENERIC_TYPEDEFS = gql`
 `;
 
 const SAMPLE_FIELDS = `
+  # internal
+  recordId: String!
+
   # (s:Sample)
   smileSampleId: String!
   revisable: Boolean
@@ -259,6 +262,13 @@ const QUERY_TYPEDEFS = gql`
       offset: Int!
       phiEnabled: Boolean
       includeDemographics: Boolean!
+    ): [DashboardSample!]!
+
+    dashboardSampleHistory(
+      searchVals: [String!]!
+      sort: DashboardRecordSort!
+      limit: Int!
+      offset: Int!
     ): [DashboardSample!]!
 
     allAnchorSeqDateData(phiEnabled: Boolean): [AnchorSeqDateData!]!

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -14169,6 +14169,18 @@
             "deprecationReason": null
           },
           {
+            "name": "changelog",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cmoPatientId",
             "description": null,
             "args": [],
@@ -14903,6 +14915,18 @@
                   }
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "changelog",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -14565,6 +14565,22 @@
             "deprecationReason": null
           },
           {
+            "name": "recordId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "revisable",
             "description": null,
             "args": [],
@@ -15311,6 +15327,22 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recordId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -40598,6 +40630,103 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "DashboardRequest",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dashboardSampleHistory",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "searchVals",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "DashboardRecordSort",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DashboardSample",
                     "ofType": null
                   }
                 }

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -13036,6 +13036,18 @@
             "deprecationReason": null
           },
           {
+            "name": "changelog",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cohortId",
             "description": null,
             "args": [],
@@ -13250,6 +13262,18 @@
                   }
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "changelog",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -13036,18 +13036,6 @@
             "deprecationReason": null
           },
           {
-            "name": "changelog",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "cohortId",
             "description": null,
             "args": [],

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -176,6 +176,7 @@ fragment DashboardSampleMetadataParts on DashboardSample {
   platform
   igoSampleStatus
   dmpRecommendedCoverage
+  changelog
   ## (sm:SampleMetadata)-[:HAS_STATUS]->(s:Status)
   validationReport
   validationStatus

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -102,6 +102,7 @@ query DashboardCohorts(
     type
     pipelineVersion
     searchableSampleIds
+    changelog
     _total
     _uniqueSampleCount
   }
@@ -312,6 +313,7 @@ mutation UpdateTempoCohort($dashboardCohort: DashboardCohortInput!) {
     type
     pipelineVersion
     searchableSampleIds
+    changelog
     _total
     _uniqueSampleCount
   }

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -139,6 +139,27 @@ query DashboardSamples(
   }
 }
 
+query DashboardSampleHistory(
+  $searchVals: [String!]!
+  $sort: DashboardRecordSort!
+  $limit: Int!
+  $offset: Int!
+) {
+  dashboardSampleHistory(
+    searchVals: $searchVals
+    sort: $sort
+    limit: $limit
+    offset: $offset
+  ) {
+    ...DashboardSampleParts
+    ...DashboardSampleMetadataParts
+    ...DashboardTempoParts
+    ...DashboardDbGapParts
+    ...DashboardPatientParts
+    _total
+  }
+}
+
 fragment DashboardSampleParts on DashboardSample {
   # (s:Sample)
   smileSampleId
@@ -147,6 +168,8 @@ fragment DashboardSampleParts on DashboardSample {
 }
 
 fragment DashboardSampleMetadataParts on DashboardSample {
+  # internal
+  recordId
   # (s:Sample)-[:HAS_METADATA]->(sm:SampleMetadata)
   ## Root-level fields
   primaryId

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -102,7 +102,6 @@ query DashboardCohorts(
     type
     pipelineVersion
     searchableSampleIds
-    changelog
     _total
     _uniqueSampleCount
   }
@@ -313,7 +312,6 @@ mutation UpdateTempoCohort($dashboardCohort: DashboardCohortInput!) {
     type
     pipelineVersion
     searchableSampleIds
-    changelog
     _total
     _uniqueSampleCount
   }


### PR DESCRIPTION
## Description

Summary of changes:

1. There is a login button always present in the top right of the dashboard
2. Several privileges are now in place for authorized users:
  - submitting sample updates
  - viewing/tracking billing fields (Billing + Cost Center/Fund Number)
  - building and submitting cohorts to TEMPO
  - viewing the cohorts page
3. Data auditing - some minor bug fixes that broke the flow of updates from the dashboard to TEMPO
4. Sample history view
5. Changes to flow of submitting updates to sample data: 
  - Before auth-gating updates: Users could double click on a cell to enter 'edit mode'
  - New behavior:
    - Double clicking on a cell as an unauthenticated user will prompt you to login. You will immediately be entered into edit mode so you will not need to double click the same cell again to continue editing the cell. 
    - You may also login before attempting to make any changes using the top right Login button.


## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [x] Searching for a single term or multiple terms returns relevant results
- [x] Searching in PHI mode returns results with PHI columns
- [x] Filtering columns returns the results matching the filter
- [x] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [x] Clicking "Download as TSV"
- [x] Searching for some terms then clicking "Download as TSV"
- [x] Filtering a column then clicking "Download as TSV"
- [x] Search in PHI mode then clicking "Download as TSV"
- [x] Clicking the dropdown download option <download option name>
- [x] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)

#### AG Grid interactions

- [x] [Samples page] Editing a cell updates the value as expected
- [x] [Samples page] Pasting data into the grid works as expected
- [x] Editing a cell in a non-editable row/column is prevented
- [x] Column sorting in ascending and descending order works as expected
- [x] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [x] [Samples page] Cell changes confirmation modal appears and works as expected
- [x] [Requests page] Validation errors are displayed in the Record Validation modal
- [x] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [x] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [x] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [x] The GraphQL types that are auto-generated via `yarn run codegen`
- [x] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
