### PR TITLE
Add cohort builder as side panel and window

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react": "^17.0.2",
     "react-bootstrap": "^2.5.0",
     "react-dom": "^17.0.2",
+    "react-rnd": "^10.5.3",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "react-spinkit": "^3.0.0",

--- a/frontend/public/assets/css/style.css
+++ b/frontend/public/assets/css/style.css
@@ -1259,3 +1259,69 @@ h6 {
   text-align: right;
   color: red;
 }
+
+.cohort-builder-inline-panel {
+  width: 50%;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.cohort-builder-inline-header {
+  padding: 8px 14px;
+  background-color: #0d6efd;
+  color: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+  font-weight: bold;
+}
+
+.cohort-builder-inline-body {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+}
+
+.cohort-builder-window {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border: 1px solid #adb5bd;
+  border-radius: 6px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.22);
+  overflow: hidden;
+  background-color: #fff;
+}
+
+.cohort-builder-drag-handle {
+  cursor: move;
+  padding: 8px 14px;
+  background-color: #0d6efd;
+  color: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  user-select: none;
+  flex-shrink: 0;
+  font-weight: bold;
+}
+
+.cohort-builder-close-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+
+.cohort-builder-body {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}

--- a/frontend/src/components/CohortBuilderContainer.tsx
+++ b/frontend/src/components/CohortBuilderContainer.tsx
@@ -1,7 +1,7 @@
 import { Button, Col, Container, Form, Row } from "react-bootstrap";
 import { AgGridReact } from "ag-grid-react";
 import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
-import React, { RefObject, useState } from "react";
+import React, { RefObject, useEffect } from "react";
 import { CohortBuilderDownloadButton } from "./CohortBuilderDownloadButton";
 import {
   createCustomHeader,
@@ -22,8 +22,12 @@ interface CohortBuilderContainerProps {
   setSelectedRowIds?: React.Dispatch<
     React.SetStateAction<CohortBuilderSample[]>
   >;
-  setShowSelectedPopup: React.Dispatch<React.SetStateAction<boolean>>;
+  onClose: () => void;
   gridRef: RefObject<AgGridReactType<any>>;
+  tempoCohortRequest: TempoCohortRequest;
+  setTempoCohortRequest: React.Dispatch<
+    React.SetStateAction<TempoCohortRequest>
+  >;
 }
 
 export interface CohortBuilderSample {
@@ -39,18 +43,14 @@ export function CohortBuilderContainer({
   gridRef,
   selectedRowIds,
   setSelectedRowIds,
-  setShowSelectedPopup,
+  onClose,
+  tempoCohortRequest,
+  setTempoCohortRequest,
 }: CohortBuilderContainerProps) {
   const { data } = useAllBlockedCohortIdsQuery();
 
   function handleCohortBuilderClose() {
-    setShowSelectedPopup(false);
-    if (setSelectedRowIds) {
-      setSelectedRowIds([]);
-    }
-    if (gridRef.current?.api) {
-      gridRef.current.api.deselectAll();
-    }
+    onClose();
   }
 
   const tempoCohortSamplesData = selectedRowIds.map((v) => ({
@@ -62,15 +62,32 @@ export function CohortBuilderContainer({
     embargoDate: v.embargoDate,
   }));
 
-  const [tempoCohortRequest, setTempoCohortRequest] =
-    useState<TempoCohortRequest>({
-      cohortId: generateNewCohortId(),
-      endUsers: "",
-      pmUsers: "",
-      projectTitle: "",
-      projectSubtitle: "",
-      type: "investigator",
-    } as TempoCohortRequest);
+  useEffect(() => {
+    if (!tempoCohortRequest.cohortId && data) {
+      const blockedIds = data.allBlockedCohortIds;
+
+      const makeNewCohortId = () => {
+        let cohortId = "";
+        while (cohortId.length < 6) {
+          cohortId += Math.random().toString(36).slice(2);
+        }
+        return "CCS_" + cohortId.slice(0, 6).toUpperCase();
+      };
+
+      const generateNewCohortId = () => {
+        let cohortId = makeNewCohortId();
+        while (blockedIds.includes(cohortId)) {
+          cohortId = makeNewCohortId();
+        }
+        return cohortId;
+      };
+
+      setTempoCohortRequest((prev) => ({
+        ...prev,
+        cohortId: generateNewCohortId(),
+      }));
+    }
+  }, [data, tempoCohortRequest.cohortId, setTempoCohortRequest]);
 
   // adding new fields here also requires changes to DataGrid -> handleGridSelectionChanged to pass these fields
   const cohortBuilderColDefs = getCohortBuilderColDefs(
@@ -79,48 +96,12 @@ export function CohortBuilderContainer({
     setSelectedRowIds
   );
 
-  /**
-   * Generates and returns a randomized cohort ID.
-   * @returns string
-   */
-  function makeNewCohortId() {
-    let cohortId = "";
-    while (cohortId.length < 6) {
-      cohortId += Math.random().toString(36).slice(2);
-    }
-    return "CCS_" + cohortId.slice(0, 6).toUpperCase();
-  }
-
-  /**
-   * Determines if cohort ID passed is in use or not.
-   * @param cohortId
-   * @returns boolean
-   */
-  function isCohortIdInUse(cohortId: string) {
-    return data?.allBlockedCohortIds.includes(cohortId);
-  }
-
-  /**
-   * Generates and returns a randomized cohort ID. Verifies it is available as well.
-   * @returns string
-   */
-  function generateNewCohortId() {
-    var cohortId = makeNewCohortId();
-    if (isCohortIdInUse(cohortId)) {
-      while (isCohortIdInUse(cohortId)) {
-        cohortId = makeNewCohortId();
-      }
-    }
-    return cohortId;
-  }
-
   return (
-    <div className="d-flex flex-column" style={{ height: "calc(15vh - 10px)" }}>
+    <div className="d-flex flex-column" style={{ height: "100%" }}>
       <Container
         className="ag-theme-alpine flex-grow-1"
         style={{
           border: "1px solid #ccc",
-          borderRadius: "5px",
           backgroundColor: "#f9f9f9",
         }}
       >
@@ -322,7 +303,6 @@ export function CohortBuilderContainer({
           </Col>
         </Row>
       </Container>
-      <br />
     </div>
   );
 }

--- a/frontend/src/components/CohortBuilderWindow.tsx
+++ b/frontend/src/components/CohortBuilderWindow.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, RefObject, useLayoutEffect, useRef, useState } from "react";
 
+import { Close, Dock } from "@material-ui/icons";
 import { Rnd } from "react-rnd";
 
 interface CohortBuilderWindowProps {
@@ -56,14 +57,14 @@ export function CohortBuilderWindow({
               title="Snap to side panel"
               className="cohort-builder-close-btn"
             >
-              &#8676;
+              <Dock fontSize="small" />
             </button>
             <button
               onClick={onClose}
               title="Close cohort builder"
               className="cohort-builder-close-btn"
             >
-              &times;
+              <Close fontSize="small" />
             </button>
           </div>
         </div>

--- a/frontend/src/components/CohortBuilderWindow.tsx
+++ b/frontend/src/components/CohortBuilderWindow.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, RefObject, useLayoutEffect, useRef, useState } from "react";
 
-import { Close, Dock } from "@material-ui/icons";
+import { Close, FirstPage } from "@material-ui/icons";
 import { Rnd } from "react-rnd";
 
 interface CohortBuilderWindowProps {
@@ -57,7 +57,7 @@ export function CohortBuilderWindow({
               title="Snap to side panel"
               className="cohort-builder-close-btn"
             >
-              <Dock fontSize="small" />
+              <FirstPage fontSize="small" />
             </button>
             <button
               onClick={onClose}

--- a/frontend/src/components/CohortBuilderWindow.tsx
+++ b/frontend/src/components/CohortBuilderWindow.tsx
@@ -1,0 +1,75 @@
+import { ReactNode, RefObject, useLayoutEffect, useRef, useState } from "react";
+
+import { Rnd } from "react-rnd";
+
+interface CohortBuilderWindowProps {
+  containerRef: RefObject<HTMLDivElement>;
+  onClose: () => void;
+  onSnapToSide: () => void;
+  children: ReactNode;
+}
+
+export function CohortBuilderWindow({
+  containerRef,
+  onClose,
+  onSnapToSide,
+  children,
+}: CohortBuilderWindowProps) {
+  const rndRef = useRef<Rnd>(null);
+  const [visible, setVisible] = useState(false);
+
+  // Measure the flex-row container to match the inline side-panel by default
+  // width = half the container, height = full container height,
+  // positioned at the right half of the container.
+  useLayoutEffect(() => {
+    if (rndRef.current && containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
+      const w = rect.width / 2;
+      const h = rect.height;
+      rndRef.current.updateSize({ width: w, height: h });
+      rndRef.current.updatePosition({ x: rect.left + w, y: rect.top });
+      setVisible(true);
+    }
+  }, [containerRef]);
+
+  return (
+    <Rnd
+      ref={rndRef}
+      default={{
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+      }}
+      minWidth={600}
+      minHeight={400}
+      bounds="window"
+      dragHandleClassName="cohort-builder-drag-handle"
+      style={{ zIndex: 1050, visibility: visible ? "visible" : "hidden" }}
+    >
+      <div className="cohort-builder-window">
+        <div className="cohort-builder-drag-handle">
+          <span>Cohort Builder</span>
+          <div className="d-flex gap-2 align-items-center">
+            <button
+              onClick={onSnapToSide}
+              title="Snap to side panel"
+              className="cohort-builder-close-btn"
+            >
+              &#8676;
+            </button>
+            <button
+              onClick={onClose}
+              title="Close cohort builder"
+              className="cohort-builder-close-btn"
+            >
+              &times;
+            </button>
+          </div>
+        </div>
+
+        <div className="cohort-builder-body">{children}</div>
+      </div>
+    </Rnd>
+  );
+}

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -37,6 +37,7 @@ import {
 import { CohortBuilderWindow } from "../../components/CohortBuilderWindow";
 import { TempoCohortRequest } from "../../generated/graphql";
 import { Close, NoteAddOutlined, OpenInNew } from "@material-ui/icons";
+import { CustomTooltip } from "../../components/CustomToolTip";
 import { SampleHistoryModal } from "../../components/SamplesModal";
 import { useParams } from "react-router-dom";
 import { useUserEmail } from "../../contexts/UserEmailContext";
@@ -246,14 +247,30 @@ export function SamplesPage() {
         </Col>
 
         <Col className="text-end">
-          <Button
-            style={{ marginRight: 5, border: "none", padding: 3 }}
-            onClick={() => setCohortBuilderMode("inline")}
-            title="Build a new cohort for TEMPO processing"
-            disabled={disableCohortBuildling}
-          >
-            <NoteAddOutlined />
-          </Button>
+          {disableCohortBuildling ? (
+            <CustomTooltip
+              icon={
+                <Button
+                  style={{ marginRight: 5, border: "none", padding: 3 }}
+                  onClick={() => setCohortBuilderMode("inline")}
+                  title="Build a new cohort for TEMPO processing"
+                  disabled
+                >
+                  <NoteAddOutlined />
+                </Button>
+              }
+            >
+              Must be on the WES tab and logged in to access cohort builder
+            </CustomTooltip>
+          ) : (
+            <Button
+              style={{ marginRight: 5, border: "none", padding: 3 }}
+              onClick={() => setCohortBuilderMode("inline")}
+              title="Build a new cohort for TEMPO processing"
+            >
+              <NoteAddOutlined />
+            </Button>
+          )}
           <DownloadButton
             downloadOptions={downloadOptions}
             onDownload={handleDownload}

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -36,7 +36,7 @@ import {
 } from "../../components/CohortBuilderContainer";
 import { CohortBuilderWindow } from "../../components/CohortBuilderWindow";
 import { TempoCohortRequest } from "../../generated/graphql";
-import { NoteAddOutlined, OpenInNew } from "@material-ui/icons";
+import { Close, NoteAddOutlined, OpenInNew } from "@material-ui/icons";
 import { SampleHistoryModal } from "../../components/SamplesModal";
 import { useParams } from "react-router-dom";
 import { useUserEmail } from "../../contexts/UserEmailContext";
@@ -293,7 +293,7 @@ export function SamplesPage() {
                   title="Close cohort builder"
                   className="cohort-builder-close-btn"
                 >
-                  &times;
+                  <Close fontSize="small" />
                 </button>
               </div>
             </div>

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -34,7 +34,9 @@ import {
   CohortBuilderContainer,
   CohortBuilderSample,
 } from "../../components/CohortBuilderContainer";
-import { NoteAddOutlined } from "@material-ui/icons";
+import { CohortBuilderWindow } from "../../components/CohortBuilderWindow";
+import { TempoCohortRequest } from "../../generated/graphql";
+import { NoteAddOutlined, OpenInNew } from "@material-ui/icons";
 import { SampleHistoryModal } from "../../components/SamplesModal";
 import { useParams } from "react-router-dom";
 import { useUserEmail } from "../../contexts/UserEmailContext";
@@ -53,10 +55,45 @@ export function SamplesPage() {
     filterButtonOptions[0].recordContexts
   );
   const gridRef = useRef<AgGridReactType<DashboardSample>>(null);
+  const cohortBuilderRef = useRef<HTMLDivElement>(null);
   const [selectedRowIds, setSelectedRowIds] = useState<CohortBuilderSample[]>(
     []
   );
-  const [showSelectedPopup, setShowSelectedPopup] = useState(false);
+  const [cohortBuilderMode, setCohortBuilderMode] = useState<
+    "hidden" | "inline" | "window"
+  >("hidden");
+  const [tempoCohortRequest, setTempoCohortRequest] =
+    useState<TempoCohortRequest>({
+      cohortId: "",
+      endUsers: "",
+      pmUsers: "",
+      projectTitle: "",
+      projectSubtitle: "",
+      samples: [],
+      type: "investigator",
+    });
+
+  const showCohortBuilder = cohortBuilderMode !== "hidden";
+
+  function handleCohortBuilderClose() {
+    setCohortBuilderMode("hidden");
+    setSelectedRowIds([]);
+    gridRef.current?.api?.deselectAll();
+    setTempoCohortRequest({
+      cohortId: "",
+      endUsers: "",
+      pmUsers: "",
+      projectTitle: "",
+      projectSubtitle: "",
+      samples: [],
+      type: "investigator",
+    });
+  }
+
+  function handleCohortBuilderPopOut() {
+    setCohortBuilderMode("window");
+  }
+
   const [selectedFilterLabel, setSelectedFilterLabel] = useState(
     filterButtonOptions[0].label
   );
@@ -73,7 +110,7 @@ export function SamplesPage() {
     if (prevIsWesAndLoggedIn.current && !isWesAndLoggedIn) {
       gridRef.current?.api?.deselectAll();
       setSelectedRowIds([]);
-      setShowSelectedPopup(false);
+      setCohortBuilderMode("hidden");
     }
     prevIsWesAndLoggedIn.current = isWesAndLoggedIn;
   }, [isWesAndLoggedIn]);
@@ -100,13 +137,13 @@ export function SamplesPage() {
 
   useEffect(() => {
     if (gridRef.current && gridRef.current.columnApi) {
-      if (showSelectedPopup && !disableCohortBuildling) {
+      if (showCohortBuilder && !disableCohortBuildling) {
         gridRef.current.columnApi.setColumnsVisible(["selected"], true);
       } else {
         gridRef.current.columnApi.setColumnsVisible(["selected"], false);
       }
     }
-  }, [gridRef, colDefs, showSelectedPopup, disableCohortBuildling]);
+  }, [gridRef, colDefs, showCohortBuilder, disableCohortBuildling]);
 
   const { changes, cellChangesHandlers, handleCellEditRequest, handlePaste } =
     useCellChanges({
@@ -211,7 +248,7 @@ export function SamplesPage() {
         <Col className="text-end">
           <Button
             style={{ marginRight: 5, border: "none", padding: 3 }}
-            onClick={() => setShowSelectedPopup(true)}
+            onClick={() => setCohortBuilderMode("inline")}
             title="Build a new cohort for TEMPO processing"
             disabled={disableCohortBuildling}
           >
@@ -223,28 +260,75 @@ export function SamplesPage() {
           />
         </Col>
       </Toolbar>
-      <DataGrid
-        gridRef={gridRef}
-        colDefs={authFilteredColDefs}
-        refreshData={refreshData}
-        changes={changes}
-        handleCellEditRequest={handleCellEditRequest}
-        handlePaste={handlePaste}
-        selectedRowIds={selectedRowIds}
-        onSelectionChanged={setSelectedRowIds}
-        onCellDoubleClicked={handleCellDoubleClicked}
-      />
+      <div
+        ref={cohortBuilderRef}
+        className="d-flex flex-row flex-grow-1"
+        style={{ minHeight: 0 }}
+      >
+        <DataGrid
+          gridRef={gridRef}
+          colDefs={authFilteredColDefs}
+          refreshData={refreshData}
+          changes={changes}
+          handleCellEditRequest={handleCellEditRequest}
+          handlePaste={handlePaste}
+          selectedRowIds={selectedRowIds}
+          onSelectionChanged={setSelectedRowIds}
+          onCellDoubleClicked={handleCellDoubleClicked}
+        />
+        {cohortBuilderMode === "inline" && (
+          <div className="cohort-builder-inline-panel">
+            <div className="cohort-builder-inline-header">
+              <span>Cohort Builder</span>
+              <div className="d-flex gap-2 align-items-center">
+                <button
+                  onClick={handleCohortBuilderPopOut}
+                  title="Open in floating window"
+                  className="cohort-builder-close-btn"
+                >
+                  <OpenInNew fontSize="small" />
+                </button>
+                <button
+                  onClick={handleCohortBuilderClose}
+                  title="Close cohort builder"
+                  className="cohort-builder-close-btn"
+                >
+                  &times;
+                </button>
+              </div>
+            </div>
+            <div className="cohort-builder-inline-body">
+              <CohortBuilderContainer
+                gridRef={gridRef}
+                selectedRowIds={selectedRowIds}
+                setSelectedRowIds={setSelectedRowIds}
+                onClose={handleCohortBuilderClose}
+                tempoCohortRequest={tempoCohortRequest}
+                setTempoCohortRequest={setTempoCohortRequest}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {cohortBuilderMode === "window" && (
+        <CohortBuilderWindow
+          containerRef={cohortBuilderRef}
+          onClose={handleCohortBuilderClose}
+          onSnapToSide={() => setCohortBuilderMode("inline")}
+        >
+          <CohortBuilderContainer
+            gridRef={gridRef}
+            selectedRowIds={selectedRowIds}
+            setSelectedRowIds={setSelectedRowIds}
+            onClose={handleCohortBuilderClose}
+            tempoCohortRequest={tempoCohortRequest}
+            setTempoCohortRequest={setTempoCohortRequest}
+          />
+        </CohortBuilderWindow>
+      )}
 
       {isDownloading && <DownloadModal />}
-      <br />
-      {showSelectedPopup && (
-        <CohortBuilderContainer
-          gridRef={gridRef}
-          selectedRowIds={selectedRowIds}
-          setSelectedRowIds={setSelectedRowIds}
-          setShowSelectedPopup={setShowSelectedPopup}
-        />
-      )}
 
       {hasParams && smileSampleId && (
         <SampleHistoryModal

--- a/yarn.lock
+++ b/yarn.lock
@@ -5758,6 +5758,11 @@ clsx@^1.0.4:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -11952,6 +11957,11 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+re-resizable@^6.11.2:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.11.2.tgz#2e8f7119ca3881d5b5aea0ffa014a80e5c1252b3"
+  integrity sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==
+
 react-app-polyfill@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-3.0.0.tgz#95221e0a9bd259e5ca6b177c7bb1cb6768f68fd7"
@@ -12021,6 +12031,14 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-draggable@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.5.0.tgz#0b274ccb6965fcf97ed38fcf7e3cc223bc48cdf5"
+  integrity sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==
+  dependencies:
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+
 react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
@@ -12050,6 +12068,15 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-rnd@^10.5.3:
+  version "10.5.3"
+  resolved "https://registry.yarnpkg.com/react-rnd/-/react-rnd-10.5.3.tgz#f8c484034276a561e8aa2fbf6a94580596621013"
+  integrity sha512-s/sIT3pGZnQ+57egijkTp9mizjIWrJz68Pq6yd+F/wniFY3IriML18dUXnQe/HP9uMiJ+9MAp44hljG99fZu6Q==
+  dependencies:
+    re-resizable "^6.11.2"
+    react-draggable "^4.5.0"
+    tslib "2.6.2"
 
 react-router-dom@^6.3.0:
   version "6.5.0"
@@ -13770,6 +13797,11 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
+tslib@2.6.2, tslib@^2.5.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -13779,11 +13811,6 @@ tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, 
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
-
-tslib@^2.5.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tslib@^2.5.3:
   version "2.8.1"


### PR DESCRIPTION
Implements https://github.com/mskcc/smile-server/issues/1693

## Description

<Include a summary of the changes. Please also include relevant motivation and context. List any external dependencies that are required for this change, like new environment variables.>

## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [x] Searching for a single term or multiple terms returns relevant results
- [x] Searching in PHI mode returns results with PHI columns
- [x] Filtering columns returns the results matching the filter
- [x] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [x] Clicking "Download as TSV"
- [x] Searching for some terms then clicking "Download as TSV"
- [x] Filtering a column then clicking "Download as TSV"
- [x] Search in PHI mode then clicking "Download as TSV"
- [x] Clicking the dropdown download option <download option name>
- [x] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
- [x] Viewing a sample's data diff and clicking "Download as TSV"

#### AG Grid interactions

- [x] [Samples page] Editing a cell updates the value as expected
- [x] [Samples page] Pasting data into the grid works as expected
- [x] Editing a cell in a non-editable row/column is prevented
- [x] Column sorting in ascending and descending order works as expected
- [x] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [x] [Samples page] Cell changes confirmation modal appears and works as expected
- [x] [Requests page] Validation errors are displayed in the Record Validation modal
- [x] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [x] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [x] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [x] The GraphQL types that are auto-generated via `yarn run codegen`
- [x] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
