### PR TITLE
Add IGO QC Reports to DashboardSample type

### DIFF
--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1558,6 +1558,7 @@ export type DashboardSample = {
   historicalCmoSampleNames?: Maybe<Scalars["String"]>;
   igoComplete?: Maybe<Scalars["Boolean"]>;
   igoDeliveryDate?: Maybe<Scalars["String"]>;
+  igoQcReports?: Maybe<Array<Maybe<IgoQcReport>>>;
   igoSampleStatus?: Maybe<Scalars["String"]>;
   importDate?: Maybe<Scalars["String"]>;
   initialPipelineRunDate?: Maybe<Scalars["String"]>;
@@ -1950,6 +1951,14 @@ export type DeleteInfo = {
   bookmark?: Maybe<Scalars["String"]>;
   nodesDeleted: Scalars["Int"];
   relationshipsDeleted: Scalars["Int"];
+};
+
+export type IgoQcReport = {
+  __typename?: "IgoQcReport";
+  IGORecommendation?: Maybe<Scalars["String"]>;
+  comments?: Maybe<Scalars["String"]>;
+  investigatorDecision?: Maybe<Scalars["String"]>;
+  qcReportType?: Maybe<Scalars["String"]>;
 };
 
 export type MafComplete = {
@@ -11540,6 +11549,13 @@ export type DashboardSamplesQuery = {
     dbGapStudy?: string | null;
     irbConsentProtocol?: string | null;
     dmpPatientAlias?: string | null;
+    igoQcReports?: Array<{
+      __typename?: "IgoQcReport";
+      qcReportType?: string | null;
+      IGORecommendation?: string | null;
+      comments?: string | null;
+      investigatorDecision?: string | null;
+    } | null> | null;
   }>;
 };
 
@@ -11658,6 +11674,17 @@ export type DashboardSampleMetadataPartsFragment = {
   cancerType?: string | null;
   cancerTypeDetailed?: string | null;
   igoDeliveryDate?: string | null;
+};
+
+export type IgoQcReportPartsFragment = {
+  __typename?: "DashboardSample";
+  igoQcReports?: Array<{
+    __typename?: "IgoQcReport";
+    qcReportType?: string | null;
+    IGORecommendation?: string | null;
+    comments?: string | null;
+    investigatorDecision?: string | null;
+  } | null> | null;
 };
 
 export type DashboardTempoPartsFragment = {
@@ -11897,6 +11924,16 @@ export const DashboardSampleMetadataPartsFragmentDoc = gql`
     cancerType
     cancerTypeDetailed
     igoDeliveryDate
+  }
+`;
+export const IgoQcReportPartsFragmentDoc = gql`
+  fragment IgoQcReportParts on DashboardSample {
+    igoQcReports {
+      qcReportType
+      IGORecommendation
+      comments
+      investigatorDecision
+    }
   }
 `;
 export const DashboardTempoPartsFragmentDoc = gql`
@@ -12259,6 +12296,7 @@ export const DashboardSamplesDocument = gql`
       ...DashboardTempoParts
       ...DashboardDbGapParts
       ...DashboardPatientParts
+      ...IgoQcReportParts
       sequencingDate
       molecularAccessionNumber
       race
@@ -12270,6 +12308,7 @@ export const DashboardSamplesDocument = gql`
   ${DashboardTempoPartsFragmentDoc}
   ${DashboardDbGapPartsFragmentDoc}
   ${DashboardPatientPartsFragmentDoc}
+  ${IgoQcReportPartsFragmentDoc}
 `;
 
 /**

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1557,6 +1557,7 @@ export type DashboardSample = {
   historicalCmoSampleNames?: Maybe<Scalars["String"]>;
   igoComplete?: Maybe<Scalars["Boolean"]>;
   igoDeliveryDate?: Maybe<Scalars["String"]>;
+  igoQcReports?: Maybe<Array<Maybe<IgoQcReport>>>;
   igoSampleStatus?: Maybe<Scalars["String"]>;
   importDate?: Maybe<Scalars["String"]>;
   initialPipelineRunDate?: Maybe<Scalars["String"]>;
@@ -1949,6 +1950,14 @@ export type DeleteInfo = {
   bookmark?: Maybe<Scalars["String"]>;
   nodesDeleted: Scalars["Int"];
   relationshipsDeleted: Scalars["Int"];
+};
+
+export type IgoQcReport = {
+  __typename?: "IgoQcReport";
+  IGORecommendation?: Maybe<Scalars["String"]>;
+  comments?: Maybe<Scalars["String"]>;
+  investigatorDecision?: Maybe<Scalars["String"]>;
+  qcReportType?: Maybe<Scalars["String"]>;
 };
 
 export type MafComplete = {
@@ -11539,6 +11548,13 @@ export type DashboardSamplesQuery = {
     dbGapStudy?: string | null;
     irbConsentProtocol?: string | null;
     dmpPatientAlias?: string | null;
+    igoQcReports?: Array<{
+      __typename?: "IgoQcReport";
+      qcReportType?: string | null;
+      IGORecommendation?: string | null;
+      comments?: string | null;
+      investigatorDecision?: string | null;
+    } | null> | null;
   }>;
 };
 
@@ -11657,6 +11673,17 @@ export type DashboardSampleMetadataPartsFragment = {
   cancerType?: string | null;
   cancerTypeDetailed?: string | null;
   igoDeliveryDate?: string | null;
+};
+
+export type IgoQcReportPartsFragment = {
+  __typename?: "DashboardSample";
+  igoQcReports?: Array<{
+    __typename?: "IgoQcReport";
+    qcReportType?: string | null;
+    IGORecommendation?: string | null;
+    comments?: string | null;
+    investigatorDecision?: string | null;
+  } | null> | null;
 };
 
 export type DashboardTempoPartsFragment = {
@@ -11898,6 +11925,16 @@ export const DashboardSampleMetadataPartsFragmentDoc = gql`
     igoDeliveryDate
   }
 `;
+export const IgoQcReportPartsFragmentDoc = gql`
+  fragment IgoQcReportParts on DashboardSample {
+    igoQcReports {
+      qcReportType
+      IGORecommendation
+      comments
+      investigatorDecision
+    }
+  }
+`;
 export const DashboardTempoPartsFragmentDoc = gql`
   fragment DashboardTempoParts on DashboardSample {
     billed
@@ -12104,6 +12141,7 @@ export const DashboardSamplesDocument = gql`
       ...DashboardTempoParts
       ...DashboardDbGapParts
       ...DashboardPatientParts
+      ...IgoQcReportParts
       sequencingDate
       molecularAccessionNumber
       race
@@ -12115,6 +12153,7 @@ export const DashboardSamplesDocument = gql`
   ${DashboardTempoPartsFragmentDoc}
   ${DashboardDbGapPartsFragmentDoc}
   ${DashboardPatientPartsFragmentDoc}
+  ${IgoQcReportPartsFragmentDoc}
 `;
 export type DashboardSamplesQueryResult = Apollo.QueryResult<
   DashboardSamplesQuery,

--- a/graphql-server/src/schemas/queries/samples.ts
+++ b/graphql-server/src/schemas/queries/samples.ts
@@ -376,6 +376,7 @@ export function buildSamplesQueryBody({
         sex: latestSm.sex,
         cfDNA2dBarcode: latestSm.cfDNA2dBarcode,
         igoComplete: latestSm.igoComplete,
+        igoQcReports: apoc.convert.fromJsonList(latestSm.qcReports),
         libraries: latestSm.libraries,
         recipe: cmoSampleIdFields.recipe,
         analyteType: cmoSampleIdFields.naToExtract,

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -55,6 +55,7 @@ const SAMPLE_FIELDS = `
   sex: String
   cfDNA2dBarcode: String
   igoComplete: Boolean
+
   ## Custom fields
   recipe: String
   altId: String
@@ -65,6 +66,7 @@ const SAMPLE_FIELDS = `
   igoSampleStatus: String
   dmpRecommendedCoverage: String
   changelog: String
+
   ## (sm:SampleMetadata)-[:HAS_STATUS]->(s:Status)
   validationReport: String
   validationStatus: Boolean
@@ -188,6 +190,14 @@ const QUERY_RESULT_TYPEDEFS = gql`
 
   type DashboardSample {
     ${SAMPLE_FIELDS}
+    igoQcReports: [IgoQcReport]
+   }
+
+  type IgoQcReport {
+    qcReportType: String
+    IGORecommendation: String
+    comments: String
+    investigatorDecision: String
   }
 
   type PatientIdsTriplet {

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -14349,6 +14349,22 @@
             "deprecationReason": null
           },
           {
+            "name": "igoQcReports",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IgoQcReport",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "igoSampleStatus",
             "description": null,
             "args": [],
@@ -18289,6 +18305,65 @@
         "fields": null,
         "inputFields": null,
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "IgoQcReport",
+        "description": null,
+        "fields": [
+          {
+            "name": "IGORecommendation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "comments",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "investigatorDecision",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "qcReportType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -132,6 +132,7 @@ query DashboardSamples(
     ...DashboardTempoParts
     ...DashboardDbGapParts
     ...DashboardPatientParts
+    ...IgoQcReportParts
     sequencingDate
     molecularAccessionNumber
     race
@@ -211,6 +212,15 @@ fragment DashboardSampleMetadataParts on DashboardSample {
 
   # (r:Request)-[:HAS_SAMPLE]->(s)
   igoDeliveryDate
+}
+
+fragment IgoQcReportParts on DashboardSample {
+  igoQcReports {
+    qcReportType
+    IGORecommendation
+    comments
+    investigatorDecision
+  }
 }
 
 fragment DashboardTempoParts on DashboardSample {


### PR DESCRIPTION
## Description

IGO QC Reports can be used to inform reasons why a sample failed during IGO processing  which may also impact whether a sample gets a CMO label generated for it.

Specifically the fields investigatorDecision and IGORecommendation may be helpful in quickly identifying why a sample failed validation and/or failed to get a label generated.

## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [x] Searching for a single term or multiple terms returns relevant results
- [x] Searching in PHI mode returns results with PHI columns
- [x] Filtering columns returns the results matching the filter
- [x] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [x] Clicking "Download as TSV"
- [x] Searching for some terms then clicking "Download as TSV"
- [x] Filtering a column then clicking "Download as TSV"
- [x] Search in PHI mode then clicking "Download as TSV"
- [x] Clicking the dropdown download option <download option name>
- [x] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
- [x] Viewing a sample's data diff and clicking "Download as TSV"

#### AG Grid interactions

- [x] [Samples page] Editing a cell updates the value as expected
- [x] [Samples page] Pasting data into the grid works as expected
- [x] Editing a cell in a non-editable row/column is prevented
- [x] Column sorting in ascending and descending order works as expected
- [x] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [x] [Samples page] Cell changes confirmation modal appears and works as expected
- [x] [Requests page] Validation errors are displayed in the Record Validation modal
- [x] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [x] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [x] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [x] The GraphQL types that are auto-generated via `yarn run codegen`
- [ ] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
