### PR TITLE
Set author to username that's signed in for data audit

### DIFF
--- a/frontend/src/components/CellChangesContainer.tsx
+++ b/frontend/src/components/CellChangesContainer.tsx
@@ -3,6 +3,7 @@ import { AgGridReact } from "ag-grid-react";
 import { RecordChange } from "../types/shared";
 import { Dispatch, SetStateAction, useState } from "react";
 import { NO_CHANGELOG_WARNING } from "../configs/shared";
+import { useUserEmail } from "../contexts/UserEmailContext";
 
 function buildUpdateModalColumnDefs(fieldToHeaderName?: (f: string) => string) {
   return [
@@ -50,6 +51,8 @@ export function CellChangesContainer({
   fieldToHeaderName,
 }: CellChangesContainerProps) {
   const [changelog, setChangelog] = useState("");
+  const { userEmail } = useUserEmail();
+  const username = userEmail?.split("@")[0];
 
   if (isSampleLevelChanges) {
     autoGroupColumnDef.headerName = "Primary ID";
@@ -114,8 +117,19 @@ export function CellChangesContainer({
                 <Form.Control
                   type="text"
                   size="sm"
+                  className="me-3"
                   value={changelog}
                   onChange={(e) => setChangelog(e.target.value)}
+                />
+                <Form.Label className="mb-0 me-2 text-nowrap">
+                  Author:
+                </Form.Label>
+                <Form.Control
+                  style={{ width: "30%" }}
+                  type="text"
+                  size="sm"
+                  value={username ?? ""}
+                  disabled
                 />
               </Form.Group>
             )}

--- a/frontend/src/components/CellChangesContainer.tsx
+++ b/frontend/src/components/CellChangesContainer.tsx
@@ -31,7 +31,7 @@ interface CellChangesContainerProps {
   cellChangesHandlers: {
     handleDiscardChanges: () => void;
     handleConfirmUpdates: () => void;
-    handleSubmitUpdates: (author: string, reasonForChange: string) => void;
+    handleSubmitUpdates: (reasonForChange: string) => void;
     showUpdateModal: boolean;
     setShowUpdateModal: Dispatch<SetStateAction<boolean>>;
   };
@@ -50,7 +50,6 @@ export function CellChangesContainer({
   fieldToHeaderName,
 }: CellChangesContainerProps) {
   const [changelog, setChangelog] = useState("");
-  const [authorChangelog, setAuthorChangelog] = useState("");
 
   if (isSampleLevelChanges) {
     autoGroupColumnDef.headerName = "Primary ID";
@@ -58,9 +57,7 @@ export function CellChangesContainer({
     autoGroupColumnDef.headerName = "Cohort ID";
   }
 
-  const disableSubmitUpdates =
-    isSampleLevelChanges &&
-    (changelog.trim() === "" || authorChangelog.trim() === "");
+  const disableSubmitUpdates = isSampleLevelChanges && changelog.trim() === "";
 
   function handleUpdateModalHide() {
     setShowUpdateModal(false);
@@ -117,19 +114,8 @@ export function CellChangesContainer({
                 <Form.Control
                   type="text"
                   size="sm"
-                  className="me-3"
                   value={changelog}
                   onChange={(e) => setChangelog(e.target.value)}
-                />
-                <Form.Label className="mb-0 me-2 text-nowrap">
-                  Author:
-                </Form.Label>
-                <Form.Control
-                  style={{ width: "30%" }}
-                  type="text"
-                  size="sm"
-                  value={authorChangelog}
-                  onChange={(e) => setAuthorChangelog(e.target.value)}
                 />
               </Form.Group>
             )}
@@ -144,7 +130,7 @@ export function CellChangesContainer({
             </Button>
             <Button
               className="btn btn-success"
-              onClick={() => handleSubmitUpdates(authorChangelog, changelog)}
+              onClick={() => handleSubmitUpdates(changelog)}
               disabled={disableSubmitUpdates}
             >
               Submit Updates

--- a/frontend/src/configs/shared.tsx
+++ b/frontend/src/configs/shared.tsx
@@ -64,4 +64,4 @@ export const INVALID_COST_CENTER_WARNING =
   "Please note that 5 digit legacy Cost Center formats (#####/#####) will also be accepted temporarily.";
 
 export const NO_CHANGELOG_WARNING =
-  "Please update Reason for Change and Author fields.";
+  "Reason for Change field must be filled in before submitting updates.";

--- a/frontend/src/hooks/useCellChanges.ts
+++ b/frontend/src/hooks/useCellChanges.ts
@@ -179,7 +179,7 @@ export function useCellChanges({
     }
   }
 
-  async function handleSubmitUpdates(author: string, reasonForChange: string) {
+  async function handleSubmitUpdates(reasonForChange: string) {
     if (changes.length === 0) {
       console.error("No changes available to submit.");
       return;
@@ -189,8 +189,15 @@ export function useCellChanges({
 
     const changesWithReason = [...changes];
 
+    const username = userEmail?.split("@")[0];
+    if (!username) {
+      console.error("User email is unexpectedly empty.");
+    }
+
     if (isSampleLevelChanges) {
-      const formattedChangelog = `${author}: ${reasonForChange}`;
+      const formattedChangelog = username
+        ? `${username}: ${reasonForChange}`
+        : reasonForChange;
       recordIds.forEach((r) => {
         const change = changes.find((c) => c.recordId === r);
         if (!change) {


### PR DESCRIPTION
Implements https://github.com/mskcc/smile-server/issues/1825

## Description

<Include a summary of the changes. Please also include relevant motivation and context. List any external dependencies that are required for this change, like new environment variables.>

## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [ ] Searching for a single term or multiple terms returns relevant results
- [ ] Searching in PHI mode returns results with PHI columns
- [ ] Filtering columns returns the results matching the filter
- [ ] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [ ] Clicking "Download as TSV"
- [ ] Searching for some terms then clicking "Download as TSV"
- [ ] Filtering a column then clicking "Download as TSV"
- [ ] Search in PHI mode then clicking "Download as TSV"
- [ ] Clicking the dropdown download option <download option name>
- [ ] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
- [ ] Downloads work when viewing Sample Metadata History

#### AG Grid interactions

- [ ] [Samples page] Editing a cell updates the value as expected
- [ ] [Samples page] Pasting data into the grid works as expected
- [ ] Editing a cell in a non-editable row/column is prevented
- [ ] Column sorting in ascending and descending order works as expected
- [ ] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [ ] [Samples page] Cell changes confirmation modal appears and works as expected
- [ ] [Requests page] Validation errors are displayed in the Record Validation modal
- [ ] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [ ] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [ ] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [ ] The GraphQL types that are auto-generated via `yarn run codegen`
- [ ] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
