### PR TITLE
Add pending animation when submitting an update on cohorts page

### DIFF
--- a/frontend/src/hooks/useCellChanges.ts
+++ b/frontend/src/hooks/useCellChanges.ts
@@ -265,6 +265,41 @@ export function useCellChanges({
       for (const dashboardCohort of newDashboardCohorts) {
         updateTempoCohortMutation({ variables: { dashboardCohort } });
       }
+
+      // Manually handle optimistic updates for cohorts (same pattern as samples)
+      const optimisticCohorts = records!.map((c) => {
+        c = c as DashboardCohort;
+        const changesForCohort =
+          c.cohortId != null ? changesByRecordId.get(c.cohortId) : undefined;
+        if (changesForCohort) {
+          const changedFields = changesForCohort.reduce((acc, change) => {
+            acc[change.fieldName] = change.newValue;
+            return acc;
+          }, {} as Record<string, any>);
+          return {
+            ...c,
+            ...changedFields,
+            revisable: false,
+            importDate: formatCellDate(new Date()) as string,
+          };
+        }
+        return c;
+      });
+      optimisticCohorts.sort((a, b) => {
+        return (
+          new Date(b.importDate ?? "").getTime() -
+          new Date(a.importDate ?? "").getTime()
+        );
+      });
+      const optimisticDatasource = {
+        getRows: (params: IServerSideGetRowsParams) => {
+          params.success({
+            rowData: optimisticCohorts!,
+            rowCount: optimisticCohorts[0]?._total || 0,
+          });
+        },
+      };
+      gridRef.current?.api?.setServerSideDatasource(optimisticDatasource);
     }
 
     // "Reset" the grid with the latest data

--- a/frontend/src/hooks/useCellChanges.ts
+++ b/frontend/src/hooks/useCellChanges.ts
@@ -33,6 +33,7 @@ interface UseCellChangesParams {
   records: Array<DashboardSample> | Array<DashboardCohort> | undefined;
   refreshData: () => void;
   isSampleLevelChanges: boolean;
+  pinnedRecordIds?: string[];
 }
 
 export function useCellChanges({
@@ -42,6 +43,7 @@ export function useCellChanges({
   records,
   refreshData,
   isSampleLevelChanges,
+  pinnedRecordIds = [],
 }: UseCellChangesParams) {
   const [changes, setChanges] = useState<Array<RecordChange>>([]);
   const { userEmail, setUserEmail } = useUserEmail();
@@ -286,6 +288,17 @@ export function useCellChanges({
         return c;
       });
       optimisticCohorts.sort((a, b) => {
+        const aPinned = pinnedRecordIds.includes(
+          (a as DashboardCohort).cohortId ?? ""
+        )
+          ? 0
+          : 1;
+        const bPinned = pinnedRecordIds.includes(
+          (b as DashboardCohort).cohortId ?? ""
+        )
+          ? 0
+          : 1;
+        if (aPinned !== bPinned) return aPinned - bPinned;
         return (
           new Date(b.importDate ?? "").getTime() -
           new Date(a.importDate ?? "").getTime()

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -66,6 +66,7 @@ export function CohortsPage() {
       records: data?.[QUERY_NAME],
       refreshData,
       isSampleLevelChanges: false,
+      pinnedRecordIds: PINNED_COHORT_IDS,
     });
 
   const { isDownloading, handleDownload, getCurrentData } =

--- a/frontend/src/pages/cohorts/config.tsx
+++ b/frontend/src/pages/cohorts/config.tsx
@@ -19,7 +19,7 @@ import {
   createCustomHeader,
   lockIcon,
   toolTipIcon,
-  LoadingIcon
+  LoadingIcon,
 } from "../../configs/gridIcons";
 import { buildFieldToHeaderName } from "../../utils/fieldToHeaderName";
 import { Check } from "@material-ui/icons";
@@ -74,6 +74,13 @@ export const cohortColDefs: ColDef<DashboardCohort>[] = [
     headerTooltip:
       "The status of the cohort in SMILE (e.g. PROVISONAL, DELIVERED)",
     headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
+    cellRenderer: (params: ICellRendererParams<DashboardCohort>) => {
+      if (!params.data) return null;
+      if ((params.data as any).revisable === false) {
+        return <LoadingIcon />;
+      }
+      return params.value ?? null;
+    },
   },
   {
     field: "totalSampleCount",
@@ -125,9 +132,6 @@ export const cohortColDefs: ColDef<DashboardCohort>[] = [
     headerName: "Status",
     cellRenderer: (params: ICellRendererParams<DashboardCohort>) => {
       if (!params.data) return null;
-      if ((params.data as any).revisable === false) {
-        return <LoadingIcon />;
-      }
       const status = params.data.status;
       if (status === "PASS") {
         return <Check />;

--- a/frontend/src/pages/cohorts/config.tsx
+++ b/frontend/src/pages/cohorts/config.tsx
@@ -19,8 +19,11 @@ import {
   createCustomHeader,
   lockIcon,
   toolTipIcon,
+  LoadingIcon
 } from "../../configs/gridIcons";
 import { buildFieldToHeaderName } from "../../utils/fieldToHeaderName";
+import { Check } from "@material-ui/icons";
+import WarningIcon from "@material-ui/icons/Warning";
 
 type BuildDownloadOptionsParams = BuildDownloadOptionsParamsBase & {
   // Put additional parameters here if needed
@@ -120,6 +123,21 @@ export const cohortColDefs: ColDef<DashboardCohort>[] = [
   {
     field: "status",
     headerName: "Status",
+    cellRenderer: (params: ICellRendererParams<DashboardCohort>) => {
+      if (!params.data) return null;
+      if ((params.data as any).revisable === false) {
+        return <LoadingIcon />;
+      }
+      const status = params.data.status;
+      if (status === "PASS") {
+        return <Check />;
+      }
+      if (status) {
+        return <WarningIcon className="warning-icon" />;
+      }
+      return null;
+    },
+    sortable: false,
   },
   {
     field: "type",


### PR DESCRIPTION
Implements https://github.com/mskcc/smile-server/issues/1817

## Description

<Include a summary of the changes. Please also include relevant motivation and context. List any external dependencies that are required for this change, like new environment variables.>

## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [ ] Searching for a single term or multiple terms returns relevant results
- [ ] Searching in PHI mode returns results with PHI columns
- [ ] Filtering columns returns the results matching the filter
- [ ] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [ ] Clicking "Download as TSV"
- [ ] Searching for some terms then clicking "Download as TSV"
- [ ] Filtering a column then clicking "Download as TSV"
- [ ] Search in PHI mode then clicking "Download as TSV"
- [ ] Clicking the dropdown download option <download option name>
- [ ] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
- [ ] Viewing a sample's data diff and clicking "Download as TSV"

#### AG Grid interactions

- [ ] [Samples page] Editing a cell updates the value as expected
- [ ] [Samples page] Pasting data into the grid works as expected
- [ ] Editing a cell in a non-editable row/column is prevented
- [ ] Column sorting in ascending and descending order works as expected
- [ ] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [ ] [Samples page] Cell changes confirmation modal appears and works as expected
- [ ] [Requests page] Validation errors are displayed in the Record Validation modal
- [ ] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [ ] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [ ] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [ ] The GraphQL types that are auto-generated via `yarn run codegen`
- [ ] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
