### PR TITLE
Init commit - AI validation assist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ jobs:
       - attach_workspace:
           at: /tmp/
       - run:
+          name: Add GitHub to known_hosts
+          command: mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - run:
           name: 'Check code style with Prettier'
           command: cd /tmp/repo/ && yarn run prettierCheckCircleCI
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   working_directory: /tmp/repo
   docker:
     # specify the version you desire here
-    - image: cimg/node:16.20.2-browsers
+    - image: cimg/node:18.20.2-browsers
   resource_class: large
 
 version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 
 # testing
 /coverage
+/tmp
 
 # production
 /build
@@ -22,6 +23,8 @@ dist/
 *.env.test.local
 *.env.production.local
 *.code-workspace
+*.nvmrc
+*.yarnrc
 
 npm-debug.log*
 yarn-debug.log

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-engines true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.10.0
+FROM node:18
 ADD ./ /smile-dashboard
 WORKDIR /smile-dashboard
 RUN yarn --cwd frontend install

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,9 @@
 {
   "name": "frontend",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=18"
+  },
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,9 +71,9 @@
     ]
   },
   "devDependencies": {
-    "@graphql-codegen/introspection": "2.2.0",
-    "@graphql-codegen/typescript": "2.7.1",
-    "@graphql-codegen/typescript-operations": "2.5.1",
-    "@graphql-codegen/typescript-react-apollo": "3.3.1"
+    "@graphql-codegen/introspection": "4.0.3",
+    "@graphql-codegen/typescript": "4.1.6",
+    "@graphql-codegen/typescript-operations": "4.5.1",
+    "@graphql-codegen/typescript-react-apollo": "4.4.2"
   }
 }

--- a/frontend/src/components/RecordValidation.tsx
+++ b/frontend/src/components/RecordValidation.tsx
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, useState } from "react";
 import { DashboardRequest } from "../generated/graphql";
 import { CustomTooltip } from "../components/CustomToolTip";
 import WarningIcon from "@material-ui/icons/Warning";
-import { Button, Modal } from "react-bootstrap";
+import { Alert, Button, Modal, Spinner } from "react-bootstrap";
 import { ColDef } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import {
@@ -13,6 +13,7 @@ import {
   StatusMap,
 } from "../configs/recordValidationMaps";
 import { multiLineColDef } from "../configs/shared";
+import { useGetValidationAdviceLazyQuery } from "../generated/graphql";
 
 type ModalTitle = `Error report for ${string}`;
 
@@ -22,14 +23,18 @@ export function RecordValidation({
   toleratedSampleErrors,
   modalTitle,
   recordStatusMap,
+  recordId,
 }: {
   validationStatus: DashboardRequest["validationStatus"];
   validationReport: DashboardRequest["validationReport"];
   toleratedSampleErrors?: DashboardRequest["toleratedSampleErrors"];
   modalTitle: ModalTitle;
   recordStatusMap: StatusMap;
+  recordId?: string;
 }) {
   const [modalShow, setModalShow] = useState(false);
+  const recordType =
+    typeof toleratedSampleErrors === "undefined" ? "SAMPLE" : "REQUEST";
   return (
     <>
       <WarningIconButton setModalShow={setModalShow} />
@@ -42,6 +47,8 @@ export function RecordValidation({
           toleratedSampleErrors={toleratedSampleErrors}
           title={modalTitle}
           recordStatusMap={recordStatusMap}
+          recordId={recordId}
+          recordType={recordType}
         />
       )}
     </>
@@ -106,6 +113,8 @@ function ErrorReportModal({
   toleratedSampleErrors,
   title,
   recordStatusMap,
+  recordId,
+  recordType,
 }: {
   show: boolean;
   onHide: () => void;
@@ -114,7 +123,13 @@ function ErrorReportModal({
   toleratedSampleErrors: DashboardRequest["toleratedSampleErrors"];
   title: ModalTitle;
   recordStatusMap: StatusMap;
+  recordId?: string;
+  recordType: string;
 }) {
+  const [
+    getAdvice,
+    { loading: adviceLoading, data: adviceData, error: adviceError },
+  ] = useGetValidationAdviceLazyQuery();
   const validationDataForAgGrid: StatusItem[] = [];
 
   // Prepare the data for AG Grid
@@ -202,6 +217,8 @@ function ErrorReportModal({
     return null;
   }
 
+  const advice = adviceData?.getValidationAdvice;
+
   return (
     <Modal dialogClassName="modal-90w" show={show} onHide={onHide}>
       <Modal.Header closeButton>
@@ -217,8 +234,62 @@ function ErrorReportModal({
             onGridReady={(params) => params.api.sizeColumnsToFit()}
           />
         </div>
+        {/* refactor to its own component */}
+        {adviceLoading && (
+          <div className="mt-3 d-flex align-items-center gap-2">
+            <Spinner animation="border" size="sm" role="status" />
+            <span>Getting AI advice…</span>
+          </div>
+        )}
+        {adviceError && (
+          <Alert variant="danger" className="mt-3">
+            Unable to get AI advice. Please try again or contact the SMILE team.
+          </Alert>
+        )}
+        {advice && (
+          <Alert variant="info" className="mt-3">
+            <Alert.Heading>AI Advice</Alert.Heading>
+            <p>{advice.advice}</p>
+            {advice.suggestedSteps.length > 0 && (
+              <>
+                <strong>Suggested steps:</strong>
+                <ol className="mb-0 mt-1">
+                  {advice.suggestedSteps.map((step, i) => (
+                    <li key={i}>{step}</li>
+                  ))}
+                </ol>
+              </>
+            )}
+          </Alert>
+        )}
       </Modal.Body>
       <Modal.Footer>
+        {validationReport && !advice && (
+          <Button
+            variant="outline-primary"
+            disabled={adviceLoading}
+            onClick={() => {
+              const vars = {
+                validationReport,
+                recordType,
+                recordId,
+              };
+              console.log("[Ask AI] sending request:", vars);
+              getAdvice({ variables: vars }).then((res) => {
+                if (res.error) {
+                  console.error("[Ask AI] response error:", res.error);
+                } else {
+                  console.log(
+                    "[Ask AI] response:",
+                    res.data?.getValidationAdvice
+                  );
+                }
+              });
+            }}
+          >
+            Ask AI for advice
+          </Button>
+        )}
         <Button onClick={onHide}>Close</Button>
       </Modal.Footer>
     </Modal>

--- a/frontend/src/components/RecordValidation.tsx
+++ b/frontend/src/components/RecordValidation.tsx
@@ -24,6 +24,7 @@ export function RecordValidation({
   modalTitle,
   recordStatusMap,
   recordId,
+  igoQcReports,
 }: {
   validationStatus: DashboardRequest["validationStatus"];
   validationReport: DashboardRequest["validationReport"];
@@ -31,6 +32,7 @@ export function RecordValidation({
   modalTitle: ModalTitle;
   recordStatusMap: StatusMap;
   recordId?: string;
+  igoQcReports?: string | null;
 }) {
   const [modalShow, setModalShow] = useState(false);
   const recordType =
@@ -49,6 +51,7 @@ export function RecordValidation({
           recordStatusMap={recordStatusMap}
           recordId={recordId}
           recordType={recordType}
+          igoQcReports={igoQcReports}
         />
       )}
     </>
@@ -115,6 +118,7 @@ function ErrorReportModal({
   recordStatusMap,
   recordId,
   recordType,
+  igoQcReports,
 }: {
   show: boolean;
   onHide: () => void;
@@ -125,6 +129,7 @@ function ErrorReportModal({
   recordStatusMap: StatusMap;
   recordId?: string;
   recordType: string;
+  igoQcReports?: string | null;
 }) {
   const [
     getAdvice,
@@ -273,6 +278,7 @@ function ErrorReportModal({
                 validationReport,
                 recordType,
                 recordId,
+                igoQcReports: igoQcReports ?? undefined,
               };
               console.log("[Ask AI] sending request:", vars);
               getAdvice({ variables: vars }).then((res) => {

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -4266,6 +4266,7 @@ export type Query = {
   dbGaps: Array<DbGap>;
   dbGapsAggregate: DbGapAggregateSelection;
   dbGapsConnection: DbGapsConnection;
+  getValidationAdvice?: Maybe<ValidationAdvice>;
   mafCompletes: Array<MafComplete>;
   mafCompletesAggregate: MafCompleteAggregateSelection;
   mafCompletesConnection: MafCompletesConnection;
@@ -4413,6 +4414,12 @@ export type QueryDbGapsConnectionArgs = {
   first?: InputMaybe<Scalars["Int"]>;
   sort?: InputMaybe<Array<InputMaybe<DbGapSort>>>;
   where?: InputMaybe<DbGapWhere>;
+};
+
+export type QueryGetValidationAdviceArgs = {
+  recordId?: InputMaybe<Scalars["String"]>;
+  recordType: Scalars["String"];
+  validationReport: Scalars["String"];
 };
 
 export type QueryMafCompletesArgs = {
@@ -11359,6 +11366,12 @@ export type UpdateTemposMutationResponse = {
   tempos: Array<Tempo>;
 };
 
+export type ValidationAdvice = {
+  __typename?: "ValidationAdvice";
+  advice: Scalars["String"];
+  suggestedSteps: Array<Scalars["String"]>;
+};
+
 export type DashboardRequestsQueryVariables = Exact<{
   searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
   columnFilters?: InputMaybe<
@@ -11822,6 +11835,21 @@ export type AllBlockedCohortIdsQueryVariables = Exact<{ [key: string]: never }>;
 export type AllBlockedCohortIdsQuery = {
   __typename?: "Query";
   allBlockedCohortIds: Array<string>;
+};
+
+export type GetValidationAdviceQueryVariables = Exact<{
+  validationReport: Scalars["String"];
+  recordType: Scalars["String"];
+  recordId?: InputMaybe<Scalars["String"]>;
+}>;
+
+export type GetValidationAdviceQuery = {
+  __typename?: "Query";
+  getValidationAdvice?: {
+    __typename?: "ValidationAdvice";
+    advice: string;
+    suggestedSteps: Array<string>;
+  } | null;
 };
 
 export type AllAnchorSeqDateDataQueryVariables = Exact<{
@@ -12571,6 +12599,75 @@ export type AllBlockedCohortIdsLazyQueryHookResult = ReturnType<
 export type AllBlockedCohortIdsQueryResult = Apollo.QueryResult<
   AllBlockedCohortIdsQuery,
   AllBlockedCohortIdsQueryVariables
+>;
+export const GetValidationAdviceDocument = gql`
+  query GetValidationAdvice(
+    $validationReport: String!
+    $recordType: String!
+    $recordId: String
+  ) {
+    getValidationAdvice(
+      validationReport: $validationReport
+      recordType: $recordType
+      recordId: $recordId
+    ) {
+      advice
+      suggestedSteps
+    }
+  }
+`;
+
+/**
+ * __useGetValidationAdviceQuery__
+ *
+ * To run a query within a React component, call `useGetValidationAdviceQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetValidationAdviceQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetValidationAdviceQuery({
+ *   variables: {
+ *      validationReport: // value for 'validationReport'
+ *      recordType: // value for 'recordType'
+ *      recordId: // value for 'recordId'
+ *   },
+ * });
+ */
+export function useGetValidationAdviceQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetValidationAdviceQuery,
+    GetValidationAdviceQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetValidationAdviceQuery,
+    GetValidationAdviceQueryVariables
+  >(GetValidationAdviceDocument, options);
+}
+export function useGetValidationAdviceLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetValidationAdviceQuery,
+    GetValidationAdviceQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetValidationAdviceQuery,
+    GetValidationAdviceQueryVariables
+  >(GetValidationAdviceDocument, options);
+}
+export type GetValidationAdviceQueryHookResult = ReturnType<
+  typeof useGetValidationAdviceQuery
+>;
+export type GetValidationAdviceLazyQueryHookResult = ReturnType<
+  typeof useGetValidationAdviceLazyQuery
+>;
+export type GetValidationAdviceQueryResult = Apollo.QueryResult<
+  GetValidationAdviceQuery,
+  GetValidationAdviceQueryVariables
 >;
 export const AllAnchorSeqDateDataDocument = gql`
   query AllAnchorSeqDateData($phiEnabled: Boolean = false) {

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -11,15 +11,24 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never;
+    };
 const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  BigInt: any;
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  BigInt: { input: any; output: any };
 };
 
 export enum AgGridSortDirection {
@@ -29,43 +38,43 @@ export enum AgGridSortDirection {
 
 export type AnchorSeqDateData = {
   __typename?: "AnchorSeqDateData";
-  ANCHOR_ONCOTREE_CODE: Scalars["String"];
-  ANCHOR_SEQUENCING_DATE: Scalars["String"];
-  DMP_PATIENT_ID: Scalars["String"];
-  MRN: Scalars["String"];
+  ANCHOR_ONCOTREE_CODE: Scalars["String"]["output"];
+  ANCHOR_SEQUENCING_DATE: Scalars["String"]["output"];
+  DMP_PATIENT_ID: Scalars["String"]["output"];
+  MRN: Scalars["String"]["output"];
 };
 
 export type BamComplete = {
   __typename?: "BamComplete";
-  date: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
   temposHasEvent: Array<Tempo>;
   temposHasEventAggregate?: Maybe<BamCompleteTempoTemposHasEventAggregationSelection>;
   temposHasEventConnection: BamCompleteTemposHasEventConnection;
 };
 
 export type BamCompleteTemposHasEventArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type BamCompleteTemposHasEventAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type BamCompleteTemposHasEventConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<BamCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<BamCompleteTemposHasEventConnectionWhere>;
 };
 
 export type BamCompleteAggregateSelection = {
   __typename?: "BamCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   status: StringAggregateSelection;
 };
@@ -81,8 +90,8 @@ export type BamCompleteConnectWhere = {
 };
 
 export type BamCompleteCreateInput = {
-  date: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
   temposHasEvent?: InputMaybe<BamCompleteTemposHasEventFieldInput>;
 };
 
@@ -98,13 +107,13 @@ export type BamCompleteDisconnectInput = {
 
 export type BamCompleteEdge = {
   __typename?: "BamCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: BamComplete;
 };
 
 export type BamCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more BamCompleteSort objects to sort BamCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<BamCompleteSort>>;
 };
@@ -121,7 +130,7 @@ export type BamCompleteSort = {
 
 export type BamCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "BamCompleteTempoTemposHasEventAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<BamCompleteTempoTemposHasEventNodeAggregateSelection>;
 };
 
@@ -140,18 +149,18 @@ export type BamCompleteTemposHasEventAggregateInput = {
   AND?: InputMaybe<Array<BamCompleteTemposHasEventAggregateInput>>;
   NOT?: InputMaybe<BamCompleteTemposHasEventAggregateInput>;
   OR?: InputMaybe<Array<BamCompleteTemposHasEventAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<BamCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type BamCompleteTemposHasEventConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -159,7 +168,7 @@ export type BamCompleteTemposHasEventConnection = {
   __typename?: "BamCompleteTemposHasEventConnection";
   edges: Array<BamCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type BamCompleteTemposHasEventConnectionSort = {
@@ -196,116 +205,164 @@ export type BamCompleteTemposHasEventNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<BamCompleteTemposHasEventNodeAggregationWhereInput>>;
   NOT?: InputMaybe<BamCompleteTemposHasEventNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<BamCompleteTemposHasEventNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type BamCompleteTemposHasEventRelationship = {
   __typename?: "BamCompleteTemposHasEventRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -323,8 +380,8 @@ export type BamCompleteTemposHasEventUpdateFieldInput = {
 };
 
 export type BamCompleteUpdateInput = {
-  date?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEvent?: InputMaybe<Array<BamCompleteTemposHasEventUpdateFieldInput>>;
 };
 
@@ -332,18 +389,18 @@ export type BamCompleteWhere = {
   AND?: InputMaybe<Array<BamCompleteWhere>>;
   NOT?: InputMaybe<BamCompleteWhere>;
   OR?: InputMaybe<Array<BamCompleteWhere>>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEventAggregate?: InputMaybe<BamCompleteTemposHasEventAggregateInput>;
   /** Return BamCompletes where all of the related BamCompleteTemposHasEventConnections match this filter */
   temposHasEventConnection_ALL?: InputMaybe<BamCompleteTemposHasEventConnectionWhere>;
@@ -367,20 +424,21 @@ export type BamCompletesConnection = {
   __typename?: "BamCompletesConnection";
   edges: Array<BamCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type BigIntAggregateSelection = {
   __typename?: "BigIntAggregateSelection";
-  average?: Maybe<Scalars["BigInt"]>;
-  max?: Maybe<Scalars["BigInt"]>;
-  min?: Maybe<Scalars["BigInt"]>;
-  sum?: Maybe<Scalars["BigInt"]>;
+  average?: Maybe<Scalars["BigInt"]["output"]>;
+  max?: Maybe<Scalars["BigInt"]["output"]>;
+  min?: Maybe<Scalars["BigInt"]["output"]>;
+  sum?: Maybe<Scalars["BigInt"]["output"]>;
 };
 
 export type Cohort = {
   __typename?: "Cohort";
-  cohortId: Scalars["String"];
+  cohortId: Scalars["String"]["output"];
+  cohortStatus: Scalars["String"]["output"];
   hasCohortCompleteCohortCompletes: Array<CohortComplete>;
   hasCohortCompleteCohortCompletesAggregate?: Maybe<CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection>;
   hasCohortCompleteCohortCompletesConnection: CohortHasCohortCompleteCohortCompletesConnection;
@@ -390,20 +448,20 @@ export type Cohort = {
 };
 
 export type CohortHasCohortCompleteCohortCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<CohortCompleteOptions>;
   where?: InputMaybe<CohortCompleteWhere>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<CohortCompleteWhere>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesConnectionSort>
   >;
@@ -411,20 +469,20 @@ export type CohortHasCohortCompleteCohortCompletesConnectionArgs = {
 };
 
 export type CohortHasCohortSampleSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type CohortHasCohortSampleSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type CohortHasCohortSampleSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<CohortHasCohortSampleSamplesConnectionSort>>;
   where?: InputMaybe<CohortHasCohortSampleSamplesConnectionWhere>;
 };
@@ -432,13 +490,14 @@ export type CohortHasCohortSampleSamplesConnectionArgs = {
 export type CohortAggregateSelection = {
   __typename?: "CohortAggregateSelection";
   cohortId: StringAggregateSelection;
-  count: Scalars["Int"];
+  cohortStatus: StringAggregateSelection;
+  count: Scalars["Int"]["output"];
 };
 
 export type CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection =
   {
     __typename?: "CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSelection>;
   };
 
@@ -461,32 +520,32 @@ export type CohortComplete = {
   cohortsHasCohortComplete: Array<Cohort>;
   cohortsHasCohortCompleteAggregate?: Maybe<CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection>;
   cohortsHasCohortCompleteConnection: CohortCompleteCohortsHasCohortCompleteConnection;
-  date: Scalars["String"];
-  endUsers: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  pipelineVersion?: Maybe<Scalars["String"]>;
-  pmUsers: Scalars["String"];
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
-  status: Scalars["String"];
-  type: Scalars["String"];
+  date: Scalars["String"]["output"];
+  endUsers: Scalars["String"]["output"];
+  importDate: Scalars["BigInt"]["output"];
+  pipelineVersion?: Maybe<Scalars["String"]["output"]>;
+  pmUsers: Scalars["String"]["output"];
+  projectSubtitle: Scalars["String"]["output"];
+  projectTitle: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
+  type: Scalars["String"]["output"];
 };
 
 export type CohortCompleteCohortsHasCohortCompleteArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<CohortOptions>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteConnectionSort>
   >;
@@ -495,7 +554,7 @@ export type CohortCompleteCohortsHasCohortCompleteConnectionArgs = {
 
 export type CohortCompleteAggregateSelection = {
   __typename?: "CohortCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   endUsers: StringAggregateSelection;
   importDate: BigIntAggregateSelection;
@@ -509,7 +568,7 @@ export type CohortCompleteAggregateSelection = {
 
 export type CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection = {
   __typename?: "CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection>;
 };
 
@@ -517,24 +576,25 @@ export type CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection =
   {
     __typename?: "CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection";
     cohortId: StringAggregateSelection;
+    cohortStatus: StringAggregateSelection;
   };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateInput = {
   AND?: InputMaybe<Array<CohortCompleteCohortsHasCohortCompleteAggregateInput>>;
   NOT?: InputMaybe<CohortCompleteCohortsHasCohortCompleteAggregateInput>;
   OR?: InputMaybe<Array<CohortCompleteCohortsHasCohortCompleteAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteConnectFieldInput = {
   connect?: InputMaybe<Array<CohortConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<CohortConnectWhere>;
 };
 
@@ -542,7 +602,7 @@ export type CohortCompleteCohortsHasCohortCompleteConnection = {
   __typename?: "CohortCompleteCohortsHasCohortCompleteConnection";
   edges: Array<CohortCompleteCohortsHasCohortCompleteRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortCompleteCohortsHasCohortCompleteConnectionSort = {
@@ -589,26 +649,41 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput>
   >;
-  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteRelationship = {
   __typename?: "CohortCompleteCohortsHasCohortCompleteRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Cohort;
 };
 
@@ -645,15 +720,15 @@ export type CohortCompleteConnectWhere = {
 
 export type CohortCompleteCreateInput = {
   cohortsHasCohortComplete?: InputMaybe<CohortCompleteCohortsHasCohortCompleteFieldInput>;
-  date: Scalars["String"];
-  endUsers: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pmUsers: Scalars["String"];
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
-  status: Scalars["String"];
-  type: Scalars["String"];
+  date: Scalars["String"]["input"];
+  endUsers: Scalars["String"]["input"];
+  importDate: Scalars["BigInt"]["input"];
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers: Scalars["String"]["input"];
+  projectSubtitle: Scalars["String"]["input"];
+  projectTitle: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
+  type: Scalars["String"]["input"];
 };
 
 export type CohortCompleteDeleteInput = {
@@ -670,13 +745,13 @@ export type CohortCompleteDisconnectInput = {
 
 export type CohortCompleteEdge = {
   __typename?: "CohortCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: CohortComplete;
 };
 
 export type CohortCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more CohortCompleteSort objects to sort CohortCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<CohortCompleteSort>>;
 };
@@ -704,17 +779,17 @@ export type CohortCompleteUpdateInput = {
   cohortsHasCohortComplete?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteUpdateFieldInput>
   >;
-  date?: InputMaybe<Scalars["String"]>;
-  endUsers?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Scalars["String"]>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  type?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type CohortCompleteWhere = {
@@ -738,67 +813,69 @@ export type CohortCompleteWhere = {
   cohortsHasCohortComplete_SINGLE?: InputMaybe<CohortWhere>;
   /** Return CohortCompletes where some of the related Cohorts match this filter */
   cohortsHasCohortComplete_SOME?: InputMaybe<CohortWhere>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  endUsers?: InputMaybe<Scalars["String"]>;
-  endUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
-  endUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  endUsers_IN?: InputMaybe<Array<Scalars["String"]>>;
-  endUsers_MATCHES?: InputMaybe<Scalars["String"]>;
-  endUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]>>;
-  importDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_CONTAINS?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pipelineVersion_MATCHES?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Scalars["String"]>;
-  pmUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
-  pmUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  pmUsers_IN?: InputMaybe<Array<Scalars["String"]>>;
-  pmUsers_MATCHES?: InputMaybe<Scalars["String"]>;
-  pmUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_IN?: InputMaybe<Array<Scalars["String"]>>;
-  projectSubtitle_MATCHES?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
-  projectTitle_CONTAINS?: InputMaybe<Scalars["String"]>;
-  projectTitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectTitle_IN?: InputMaybe<Array<Scalars["String"]>>;
-  projectTitle_MATCHES?: InputMaybe<Scalars["String"]>;
-  projectTitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  type?: InputMaybe<Scalars["String"]>;
-  type_CONTAINS?: InputMaybe<Scalars["String"]>;
-  type_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  type_IN?: InputMaybe<Array<Scalars["String"]>>;
-  type_MATCHES?: InputMaybe<Scalars["String"]>;
-  type_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  endUsers_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  importDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  pipelineVersion_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  pmUsers_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  projectSubtitle_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  projectTitle_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
+  type_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  type_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  type_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  type_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  type_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type CohortCompletesConnection = {
   __typename?: "CohortCompletesConnection";
   edges: Array<CohortCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortConnectInput = {
@@ -815,7 +892,8 @@ export type CohortConnectWhere = {
 };
 
 export type CohortCreateInput = {
-  cohortId: Scalars["String"];
+  cohortId: Scalars["String"]["input"];
+  cohortStatus: Scalars["String"]["input"];
   hasCohortCompleteCohortCompletes?: InputMaybe<CohortHasCohortCompleteCohortCompletesFieldInput>;
   hasCohortSampleSamples?: InputMaybe<CohortHasCohortSampleSamplesFieldInput>;
 };
@@ -840,7 +918,7 @@ export type CohortDisconnectInput = {
 
 export type CohortEdge = {
   __typename?: "CohortEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Cohort;
 };
 
@@ -848,18 +926,18 @@ export type CohortHasCohortCompleteCohortCompletesAggregateInput = {
   AND?: InputMaybe<Array<CohortHasCohortCompleteCohortCompletesAggregateInput>>;
   NOT?: InputMaybe<CohortHasCohortCompleteCohortCompletesAggregateInput>;
   OR?: InputMaybe<Array<CohortHasCohortCompleteCohortCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<CohortCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<CohortCompleteConnectWhere>;
 };
 
@@ -867,7 +945,7 @@ export type CohortHasCohortCompleteCohortCompletesConnection = {
   __typename?: "CohortHasCohortCompleteCohortCompletesConnection";
   edges: Array<CohortHasCohortCompleteCohortCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortHasCohortCompleteCohortCompletesConnectionSort = {
@@ -914,151 +992,151 @@ export type CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput>
   >;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  endUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  pipelineVersion_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  pmUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectTitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  type_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  type_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  type_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesRelationship = {
   __typename?: "CohortHasCohortCompleteCohortCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: CohortComplete;
 };
 
@@ -1087,18 +1165,18 @@ export type CohortHasCohortSampleSamplesAggregateInput = {
   AND?: InputMaybe<Array<CohortHasCohortSampleSamplesAggregateInput>>;
   NOT?: InputMaybe<CohortHasCohortSampleSamplesAggregateInput>;
   OR?: InputMaybe<Array<CohortHasCohortSampleSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<CohortHasCohortSampleSamplesNodeAggregationWhereInput>;
 };
 
 export type CohortHasCohortSampleSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -1106,7 +1184,7 @@ export type CohortHasCohortSampleSamplesConnection = {
   __typename?: "CohortHasCohortSampleSamplesConnection";
   edges: Array<CohortHasCohortSampleSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortHasCohortSampleSamplesConnectionSort = {
@@ -1145,71 +1223,71 @@ export type CohortHasCohortSampleSamplesNodeAggregationWhereInput = {
   >;
   NOT?: InputMaybe<CohortHasCohortSampleSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<CohortHasCohortSampleSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type CohortHasCohortSampleSamplesRelationship = {
   __typename?: "CohortHasCohortSampleSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -1229,8 +1307,8 @@ export type CohortHasCohortSampleSamplesUpdateFieldInput = {
 };
 
 export type CohortOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more CohortSort objects to sort Cohorts by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<CohortSort>>;
 };
@@ -1246,7 +1324,7 @@ export type CohortRelationInput = {
 
 export type CohortSampleHasCohortSampleSamplesAggregationSelection = {
   __typename?: "CohortSampleHasCohortSampleSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<CohortSampleHasCohortSampleSamplesNodeAggregateSelection>;
 };
 
@@ -1261,10 +1339,12 @@ export type CohortSampleHasCohortSampleSamplesNodeAggregateSelection = {
 /** Fields to sort Cohorts by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortSort object. */
 export type CohortSort = {
   cohortId?: InputMaybe<SortDirection>;
+  cohortStatus?: InputMaybe<SortDirection>;
 };
 
 export type CohortUpdateInput = {
-  cohortId?: InputMaybe<Scalars["String"]>;
+  cohortId?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus?: InputMaybe<Scalars["String"]["input"]>;
   hasCohortCompleteCohortCompletes?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesUpdateFieldInput>
   >;
@@ -1277,12 +1357,18 @@ export type CohortWhere = {
   AND?: InputMaybe<Array<CohortWhere>>;
   NOT?: InputMaybe<CohortWhere>;
   OR?: InputMaybe<Array<CohortWhere>>;
-  cohortId?: InputMaybe<Scalars["String"]>;
-  cohortId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cohortId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cohortId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  cohortId_MATCHES?: InputMaybe<Scalars["String"]>;
-  cohortId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cohortId?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  cohortId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  cohortStatus_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasCohortCompleteCohortCompletesAggregate?: InputMaybe<CohortHasCohortCompleteCohortCompletesAggregateInput>;
   /** Return Cohorts where all of the related CohortHasCohortCompleteCohortCompletesConnections match this filter */
   hasCohortCompleteCohortCompletesConnection_ALL?: InputMaybe<CohortHasCohortCompleteCohortCompletesConnectionWhere>;
@@ -1323,7 +1409,7 @@ export type CohortsConnection = {
   __typename?: "CohortsConnection";
   edges: Array<CohortEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CreateBamCompletesMutationResponse = {
@@ -1354,9 +1440,9 @@ export type CreateDbGapsMutationResponse = {
 export type CreateInfo = {
   __typename?: "CreateInfo";
   /** @deprecated This field has been deprecated because bookmarks are now handled by the driver. */
-  bookmark?: Maybe<Scalars["String"]>;
-  nodesCreated: Scalars["Int"];
-  relationshipsCreated: Scalars["Int"];
+  bookmark?: Maybe<Scalars["String"]["output"]>;
+  nodesCreated: Scalars["Int"]["output"];
+  relationshipsCreated: Scalars["Int"]["output"];
 };
 
 export type CreateMafCompletesMutationResponse = {
@@ -1433,265 +1519,265 @@ export type CreateTemposMutationResponse = {
 
 export type DashboardCohort = {
   __typename?: "DashboardCohort";
-  _total?: Maybe<Scalars["Int"]>;
-  _uniqueSampleCount?: Maybe<Scalars["Int"]>;
-  billed?: Maybe<Scalars["String"]>;
-  cohortId: Scalars["String"];
-  endUsers?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
-  initialCohortDeliveryDate?: Maybe<Scalars["String"]>;
-  pipelineVersion?: Maybe<Scalars["String"]>;
-  pmUsers?: Maybe<Scalars["String"]>;
-  projectSubtitle?: Maybe<Scalars["String"]>;
-  projectTitle?: Maybe<Scalars["String"]>;
-  searchableSampleIds?: Maybe<Scalars["String"]>;
-  status?: Maybe<Scalars["String"]>;
-  totalSampleCount?: Maybe<Scalars["Int"]>;
-  type?: Maybe<Scalars["String"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  _uniqueSampleCount?: Maybe<Scalars["Int"]["output"]>;
+  billed?: Maybe<Scalars["String"]["output"]>;
+  cohortId: Scalars["String"]["output"];
+  endUsers?: Maybe<Scalars["String"]["output"]>;
+  importDate?: Maybe<Scalars["String"]["output"]>;
+  initialCohortDeliveryDate?: Maybe<Scalars["String"]["output"]>;
+  pipelineVersion?: Maybe<Scalars["String"]["output"]>;
+  pmUsers?: Maybe<Scalars["String"]["output"]>;
+  projectSubtitle?: Maybe<Scalars["String"]["output"]>;
+  projectTitle?: Maybe<Scalars["String"]["output"]>;
+  searchableSampleIds?: Maybe<Scalars["String"]["output"]>;
+  status?: Maybe<Scalars["String"]["output"]>;
+  totalSampleCount?: Maybe<Scalars["Int"]["output"]>;
+  type?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type DashboardCohortInput = {
-  _total?: InputMaybe<Scalars["Int"]>;
-  _uniqueSampleCount?: InputMaybe<Scalars["Int"]>;
-  billed?: InputMaybe<Scalars["String"]>;
-  changedFieldNames: Array<Scalars["String"]>;
-  changelog?: InputMaybe<Scalars["String"]>;
-  cohortId: Scalars["String"];
-  endUsers?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["String"]>;
-  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Scalars["String"]>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
-  searchableSampleIds?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  totalSampleCount?: InputMaybe<Scalars["Int"]>;
-  type?: InputMaybe<Scalars["String"]>;
+  _total?: InputMaybe<Scalars["Int"]["input"]>;
+  _uniqueSampleCount?: InputMaybe<Scalars["Int"]["input"]>;
+  billed?: InputMaybe<Scalars["String"]["input"]>;
+  changedFieldNames: Array<Scalars["String"]["input"]>;
+  changelog?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId: Scalars["String"]["input"];
+  endUsers?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["String"]["input"]>;
+  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle?: InputMaybe<Scalars["String"]["input"]>;
+  searchableSampleIds?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type DashboardPatient = {
   __typename?: "DashboardPatient";
-  _total?: Maybe<Scalars["Int"]>;
-  anchorOncotreeCode?: Maybe<Scalars["String"]>;
-  anchorSequencingDate?: Maybe<Scalars["String"]>;
-  cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleIds?: Maybe<Scalars["String"]>;
-  consentPartA?: Maybe<Scalars["String"]>;
-  consentPartC?: Maybe<Scalars["String"]>;
-  dmpPatientId?: Maybe<Scalars["String"]>;
-  inDbGap?: Maybe<Scalars["Boolean"]>;
-  mrn?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  smilePatientId: Scalars["String"];
-  totalSampleCount?: Maybe<Scalars["Int"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  anchorOncotreeCode?: Maybe<Scalars["String"]["output"]>;
+  anchorSequencingDate?: Maybe<Scalars["String"]["output"]>;
+  cmoPatientId?: Maybe<Scalars["String"]["output"]>;
+  cmoSampleIds?: Maybe<Scalars["String"]["output"]>;
+  consentPartA?: Maybe<Scalars["String"]["output"]>;
+  consentPartC?: Maybe<Scalars["String"]["output"]>;
+  dmpPatientId?: Maybe<Scalars["String"]["output"]>;
+  inDbGap?: Maybe<Scalars["Boolean"]["output"]>;
+  mrn?: Maybe<Scalars["String"]["output"]>;
+  race?: Maybe<Scalars["String"]["output"]>;
+  smilePatientId: Scalars["String"]["output"];
+  totalSampleCount?: Maybe<Scalars["Int"]["output"]>;
 };
 
 export type DashboardRecordColumnFilter = {
-  field: Scalars["String"];
-  filter: Scalars["String"];
+  field: Scalars["String"]["input"];
+  filter: Scalars["String"]["input"];
 };
 
 export type DashboardRecordContext = {
-  fieldName?: InputMaybe<Scalars["String"]>;
-  values: Array<Scalars["String"]>;
+  fieldName?: InputMaybe<Scalars["String"]["input"]>;
+  values: Array<Scalars["String"]["input"]>;
 };
 
 export type DashboardRecordSort = {
-  colId: Scalars["String"];
+  colId: Scalars["String"]["input"];
   sort: AgGridSortDirection;
 };
 
 export type DashboardRequest = {
   __typename?: "DashboardRequest";
-  _total?: Maybe<Scalars["Int"]>;
-  bicAnalysis?: Maybe<Scalars["Boolean"]>;
-  dataAccessEmails?: Maybe<Scalars["String"]>;
-  dataAnalystEmail?: Maybe<Scalars["String"]>;
-  dataAnalystName?: Maybe<Scalars["String"]>;
-  genePanel?: Maybe<Scalars["String"]>;
-  igoDeliveryDate?: Maybe<Scalars["String"]>;
-  igoProjectId?: Maybe<Scalars["String"]>;
-  igoRequestId: Scalars["String"];
-  ilabRequestId?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
-  investigatorEmail?: Maybe<Scalars["String"]>;
-  investigatorName?: Maybe<Scalars["String"]>;
-  isCmoRequest?: Maybe<Scalars["Boolean"]>;
-  labHeadEmail?: Maybe<Scalars["String"]>;
-  labHeadName?: Maybe<Scalars["String"]>;
-  otherContactEmails?: Maybe<Scalars["String"]>;
-  piEmail?: Maybe<Scalars["String"]>;
-  projectManagerName?: Maybe<Scalars["String"]>;
-  qcAccessEmails?: Maybe<Scalars["String"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  bicAnalysis?: Maybe<Scalars["Boolean"]["output"]>;
+  dataAccessEmails?: Maybe<Scalars["String"]["output"]>;
+  dataAnalystEmail?: Maybe<Scalars["String"]["output"]>;
+  dataAnalystName?: Maybe<Scalars["String"]["output"]>;
+  genePanel?: Maybe<Scalars["String"]["output"]>;
+  igoDeliveryDate?: Maybe<Scalars["String"]["output"]>;
+  igoProjectId?: Maybe<Scalars["String"]["output"]>;
+  igoRequestId: Scalars["String"]["output"];
+  ilabRequestId?: Maybe<Scalars["String"]["output"]>;
+  importDate?: Maybe<Scalars["String"]["output"]>;
+  investigatorEmail?: Maybe<Scalars["String"]["output"]>;
+  investigatorName?: Maybe<Scalars["String"]["output"]>;
+  isCmoRequest?: Maybe<Scalars["Boolean"]["output"]>;
+  labHeadEmail?: Maybe<Scalars["String"]["output"]>;
+  labHeadName?: Maybe<Scalars["String"]["output"]>;
+  otherContactEmails?: Maybe<Scalars["String"]["output"]>;
+  piEmail?: Maybe<Scalars["String"]["output"]>;
+  projectManagerName?: Maybe<Scalars["String"]["output"]>;
+  qcAccessEmails?: Maybe<Scalars["String"]["output"]>;
   toleratedSampleErrors?: Maybe<Array<Maybe<ToleratedSampleValidationError>>>;
-  totalSampleCount?: Maybe<Scalars["Int"]>;
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  totalSampleCount?: Maybe<Scalars["Int"]["output"]>;
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type DashboardSample = {
   __typename?: "DashboardSample";
-  _total?: Maybe<Scalars["Int"]>;
-  accessLevel?: Maybe<Scalars["String"]>;
-  altId?: Maybe<Scalars["String"]>;
-  analyteType?: Maybe<Scalars["String"]>;
-  baitSet?: Maybe<Scalars["String"]>;
-  bamCompleteDate?: Maybe<Scalars["String"]>;
-  bamCompleteStatus?: Maybe<Scalars["String"]>;
-  billed?: Maybe<Scalars["Boolean"]>;
-  billedBy?: Maybe<Scalars["String"]>;
-  cancerType?: Maybe<Scalars["String"]>;
-  cancerTypeDetailed?: Maybe<Scalars["String"]>;
-  cfDNA2dBarcode?: Maybe<Scalars["String"]>;
-  changelog?: Maybe<Scalars["String"]>;
-  cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleName?: Maybe<Scalars["String"]>;
-  collectionYear?: Maybe<Scalars["String"]>;
-  costCenter?: Maybe<Scalars["String"]>;
-  custodianInformation?: Maybe<Scalars["String"]>;
-  dbGapStudy?: Maybe<Scalars["String"]>;
-  dmpPatientAlias?: Maybe<Scalars["String"]>;
-  dmpRecommendedCoverage?: Maybe<Scalars["String"]>;
-  embargoDate?: Maybe<Scalars["String"]>;
-  genePanel?: Maybe<Scalars["String"]>;
-  historicalCmoSampleNames?: Maybe<Scalars["String"]>;
-  igoComplete?: Maybe<Scalars["Boolean"]>;
-  igoDeliveryDate?: Maybe<Scalars["String"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  accessLevel?: Maybe<Scalars["String"]["output"]>;
+  altId?: Maybe<Scalars["String"]["output"]>;
+  analyteType?: Maybe<Scalars["String"]["output"]>;
+  baitSet?: Maybe<Scalars["String"]["output"]>;
+  bamCompleteDate?: Maybe<Scalars["String"]["output"]>;
+  bamCompleteStatus?: Maybe<Scalars["String"]["output"]>;
+  billed?: Maybe<Scalars["Boolean"]["output"]>;
+  billedBy?: Maybe<Scalars["String"]["output"]>;
+  cancerType?: Maybe<Scalars["String"]["output"]>;
+  cancerTypeDetailed?: Maybe<Scalars["String"]["output"]>;
+  cfDNA2dBarcode?: Maybe<Scalars["String"]["output"]>;
+  changelog?: Maybe<Scalars["String"]["output"]>;
+  cmoPatientId?: Maybe<Scalars["String"]["output"]>;
+  cmoSampleName?: Maybe<Scalars["String"]["output"]>;
+  collectionYear?: Maybe<Scalars["String"]["output"]>;
+  costCenter?: Maybe<Scalars["String"]["output"]>;
+  custodianInformation?: Maybe<Scalars["String"]["output"]>;
+  dbGapStudy?: Maybe<Scalars["String"]["output"]>;
+  dmpPatientAlias?: Maybe<Scalars["String"]["output"]>;
+  dmpRecommendedCoverage?: Maybe<Scalars["String"]["output"]>;
+  embargoDate?: Maybe<Scalars["String"]["output"]>;
+  genePanel?: Maybe<Scalars["String"]["output"]>;
+  historicalCmoSampleNames?: Maybe<Scalars["String"]["output"]>;
+  igoComplete?: Maybe<Scalars["Boolean"]["output"]>;
+  igoDeliveryDate?: Maybe<Scalars["String"]["output"]>;
   igoQcReports?: Maybe<Array<Maybe<IgoQcReport>>>;
-  igoSampleStatus?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
-  initialPipelineRunDate?: Maybe<Scalars["String"]>;
-  instrumentModel?: Maybe<Scalars["String"]>;
-  investigatorSampleId?: Maybe<Scalars["String"]>;
-  irbConsentProtocol?: Maybe<Scalars["String"]>;
-  mafCompleteDate?: Maybe<Scalars["String"]>;
-  mafCompleteNormalPrimaryId?: Maybe<Scalars["String"]>;
-  mafCompleteStatus?: Maybe<Scalars["String"]>;
-  molecularAccessionNumber?: Maybe<Scalars["String"]>;
-  oncotreeCode?: Maybe<Scalars["String"]>;
-  platform?: Maybe<Scalars["String"]>;
-  preservation?: Maybe<Scalars["String"]>;
-  primaryId?: Maybe<Scalars["String"]>;
-  qcCompleteDate?: Maybe<Scalars["String"]>;
-  qcCompleteReason?: Maybe<Scalars["String"]>;
-  qcCompleteResult?: Maybe<Scalars["String"]>;
-  qcCompleteStatus?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  recipe?: Maybe<Scalars["String"]>;
-  recordId: Scalars["String"];
-  revisable?: Maybe<Scalars["Boolean"]>;
-  sampleCategory: Scalars["String"];
-  sampleClass?: Maybe<Scalars["String"]>;
-  sampleCohortIds?: Maybe<Scalars["String"]>;
-  sampleOrigin?: Maybe<Scalars["String"]>;
-  sampleType?: Maybe<Scalars["String"]>;
-  sequencingDate?: Maybe<Scalars["String"]>;
-  sex?: Maybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
-  species?: Maybe<Scalars["String"]>;
-  tissueLocation?: Maybe<Scalars["String"]>;
-  tumorOrNormal?: Maybe<Scalars["String"]>;
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  igoSampleStatus?: Maybe<Scalars["String"]["output"]>;
+  importDate?: Maybe<Scalars["String"]["output"]>;
+  initialPipelineRunDate?: Maybe<Scalars["String"]["output"]>;
+  instrumentModel?: Maybe<Scalars["String"]["output"]>;
+  investigatorSampleId?: Maybe<Scalars["String"]["output"]>;
+  irbConsentProtocol?: Maybe<Scalars["String"]["output"]>;
+  mafCompleteDate?: Maybe<Scalars["String"]["output"]>;
+  mafCompleteNormalPrimaryId?: Maybe<Scalars["String"]["output"]>;
+  mafCompleteStatus?: Maybe<Scalars["String"]["output"]>;
+  molecularAccessionNumber?: Maybe<Scalars["String"]["output"]>;
+  oncotreeCode?: Maybe<Scalars["String"]["output"]>;
+  platform?: Maybe<Scalars["String"]["output"]>;
+  preservation?: Maybe<Scalars["String"]["output"]>;
+  primaryId?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteDate?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteReason?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteResult?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteStatus?: Maybe<Scalars["String"]["output"]>;
+  race?: Maybe<Scalars["String"]["output"]>;
+  recipe?: Maybe<Scalars["String"]["output"]>;
+  recordId: Scalars["String"]["output"];
+  revisable?: Maybe<Scalars["Boolean"]["output"]>;
+  sampleCategory: Scalars["String"]["output"];
+  sampleClass?: Maybe<Scalars["String"]["output"]>;
+  sampleCohortIds?: Maybe<Scalars["String"]["output"]>;
+  sampleOrigin?: Maybe<Scalars["String"]["output"]>;
+  sampleType?: Maybe<Scalars["String"]["output"]>;
+  sequencingDate?: Maybe<Scalars["String"]["output"]>;
+  sex?: Maybe<Scalars["String"]["output"]>;
+  smileSampleId: Scalars["String"]["output"];
+  species?: Maybe<Scalars["String"]["output"]>;
+  tissueLocation?: Maybe<Scalars["String"]["output"]>;
+  tumorOrNormal?: Maybe<Scalars["String"]["output"]>;
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type DashboardSampleInput = {
-  _total?: InputMaybe<Scalars["Int"]>;
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  altId?: InputMaybe<Scalars["String"]>;
-  analyteType?: InputMaybe<Scalars["String"]>;
-  baitSet?: InputMaybe<Scalars["String"]>;
-  bamCompleteDate?: InputMaybe<Scalars["String"]>;
-  bamCompleteStatus?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  cancerType?: InputMaybe<Scalars["String"]>;
-  cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  changedFieldNames: Array<Scalars["String"]>;
-  changelog?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  dbGapStudy?: InputMaybe<Scalars["String"]>;
-  dmpPatientAlias?: InputMaybe<Scalars["String"]>;
-  dmpRecommendedCoverage?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
-  historicalCmoSampleNames?: InputMaybe<Scalars["String"]>;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoDeliveryDate?: InputMaybe<Scalars["String"]>;
-  igoSampleStatus?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
-  instrumentModel?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  irbConsentProtocol?: InputMaybe<Scalars["String"]>;
-  mafCompleteDate?: InputMaybe<Scalars["String"]>;
-  mafCompleteNormalPrimaryId?: InputMaybe<Scalars["String"]>;
-  mafCompleteStatus?: InputMaybe<Scalars["String"]>;
-  molecularAccessionNumber?: InputMaybe<Scalars["String"]>;
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  platform?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
-  qcCompleteDate?: InputMaybe<Scalars["String"]>;
-  qcCompleteReason?: InputMaybe<Scalars["String"]>;
-  qcCompleteResult?: InputMaybe<Scalars["String"]>;
-  qcCompleteStatus?: InputMaybe<Scalars["String"]>;
-  race?: InputMaybe<Scalars["String"]>;
-  recipe?: InputMaybe<Scalars["String"]>;
-  recordId: Scalars["String"];
-  revisable?: InputMaybe<Scalars["Boolean"]>;
-  sampleCategory: Scalars["String"];
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleCohortIds?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
-  sequencingDate?: InputMaybe<Scalars["String"]>;
-  sex?: InputMaybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
-  species?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  _total?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  altId?: InputMaybe<Scalars["String"]["input"]>;
+  analyteType?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  bamCompleteDate?: InputMaybe<Scalars["String"]["input"]>;
+  bamCompleteStatus?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  cancerType?: InputMaybe<Scalars["String"]["input"]>;
+  cancerTypeDetailed?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  changedFieldNames: Array<Scalars["String"]["input"]>;
+  changelog?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy?: InputMaybe<Scalars["String"]["input"]>;
+  dmpPatientAlias?: InputMaybe<Scalars["String"]["input"]>;
+  dmpRecommendedCoverage?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
+  historicalCmoSampleNames?: InputMaybe<Scalars["String"]["input"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoDeliveryDate?: InputMaybe<Scalars["String"]["input"]>;
+  igoSampleStatus?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
+  instrumentModel?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  irbConsentProtocol?: InputMaybe<Scalars["String"]["input"]>;
+  mafCompleteDate?: InputMaybe<Scalars["String"]["input"]>;
+  mafCompleteNormalPrimaryId?: InputMaybe<Scalars["String"]["input"]>;
+  mafCompleteStatus?: InputMaybe<Scalars["String"]["input"]>;
+  molecularAccessionNumber?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  platform?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteDate?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteReason?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteResult?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteStatus?: InputMaybe<Scalars["String"]["input"]>;
+  race?: InputMaybe<Scalars["String"]["input"]>;
+  recipe?: InputMaybe<Scalars["String"]["input"]>;
+  recordId: Scalars["String"]["input"];
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
+  sampleCategory: Scalars["String"]["input"];
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCohortIds?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
+  sequencingDate?: InputMaybe<Scalars["String"]["input"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId: Scalars["String"]["input"];
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type DbGap = {
   __typename?: "DbGap";
-  dbGapStudy: Scalars["String"];
+  dbGapStudy: Scalars["String"]["output"];
   samplesHasDbgap: Array<Sample>;
   samplesHasDbgapAggregate?: Maybe<DbGapSampleSamplesHasDbgapAggregationSelection>;
   samplesHasDbgapConnection: DbGapSamplesHasDbgapConnection;
-  smileDbGapId: Scalars["String"];
+  smileDbGapId: Scalars["String"]["output"];
 };
 
 export type DbGapSamplesHasDbgapArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type DbGapSamplesHasDbgapAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type DbGapSamplesHasDbgapConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<DbGapSamplesHasDbgapConnectionSort>>;
   where?: InputMaybe<DbGapSamplesHasDbgapConnectionWhere>;
 };
 
 export type DbGapAggregateSelection = {
   __typename?: "DbGapAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   dbGapStudy: StringAggregateSelection;
   smileDbGapId: StringAggregateSelection;
 };
@@ -1705,9 +1791,9 @@ export type DbGapConnectWhere = {
 };
 
 export type DbGapCreateInput = {
-  dbGapStudy: Scalars["String"];
+  dbGapStudy: Scalars["String"]["input"];
   samplesHasDbgap?: InputMaybe<DbGapSamplesHasDbgapFieldInput>;
-  smileDbGapId: Scalars["String"];
+  smileDbGapId: Scalars["String"]["input"];
 };
 
 export type DbGapDeleteInput = {
@@ -1720,13 +1806,13 @@ export type DbGapDisconnectInput = {
 
 export type DbGapEdge = {
   __typename?: "DbGapEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: DbGap;
 };
 
 export type DbGapOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more DbGapSort objects to sort DbGaps by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<DbGapSort>>;
 };
@@ -1737,7 +1823,7 @@ export type DbGapRelationInput = {
 
 export type DbGapSampleSamplesHasDbgapAggregationSelection = {
   __typename?: "DbGapSampleSamplesHasDbgapAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<DbGapSampleSamplesHasDbgapNodeAggregateSelection>;
 };
 
@@ -1753,18 +1839,18 @@ export type DbGapSamplesHasDbgapAggregateInput = {
   AND?: InputMaybe<Array<DbGapSamplesHasDbgapAggregateInput>>;
   NOT?: InputMaybe<DbGapSamplesHasDbgapAggregateInput>;
   OR?: InputMaybe<Array<DbGapSamplesHasDbgapAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<DbGapSamplesHasDbgapNodeAggregationWhereInput>;
 };
 
 export type DbGapSamplesHasDbgapConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -1772,7 +1858,7 @@ export type DbGapSamplesHasDbgapConnection = {
   __typename?: "DbGapSamplesHasDbgapConnection";
   edges: Array<DbGapSamplesHasDbgapRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type DbGapSamplesHasDbgapConnectionSort = {
@@ -1809,71 +1895,71 @@ export type DbGapSamplesHasDbgapNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<DbGapSamplesHasDbgapNodeAggregationWhereInput>>;
   NOT?: InputMaybe<DbGapSamplesHasDbgapNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<DbGapSamplesHasDbgapNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type DbGapSamplesHasDbgapRelationship = {
   __typename?: "DbGapSamplesHasDbgapRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -1897,21 +1983,21 @@ export type DbGapSort = {
 };
 
 export type DbGapUpdateInput = {
-  dbGapStudy?: InputMaybe<Scalars["String"]>;
+  dbGapStudy?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasDbgap?: InputMaybe<Array<DbGapSamplesHasDbgapUpdateFieldInput>>;
-  smileDbGapId?: InputMaybe<Scalars["String"]>;
+  smileDbGapId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type DbGapWhere = {
   AND?: InputMaybe<Array<DbGapWhere>>;
   NOT?: InputMaybe<DbGapWhere>;
   OR?: InputMaybe<Array<DbGapWhere>>;
-  dbGapStudy?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dbGapStudy_MATCHES?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  dbGapStudy?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dbGapStudy_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasDbgapAggregate?: InputMaybe<DbGapSamplesHasDbgapAggregateInput>;
   /** Return DbGaps where all of the related DbGapSamplesHasDbgapConnections match this filter */
   samplesHasDbgapConnection_ALL?: InputMaybe<DbGapSamplesHasDbgapConnectionWhere>;
@@ -1929,70 +2015,70 @@ export type DbGapWhere = {
   samplesHasDbgap_SINGLE?: InputMaybe<SampleWhere>;
   /** Return DbGaps where some of the related Samples match this filter */
   samplesHasDbgap_SOME?: InputMaybe<SampleWhere>;
-  smileDbGapId?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileDbGapId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smileDbGapId?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileDbGapId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type DbGapsConnection = {
   __typename?: "DbGapsConnection";
   edges: Array<DbGapEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 /** Information about the number of nodes and relationships deleted during a delete mutation */
 export type DeleteInfo = {
   __typename?: "DeleteInfo";
   /** @deprecated This field has been deprecated because bookmarks are now handled by the driver. */
-  bookmark?: Maybe<Scalars["String"]>;
-  nodesDeleted: Scalars["Int"];
-  relationshipsDeleted: Scalars["Int"];
+  bookmark?: Maybe<Scalars["String"]["output"]>;
+  nodesDeleted: Scalars["Int"]["output"];
+  relationshipsDeleted: Scalars["Int"]["output"];
 };
 
 export type IgoQcReport = {
   __typename?: "IgoQcReport";
-  IGORecommendation?: Maybe<Scalars["String"]>;
-  comments?: Maybe<Scalars["String"]>;
-  investigatorDecision?: Maybe<Scalars["String"]>;
-  qcReportType?: Maybe<Scalars["String"]>;
+  IGORecommendation?: Maybe<Scalars["String"]["output"]>;
+  comments?: Maybe<Scalars["String"]["output"]>;
+  investigatorDecision?: Maybe<Scalars["String"]["output"]>;
+  qcReportType?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type MafComplete = {
   __typename?: "MafComplete";
-  date: Scalars["String"];
-  normalPrimaryId: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["output"];
+  normalPrimaryId: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
   temposHasEvent: Array<Tempo>;
   temposHasEventAggregate?: Maybe<MafCompleteTempoTemposHasEventAggregationSelection>;
   temposHasEventConnection: MafCompleteTemposHasEventConnection;
 };
 
 export type MafCompleteTemposHasEventArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type MafCompleteTemposHasEventAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type MafCompleteTemposHasEventConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<MafCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<MafCompleteTemposHasEventConnectionWhere>;
 };
 
 export type MafCompleteAggregateSelection = {
   __typename?: "MafCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   normalPrimaryId: StringAggregateSelection;
   status: StringAggregateSelection;
@@ -2009,9 +2095,9 @@ export type MafCompleteConnectWhere = {
 };
 
 export type MafCompleteCreateInput = {
-  date: Scalars["String"];
-  normalPrimaryId: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["input"];
+  normalPrimaryId: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
   temposHasEvent?: InputMaybe<MafCompleteTemposHasEventFieldInput>;
 };
 
@@ -2027,13 +2113,13 @@ export type MafCompleteDisconnectInput = {
 
 export type MafCompleteEdge = {
   __typename?: "MafCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: MafComplete;
 };
 
 export type MafCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more MafCompleteSort objects to sort MafCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<MafCompleteSort>>;
 };
@@ -2051,7 +2137,7 @@ export type MafCompleteSort = {
 
 export type MafCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "MafCompleteTempoTemposHasEventAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<MafCompleteTempoTemposHasEventNodeAggregateSelection>;
 };
 
@@ -2070,18 +2156,18 @@ export type MafCompleteTemposHasEventAggregateInput = {
   AND?: InputMaybe<Array<MafCompleteTemposHasEventAggregateInput>>;
   NOT?: InputMaybe<MafCompleteTemposHasEventAggregateInput>;
   OR?: InputMaybe<Array<MafCompleteTemposHasEventAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<MafCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type MafCompleteTemposHasEventConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -2089,7 +2175,7 @@ export type MafCompleteTemposHasEventConnection = {
   __typename?: "MafCompleteTemposHasEventConnection";
   edges: Array<MafCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type MafCompleteTemposHasEventConnectionSort = {
@@ -2126,116 +2212,164 @@ export type MafCompleteTemposHasEventNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<MafCompleteTemposHasEventNodeAggregationWhereInput>>;
   NOT?: InputMaybe<MafCompleteTemposHasEventNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<MafCompleteTemposHasEventNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type MafCompleteTemposHasEventRelationship = {
   __typename?: "MafCompleteTemposHasEventRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -2253,9 +2387,9 @@ export type MafCompleteTemposHasEventUpdateFieldInput = {
 };
 
 export type MafCompleteUpdateInput = {
-  date?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEvent?: InputMaybe<Array<MafCompleteTemposHasEventUpdateFieldInput>>;
 };
 
@@ -2263,24 +2397,24 @@ export type MafCompleteWhere = {
   AND?: InputMaybe<Array<MafCompleteWhere>>;
   NOT?: InputMaybe<MafCompleteWhere>;
   OR?: InputMaybe<Array<MafCompleteWhere>>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  normalPrimaryId_MATCHES?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  normalPrimaryId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEventAggregate?: InputMaybe<MafCompleteTemposHasEventAggregateInput>;
   /** Return MafCompletes where all of the related MafCompleteTemposHasEventConnections match this filter */
   temposHasEventConnection_ALL?: InputMaybe<MafCompleteTemposHasEventConnectionWhere>;
@@ -2304,7 +2438,7 @@ export type MafCompletesConnection = {
   __typename?: "MafCompletesConnection";
   edges: Array<MafCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Mutation = {
@@ -2601,10 +2735,10 @@ export type MutationUpdateTemposArgs = {
 /** Pagination information (Relay) */
 export type PageInfo = {
   __typename?: "PageInfo";
-  endCursor?: Maybe<Scalars["String"]>;
-  hasNextPage: Scalars["Boolean"];
-  hasPreviousPage: Scalars["Boolean"];
-  startCursor?: Maybe<Scalars["String"]>;
+  endCursor?: Maybe<Scalars["String"]["output"]>;
+  hasNextPage: Scalars["Boolean"]["output"];
+  hasPreviousPage: Scalars["Boolean"]["output"];
+  startCursor?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type Patient = {
@@ -2615,50 +2749,50 @@ export type Patient = {
   patientAliasesIsAlias: Array<PatientAlias>;
   patientAliasesIsAliasAggregate?: Maybe<PatientPatientAliasPatientAliasesIsAliasAggregationSelection>;
   patientAliasesIsAliasConnection: PatientPatientAliasesIsAliasConnection;
-  smilePatientId: Scalars["String"];
+  smilePatientId: Scalars["String"]["output"];
 };
 
 export type PatientHasSampleSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type PatientHasSampleSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type PatientHasSampleSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<PatientHasSampleSamplesConnectionSort>>;
   where?: InputMaybe<PatientHasSampleSamplesConnectionWhere>;
 };
 
 export type PatientPatientAliasesIsAliasArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<PatientAliasOptions>;
   where?: InputMaybe<PatientAliasWhere>;
 };
 
 export type PatientPatientAliasesIsAliasAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PatientAliasWhere>;
 };
 
 export type PatientPatientAliasesIsAliasConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<PatientPatientAliasesIsAliasConnectionSort>>;
   where?: InputMaybe<PatientPatientAliasesIsAliasConnectionWhere>;
 };
 
 export type PatientAggregateSelection = {
   __typename?: "PatientAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   smilePatientId: StringAggregateSelection;
 };
 
@@ -2667,32 +2801,32 @@ export type PatientAlias = {
   isAliasPatients: Array<Patient>;
   isAliasPatientsAggregate?: Maybe<PatientAliasPatientIsAliasPatientsAggregationSelection>;
   isAliasPatientsConnection: PatientAliasIsAliasPatientsConnection;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["output"];
+  value: Scalars["String"]["output"];
 };
 
 export type PatientAliasIsAliasPatientsArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<PatientOptions>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type PatientAliasIsAliasPatientsAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type PatientAliasIsAliasPatientsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<PatientAliasIsAliasPatientsConnectionSort>>;
   where?: InputMaybe<PatientAliasIsAliasPatientsConnectionWhere>;
 };
 
 export type PatientAliasAggregateSelection = {
   __typename?: "PatientAliasAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   namespace: StringAggregateSelection;
   value: StringAggregateSelection;
 };
@@ -2709,8 +2843,8 @@ export type PatientAliasConnectWhere = {
 
 export type PatientAliasCreateInput = {
   isAliasPatients?: InputMaybe<PatientAliasIsAliasPatientsFieldInput>;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["input"];
+  value: Scalars["String"]["input"];
 };
 
 export type PatientAliasDeleteInput = {
@@ -2727,7 +2861,7 @@ export type PatientAliasDisconnectInput = {
 
 export type PatientAliasEdge = {
   __typename?: "PatientAliasEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: PatientAlias;
 };
 
@@ -2735,18 +2869,18 @@ export type PatientAliasIsAliasPatientsAggregateInput = {
   AND?: InputMaybe<Array<PatientAliasIsAliasPatientsAggregateInput>>;
   NOT?: InputMaybe<PatientAliasIsAliasPatientsAggregateInput>;
   OR?: InputMaybe<Array<PatientAliasIsAliasPatientsAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<PatientAliasIsAliasPatientsNodeAggregationWhereInput>;
 };
 
 export type PatientAliasIsAliasPatientsConnectFieldInput = {
   connect?: InputMaybe<Array<PatientConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<PatientConnectWhere>;
 };
 
@@ -2754,7 +2888,7 @@ export type PatientAliasIsAliasPatientsConnection = {
   __typename?: "PatientAliasIsAliasPatientsConnection";
   edges: Array<PatientAliasIsAliasPatientsRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientAliasIsAliasPatientsConnectionSort = {
@@ -2791,26 +2925,26 @@ export type PatientAliasIsAliasPatientsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<PatientAliasIsAliasPatientsNodeAggregationWhereInput>>;
   NOT?: InputMaybe<PatientAliasIsAliasPatientsNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<PatientAliasIsAliasPatientsNodeAggregationWhereInput>>;
-  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PatientAliasIsAliasPatientsRelationship = {
   __typename?: "PatientAliasIsAliasPatientsRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Patient;
 };
 
@@ -2830,15 +2964,15 @@ export type PatientAliasIsAliasPatientsUpdateFieldInput = {
 };
 
 export type PatientAliasOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more PatientAliasSort objects to sort PatientAliases by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<PatientAliasSort>>;
 };
 
 export type PatientAliasPatientIsAliasPatientsAggregationSelection = {
   __typename?: "PatientAliasPatientIsAliasPatientsAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<PatientAliasPatientIsAliasPatientsNodeAggregateSelection>;
 };
 
@@ -2863,8 +2997,8 @@ export type PatientAliasUpdateInput = {
   isAliasPatients?: InputMaybe<
     Array<PatientAliasIsAliasPatientsUpdateFieldInput>
   >;
-  namespace?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientAliasWhere = {
@@ -2888,25 +3022,25 @@ export type PatientAliasWhere = {
   isAliasPatients_SINGLE?: InputMaybe<PatientWhere>;
   /** Return PatientAliases where some of the related Patients match this filter */
   isAliasPatients_SOME?: InputMaybe<PatientWhere>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
-  value_CONTAINS?: InputMaybe<Scalars["String"]>;
-  value_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  value_IN?: InputMaybe<Array<Scalars["String"]>>;
-  value_MATCHES?: InputMaybe<Scalars["String"]>;
-  value_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
+  value_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  value_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  value_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  value_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientAliasesConnection = {
   __typename?: "PatientAliasesConnection";
   edges: Array<PatientAliasEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientConnectInput = {
@@ -2925,7 +3059,7 @@ export type PatientConnectWhere = {
 export type PatientCreateInput = {
   hasSampleSamples?: InputMaybe<PatientHasSampleSamplesFieldInput>;
   patientAliasesIsAlias?: InputMaybe<PatientPatientAliasesIsAliasFieldInput>;
-  smilePatientId: Scalars["String"];
+  smilePatientId: Scalars["String"]["input"];
 };
 
 export type PatientDeleteInput = {
@@ -2946,7 +3080,7 @@ export type PatientDisconnectInput = {
 
 export type PatientEdge = {
   __typename?: "PatientEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Patient;
 };
 
@@ -2954,18 +3088,18 @@ export type PatientHasSampleSamplesAggregateInput = {
   AND?: InputMaybe<Array<PatientHasSampleSamplesAggregateInput>>;
   NOT?: InputMaybe<PatientHasSampleSamplesAggregateInput>;
   OR?: InputMaybe<Array<PatientHasSampleSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<PatientHasSampleSamplesNodeAggregationWhereInput>;
 };
 
 export type PatientHasSampleSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -2973,7 +3107,7 @@ export type PatientHasSampleSamplesConnection = {
   __typename?: "PatientHasSampleSamplesConnection";
   edges: Array<PatientHasSampleSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientHasSampleSamplesConnectionSort = {
@@ -3010,71 +3144,71 @@ export type PatientHasSampleSamplesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<PatientHasSampleSamplesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<PatientHasSampleSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<PatientHasSampleSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PatientHasSampleSamplesRelationship = {
   __typename?: "PatientHasSampleSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -3093,22 +3227,22 @@ export type PatientHasSampleSamplesUpdateFieldInput = {
 
 export type PatientIdsTriplet = {
   __typename?: "PatientIdsTriplet";
-  CMO_PATIENT_ID: Scalars["String"];
-  DMP_PATIENT_ID?: Maybe<Scalars["String"]>;
-  MRN: Scalars["String"];
-  RACE?: Maybe<Scalars["String"]>;
+  CMO_PATIENT_ID: Scalars["String"]["output"];
+  DMP_PATIENT_ID?: Maybe<Scalars["String"]["output"]>;
+  MRN: Scalars["String"]["output"];
+  RACE?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type PatientOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more PatientSort objects to sort Patients by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<PatientSort>>;
 };
 
 export type PatientPatientAliasPatientAliasesIsAliasAggregationSelection = {
   __typename?: "PatientPatientAliasPatientAliasesIsAliasAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<PatientPatientAliasPatientAliasesIsAliasNodeAggregateSelection>;
 };
 
@@ -3122,18 +3256,18 @@ export type PatientPatientAliasesIsAliasAggregateInput = {
   AND?: InputMaybe<Array<PatientPatientAliasesIsAliasAggregateInput>>;
   NOT?: InputMaybe<PatientPatientAliasesIsAliasAggregateInput>;
   OR?: InputMaybe<Array<PatientPatientAliasesIsAliasAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<PatientPatientAliasesIsAliasNodeAggregationWhereInput>;
 };
 
 export type PatientPatientAliasesIsAliasConnectFieldInput = {
   connect?: InputMaybe<Array<PatientAliasConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<PatientAliasConnectWhere>;
 };
 
@@ -3141,7 +3275,7 @@ export type PatientPatientAliasesIsAliasConnection = {
   __typename?: "PatientPatientAliasesIsAliasConnection";
   edges: Array<PatientPatientAliasesIsAliasRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientPatientAliasesIsAliasConnectionSort = {
@@ -3180,41 +3314,41 @@ export type PatientPatientAliasesIsAliasNodeAggregationWhereInput = {
   >;
   NOT?: InputMaybe<PatientPatientAliasesIsAliasNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<PatientPatientAliasesIsAliasNodeAggregationWhereInput>>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PatientPatientAliasesIsAliasRelationship = {
   __typename?: "PatientPatientAliasesIsAliasRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: PatientAlias;
 };
 
@@ -3242,7 +3376,7 @@ export type PatientRelationInput = {
 
 export type PatientSampleHasSampleSamplesAggregationSelection = {
   __typename?: "PatientSampleHasSampleSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<PatientSampleHasSampleSamplesNodeAggregateSelection>;
 };
 
@@ -3264,7 +3398,7 @@ export type PatientUpdateInput = {
   patientAliasesIsAlias?: InputMaybe<
     Array<PatientPatientAliasesIsAliasUpdateFieldInput>
   >;
-  smilePatientId?: InputMaybe<Scalars["String"]>;
+  smilePatientId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientWhere = {
@@ -3305,19 +3439,19 @@ export type PatientWhere = {
   patientAliasesIsAlias_SINGLE?: InputMaybe<PatientAliasWhere>;
   /** Return Patients where some of the related PatientAliases match this filter */
   patientAliasesIsAlias_SOME?: InputMaybe<PatientAliasWhere>;
-  smilePatientId?: InputMaybe<Scalars["String"]>;
-  smilePatientId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smilePatientId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smilePatientId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smilePatientId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smilePatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smilePatientId?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smilePatientId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientsConnection = {
   __typename?: "PatientsConnection";
   edges: Array<PatientEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Project = {
@@ -3325,32 +3459,32 @@ export type Project = {
   hasRequestRequests: Array<Request>;
   hasRequestRequestsAggregate?: Maybe<ProjectRequestHasRequestRequestsAggregationSelection>;
   hasRequestRequestsConnection: ProjectHasRequestRequestsConnection;
-  igoProjectId: Scalars["String"];
-  namespace: Scalars["String"];
+  igoProjectId: Scalars["String"]["output"];
+  namespace: Scalars["String"]["output"];
 };
 
 export type ProjectHasRequestRequestsArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type ProjectHasRequestRequestsAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type ProjectHasRequestRequestsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<ProjectHasRequestRequestsConnectionSort>>;
   where?: InputMaybe<ProjectHasRequestRequestsConnectionWhere>;
 };
 
 export type ProjectAggregateSelection = {
   __typename?: "ProjectAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   igoProjectId: StringAggregateSelection;
   namespace: StringAggregateSelection;
 };
@@ -3367,8 +3501,8 @@ export type ProjectConnectWhere = {
 
 export type ProjectCreateInput = {
   hasRequestRequests?: InputMaybe<ProjectHasRequestRequestsFieldInput>;
-  igoProjectId: Scalars["String"];
-  namespace: Scalars["String"];
+  igoProjectId: Scalars["String"]["input"];
+  namespace: Scalars["String"]["input"];
 };
 
 export type ProjectDeleteInput = {
@@ -3385,7 +3519,7 @@ export type ProjectDisconnectInput = {
 
 export type ProjectEdge = {
   __typename?: "ProjectEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Project;
 };
 
@@ -3393,18 +3527,18 @@ export type ProjectHasRequestRequestsAggregateInput = {
   AND?: InputMaybe<Array<ProjectHasRequestRequestsAggregateInput>>;
   NOT?: InputMaybe<ProjectHasRequestRequestsAggregateInput>;
   OR?: InputMaybe<Array<ProjectHasRequestRequestsAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<ProjectHasRequestRequestsNodeAggregationWhereInput>;
 };
 
 export type ProjectHasRequestRequestsConnectFieldInput = {
   connect?: InputMaybe<Array<RequestConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestConnectWhere>;
 };
 
@@ -3412,7 +3546,7 @@ export type ProjectHasRequestRequestsConnection = {
   __typename?: "ProjectHasRequestRequestsConnection";
   edges: Array<ProjectHasRequestRequestsRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type ProjectHasRequestRequestsConnectionSort = {
@@ -3449,331 +3583,341 @@ export type ProjectHasRequestRequestsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<ProjectHasRequestRequestsNodeAggregationWhereInput>>;
   NOT?: InputMaybe<ProjectHasRequestRequestsNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<ProjectHasRequestRequestsNodeAggregationWhereInput>>;
-  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type ProjectHasRequestRequestsRelationship = {
   __typename?: "ProjectHasRequestRequestsRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -3791,8 +3935,8 @@ export type ProjectHasRequestRequestsUpdateFieldInput = {
 };
 
 export type ProjectOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more ProjectSort objects to sort Projects by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<ProjectSort>>;
 };
@@ -3805,7 +3949,7 @@ export type ProjectRelationInput = {
 
 export type ProjectRequestHasRequestRequestsAggregationSelection = {
   __typename?: "ProjectRequestHasRequestRequestsAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<ProjectRequestHasRequestRequestsNodeAggregateSelection>;
 };
 
@@ -3844,8 +3988,8 @@ export type ProjectUpdateInput = {
   hasRequestRequests?: InputMaybe<
     Array<ProjectHasRequestRequestsUpdateFieldInput>
   >;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type ProjectWhere = {
@@ -3869,60 +4013,60 @@ export type ProjectWhere = {
   hasRequestRequests_SINGLE?: InputMaybe<RequestWhere>;
   /** Return Projects where some of the related Requests match this filter */
   hasRequestRequests_SOME?: InputMaybe<RequestWhere>;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type ProjectsConnection = {
   __typename?: "ProjectsConnection";
   edges: Array<ProjectEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type QcComplete = {
   __typename?: "QcComplete";
-  date: Scalars["String"];
-  reason: Scalars["String"];
-  result: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["output"];
+  reason: Scalars["String"]["output"];
+  result: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
   temposHasEvent: Array<Tempo>;
   temposHasEventAggregate?: Maybe<QcCompleteTempoTemposHasEventAggregationSelection>;
   temposHasEventConnection: QcCompleteTemposHasEventConnection;
 };
 
 export type QcCompleteTemposHasEventArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type QcCompleteTemposHasEventAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type QcCompleteTemposHasEventConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<QcCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<QcCompleteTemposHasEventConnectionWhere>;
 };
 
 export type QcCompleteAggregateSelection = {
   __typename?: "QcCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   reason: StringAggregateSelection;
   result: StringAggregateSelection;
@@ -3938,10 +4082,10 @@ export type QcCompleteConnectWhere = {
 };
 
 export type QcCompleteCreateInput = {
-  date: Scalars["String"];
-  reason: Scalars["String"];
-  result: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["input"];
+  reason: Scalars["String"]["input"];
+  result: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
   temposHasEvent?: InputMaybe<QcCompleteTemposHasEventFieldInput>;
 };
 
@@ -3957,13 +4101,13 @@ export type QcCompleteDisconnectInput = {
 
 export type QcCompleteEdge = {
   __typename?: "QcCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: QcComplete;
 };
 
 export type QcCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more QcCompleteSort objects to sort QcCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<QcCompleteSort>>;
 };
@@ -3982,7 +4126,7 @@ export type QcCompleteSort = {
 
 export type QcCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "QcCompleteTempoTemposHasEventAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<QcCompleteTempoTemposHasEventNodeAggregateSelection>;
 };
 
@@ -4001,18 +4145,18 @@ export type QcCompleteTemposHasEventAggregateInput = {
   AND?: InputMaybe<Array<QcCompleteTemposHasEventAggregateInput>>;
   NOT?: InputMaybe<QcCompleteTemposHasEventAggregateInput>;
   OR?: InputMaybe<Array<QcCompleteTemposHasEventAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<QcCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type QcCompleteTemposHasEventConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -4020,7 +4164,7 @@ export type QcCompleteTemposHasEventConnection = {
   __typename?: "QcCompleteTemposHasEventConnection";
   edges: Array<QcCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type QcCompleteTemposHasEventConnectionSort = {
@@ -4057,116 +4201,164 @@ export type QcCompleteTemposHasEventNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<QcCompleteTemposHasEventNodeAggregationWhereInput>>;
   NOT?: InputMaybe<QcCompleteTemposHasEventNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<QcCompleteTemposHasEventNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QcCompleteTemposHasEventRelationship = {
   __typename?: "QcCompleteTemposHasEventRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -4184,10 +4376,10 @@ export type QcCompleteTemposHasEventUpdateFieldInput = {
 };
 
 export type QcCompleteUpdateInput = {
-  date?: InputMaybe<Scalars["String"]>;
-  reason?: InputMaybe<Scalars["String"]>;
-  result?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  reason?: InputMaybe<Scalars["String"]["input"]>;
+  result?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEvent?: InputMaybe<Array<QcCompleteTemposHasEventUpdateFieldInput>>;
 };
 
@@ -4195,30 +4387,30 @@ export type QcCompleteWhere = {
   AND?: InputMaybe<Array<QcCompleteWhere>>;
   NOT?: InputMaybe<QcCompleteWhere>;
   OR?: InputMaybe<Array<QcCompleteWhere>>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  reason?: InputMaybe<Scalars["String"]>;
-  reason_CONTAINS?: InputMaybe<Scalars["String"]>;
-  reason_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  reason_IN?: InputMaybe<Array<Scalars["String"]>>;
-  reason_MATCHES?: InputMaybe<Scalars["String"]>;
-  reason_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  result?: InputMaybe<Scalars["String"]>;
-  result_CONTAINS?: InputMaybe<Scalars["String"]>;
-  result_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  result_IN?: InputMaybe<Array<Scalars["String"]>>;
-  result_MATCHES?: InputMaybe<Scalars["String"]>;
-  result_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  reason?: InputMaybe<Scalars["String"]["input"]>;
+  reason_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  reason_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  reason_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  reason_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  reason_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  result?: InputMaybe<Scalars["String"]["input"]>;
+  result_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  result_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  result_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  result_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  result_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEventAggregate?: InputMaybe<QcCompleteTemposHasEventAggregateInput>;
   /** Return QcCompletes where all of the related QcCompleteTemposHasEventConnections match this filter */
   temposHasEventConnection_ALL?: InputMaybe<QcCompleteTemposHasEventConnectionWhere>;
@@ -4242,13 +4434,13 @@ export type QcCompletesConnection = {
   __typename?: "QcCompletesConnection";
   edges: Array<QcCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Query = {
   __typename?: "Query";
   allAnchorSeqDateData: Array<AnchorSeqDateData>;
-  allBlockedCohortIds: Array<Scalars["String"]>;
+  allBlockedCohortIds: Array<Scalars["String"]["output"]>;
   bamCompletes: Array<BamComplete>;
   bamCompletesAggregate: BamCompleteAggregateSelection;
   bamCompletesConnection: BamCompletesConnection;
@@ -4306,7 +4498,7 @@ export type Query = {
 };
 
 export type QueryAllAnchorSeqDateDataArgs = {
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type QueryBamCompletesArgs = {
@@ -4319,8 +4511,8 @@ export type QueryBamCompletesAggregateArgs = {
 };
 
 export type QueryBamCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<BamCompleteSort>>>;
   where?: InputMaybe<BamCompleteWhere>;
 };
@@ -4335,8 +4527,8 @@ export type QueryCohortCompletesAggregateArgs = {
 };
 
 export type QueryCohortCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<CohortCompleteSort>>>;
   where?: InputMaybe<CohortCompleteWhere>;
 };
@@ -4351,52 +4543,52 @@ export type QueryCohortsAggregateArgs = {
 };
 
 export type QueryCohortsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<CohortSort>>>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type QueryDashboardCohortsArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardPatientsArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardRequestsArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardSampleHistoryArgs = {
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  searchVals: Array<Scalars["String"]>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  searchVals: Array<Scalars["String"]["input"]>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardSamplesArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  includeDemographics: Scalars["Boolean"];
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  includeDemographics: Scalars["Boolean"]["input"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   recordContexts?: InputMaybe<Array<InputMaybe<DashboardRecordContext>>>;
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
@@ -4410,16 +4602,17 @@ export type QueryDbGapsAggregateArgs = {
 };
 
 export type QueryDbGapsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<DbGapSort>>>;
   where?: InputMaybe<DbGapWhere>;
 };
 
 export type QueryGetValidationAdviceArgs = {
-  recordId?: InputMaybe<Scalars["String"]>;
-  recordType: Scalars["String"];
-  validationReport: Scalars["String"];
+  igoQcReports?: InputMaybe<Scalars["String"]["input"]>;
+  recordId?: InputMaybe<Scalars["String"]["input"]>;
+  recordType: Scalars["String"]["input"];
+  validationReport: Scalars["String"]["input"];
 };
 
 export type QueryMafCompletesArgs = {
@@ -4432,8 +4625,8 @@ export type QueryMafCompletesAggregateArgs = {
 };
 
 export type QueryMafCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<MafCompleteSort>>>;
   where?: InputMaybe<MafCompleteWhere>;
 };
@@ -4448,8 +4641,8 @@ export type QueryPatientAliasesAggregateArgs = {
 };
 
 export type QueryPatientAliasesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<PatientAliasSort>>>;
   where?: InputMaybe<PatientAliasWhere>;
 };
@@ -4464,8 +4657,8 @@ export type QueryPatientsAggregateArgs = {
 };
 
 export type QueryPatientsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<PatientSort>>>;
   where?: InputMaybe<PatientWhere>;
 };
@@ -4480,8 +4673,8 @@ export type QueryProjectsAggregateArgs = {
 };
 
 export type QueryProjectsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<ProjectSort>>>;
   where?: InputMaybe<ProjectWhere>;
 };
@@ -4496,8 +4689,8 @@ export type QueryQcCompletesAggregateArgs = {
 };
 
 export type QueryQcCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<QcCompleteSort>>>;
   where?: InputMaybe<QcCompleteWhere>;
 };
@@ -4512,8 +4705,8 @@ export type QueryRequestMetadataAggregateArgs = {
 };
 
 export type QueryRequestMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<RequestMetadataSort>>>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
@@ -4528,8 +4721,8 @@ export type QueryRequestsAggregateArgs = {
 };
 
 export type QueryRequestsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<RequestSort>>>;
   where?: InputMaybe<RequestWhere>;
 };
@@ -4544,8 +4737,8 @@ export type QuerySampleAliasesAggregateArgs = {
 };
 
 export type QuerySampleAliasesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<SampleAliasSort>>>;
   where?: InputMaybe<SampleAliasWhere>;
 };
@@ -4560,8 +4753,8 @@ export type QuerySampleMetadataAggregateArgs = {
 };
 
 export type QuerySampleMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<SampleMetadataSort>>>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
@@ -4576,8 +4769,8 @@ export type QuerySamplesAggregateArgs = {
 };
 
 export type QuerySamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<SampleSort>>>;
   where?: InputMaybe<SampleWhere>;
 };
@@ -4592,8 +4785,8 @@ export type QueryStatusesAggregateArgs = {
 };
 
 export type QueryStatusesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<StatusSort>>>;
   where?: InputMaybe<StatusWhere>;
 };
@@ -4608,109 +4801,109 @@ export type QueryTemposAggregateArgs = {
 };
 
 export type QueryTemposConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<TempoSort>>>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type Request = {
   __typename?: "Request";
-  bicAnalysis: Scalars["Boolean"];
-  dataAccessEmails: Scalars["String"];
-  dataAnalystEmail: Scalars["String"];
-  dataAnalystName: Scalars["String"];
-  genePanel: Scalars["String"];
+  bicAnalysis: Scalars["Boolean"]["output"];
+  dataAccessEmails: Scalars["String"]["output"];
+  dataAnalystEmail: Scalars["String"]["output"];
+  dataAnalystName: Scalars["String"]["output"];
+  genePanel: Scalars["String"]["output"];
   hasMetadataRequestMetadata: Array<RequestMetadata>;
   hasMetadataRequestMetadataAggregate?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection>;
   hasMetadataRequestMetadataConnection: RequestHasMetadataRequestMetadataConnection;
   hasSampleSamples: Array<Sample>;
   hasSampleSamplesAggregate?: Maybe<RequestSampleHasSampleSamplesAggregationSelection>;
   hasSampleSamplesConnection: RequestHasSampleSamplesConnection;
-  igoDeliveryDate?: Maybe<Scalars["BigInt"]>;
-  igoProjectId: Scalars["String"];
-  igoRequestId: Scalars["String"];
-  ilabRequestId?: Maybe<Scalars["String"]>;
-  investigatorEmail: Scalars["String"];
-  investigatorName: Scalars["String"];
-  isCmoRequest: Scalars["Boolean"];
-  labHeadEmail: Scalars["String"];
-  labHeadName: Scalars["String"];
-  libraryType?: Maybe<Scalars["String"]>;
-  namespace: Scalars["String"];
-  otherContactEmails: Scalars["String"];
-  piEmail: Scalars["String"];
-  pooledNormals?: Maybe<Array<Maybe<Scalars["String"]>>>;
-  projectManagerName: Scalars["String"];
+  igoDeliveryDate?: Maybe<Scalars["BigInt"]["output"]>;
+  igoProjectId: Scalars["String"]["output"];
+  igoRequestId: Scalars["String"]["output"];
+  ilabRequestId?: Maybe<Scalars["String"]["output"]>;
+  investigatorEmail: Scalars["String"]["output"];
+  investigatorName: Scalars["String"]["output"];
+  isCmoRequest: Scalars["Boolean"]["output"];
+  labHeadEmail: Scalars["String"]["output"];
+  labHeadName: Scalars["String"]["output"];
+  libraryType?: Maybe<Scalars["String"]["output"]>;
+  namespace: Scalars["String"]["output"];
+  otherContactEmails: Scalars["String"]["output"];
+  piEmail: Scalars["String"]["output"];
+  pooledNormals?: Maybe<Array<Maybe<Scalars["String"]["output"]>>>;
+  projectManagerName: Scalars["String"]["output"];
   projectsHasRequest: Array<Project>;
   projectsHasRequestAggregate?: Maybe<RequestProjectProjectsHasRequestAggregationSelection>;
   projectsHasRequestConnection: RequestProjectsHasRequestConnection;
-  qcAccessEmails: Scalars["String"];
-  requestJson: Scalars["String"];
-  smileRequestId: Scalars["String"];
-  strand?: Maybe<Scalars["String"]>;
+  qcAccessEmails: Scalars["String"]["output"];
+  requestJson: Scalars["String"]["output"];
+  smileRequestId: Scalars["String"]["output"];
+  strand?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type RequestHasMetadataRequestMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestMetadataOptions>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type RequestHasMetadataRequestMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type RequestHasMetadataRequestMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionSort>>;
   where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
 };
 
 export type RequestHasSampleSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type RequestHasSampleSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type RequestHasSampleSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestHasSampleSamplesConnectionSort>>;
   where?: InputMaybe<RequestHasSampleSamplesConnectionWhere>;
 };
 
 export type RequestProjectsHasRequestArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<ProjectOptions>;
   where?: InputMaybe<ProjectWhere>;
 };
 
 export type RequestProjectsHasRequestAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ProjectWhere>;
 };
 
 export type RequestProjectsHasRequestConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestProjectsHasRequestConnectionSort>>;
   where?: InputMaybe<RequestProjectsHasRequestConnectionWhere>;
 };
 
 export type RequestAggregateSelection = {
   __typename?: "RequestAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   dataAccessEmails: StringAggregateSelection;
   dataAnalystEmail: StringAggregateSelection;
   dataAnalystName: StringAggregateSelection;
@@ -4751,33 +4944,33 @@ export type RequestConnectWhere = {
 };
 
 export type RequestCreateInput = {
-  bicAnalysis: Scalars["Boolean"];
-  dataAccessEmails: Scalars["String"];
-  dataAnalystEmail: Scalars["String"];
-  dataAnalystName: Scalars["String"];
-  genePanel: Scalars["String"];
+  bicAnalysis: Scalars["Boolean"]["input"];
+  dataAccessEmails: Scalars["String"]["input"];
+  dataAnalystEmail: Scalars["String"]["input"];
+  dataAnalystName: Scalars["String"]["input"];
+  genePanel: Scalars["String"]["input"];
   hasMetadataRequestMetadata?: InputMaybe<RequestHasMetadataRequestMetadataFieldInput>;
   hasSampleSamples?: InputMaybe<RequestHasSampleSamplesFieldInput>;
-  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId: Scalars["String"];
-  igoRequestId: Scalars["String"];
-  ilabRequestId?: InputMaybe<Scalars["String"]>;
-  investigatorEmail: Scalars["String"];
-  investigatorName: Scalars["String"];
-  isCmoRequest: Scalars["Boolean"];
-  labHeadEmail: Scalars["String"];
-  labHeadName: Scalars["String"];
-  libraryType?: InputMaybe<Scalars["String"]>;
-  namespace: Scalars["String"];
-  otherContactEmails: Scalars["String"];
-  piEmail: Scalars["String"];
-  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  projectManagerName: Scalars["String"];
+  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId: Scalars["String"]["input"];
+  igoRequestId: Scalars["String"]["input"];
+  ilabRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail: Scalars["String"]["input"];
+  investigatorName: Scalars["String"]["input"];
+  isCmoRequest: Scalars["Boolean"]["input"];
+  labHeadEmail: Scalars["String"]["input"];
+  labHeadName: Scalars["String"]["input"];
+  libraryType?: InputMaybe<Scalars["String"]["input"]>;
+  namespace: Scalars["String"]["input"];
+  otherContactEmails: Scalars["String"]["input"];
+  piEmail: Scalars["String"]["input"];
+  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  projectManagerName: Scalars["String"]["input"];
   projectsHasRequest?: InputMaybe<RequestProjectsHasRequestFieldInput>;
-  qcAccessEmails: Scalars["String"];
-  requestJson: Scalars["String"];
-  smileRequestId: Scalars["String"];
-  strand?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails: Scalars["String"]["input"];
+  requestJson: Scalars["String"]["input"];
+  smileRequestId: Scalars["String"]["input"];
+  strand?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RequestDeleteInput = {
@@ -4804,7 +4997,7 @@ export type RequestDisconnectInput = {
 
 export type RequestEdge = {
   __typename?: "RequestEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -4812,18 +5005,18 @@ export type RequestHasMetadataRequestMetadataAggregateInput = {
   AND?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
   NOT?: InputMaybe<RequestHasMetadataRequestMetadataAggregateInput>;
   OR?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>;
 };
 
 export type RequestHasMetadataRequestMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<RequestMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestMetadataConnectWhere>;
 };
 
@@ -4831,7 +5024,7 @@ export type RequestHasMetadataRequestMetadataConnection = {
   __typename?: "RequestHasMetadataRequestMetadataConnection";
   edges: Array<RequestHasMetadataRequestMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestHasMetadataRequestMetadataConnectionSort = {
@@ -4874,61 +5067,71 @@ export type RequestHasMetadataRequestMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>
   >;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestHasMetadataRequestMetadataRelationship = {
   __typename?: "RequestHasMetadataRequestMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: RequestMetadata;
 };
 
@@ -4953,18 +5156,18 @@ export type RequestHasSampleSamplesAggregateInput = {
   AND?: InputMaybe<Array<RequestHasSampleSamplesAggregateInput>>;
   NOT?: InputMaybe<RequestHasSampleSamplesAggregateInput>;
   OR?: InputMaybe<Array<RequestHasSampleSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestHasSampleSamplesNodeAggregationWhereInput>;
 };
 
 export type RequestHasSampleSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -4972,7 +5175,7 @@ export type RequestHasSampleSamplesConnection = {
   __typename?: "RequestHasSampleSamplesConnection";
   edges: Array<RequestHasSampleSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestHasSampleSamplesConnectionSort = {
@@ -5009,71 +5212,71 @@ export type RequestHasSampleSamplesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<RequestHasSampleSamplesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<RequestHasSampleSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<RequestHasSampleSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestHasSampleSamplesRelationship = {
   __typename?: "RequestHasSampleSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -5095,55 +5298,55 @@ export type RequestMetadata = {
   hasStatusStatuses: Array<Status>;
   hasStatusStatusesAggregate?: Maybe<RequestMetadataStatusHasStatusStatusesAggregationSelection>;
   hasStatusStatusesConnection: RequestMetadataHasStatusStatusesConnection;
-  igoRequestId: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  requestMetadataJson: Scalars["String"];
+  igoRequestId: Scalars["String"]["output"];
+  importDate: Scalars["BigInt"]["output"];
+  requestMetadataJson: Scalars["String"]["output"];
   requestsHasMetadata: Array<Request>;
   requestsHasMetadataAggregate?: Maybe<RequestMetadataRequestRequestsHasMetadataAggregationSelection>;
   requestsHasMetadataConnection: RequestMetadataRequestsHasMetadataConnection;
 };
 
 export type RequestMetadataHasStatusStatusesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<StatusOptions>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type RequestMetadataHasStatusStatusesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type RequestMetadataHasStatusStatusesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestMetadataHasStatusStatusesConnectionSort>>;
   where?: InputMaybe<RequestMetadataHasStatusStatusesConnectionWhere>;
 };
 
 export type RequestMetadataRequestsHasMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type RequestMetadataRequestsHasMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type RequestMetadataRequestsHasMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionSort>>;
   where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
 };
 
 export type RequestMetadataAggregateSelection = {
   __typename?: "RequestMetadataAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   igoRequestId: StringAggregateSelection;
   importDate: BigIntAggregateSelection;
   requestMetadataJson: StringAggregateSelection;
@@ -5166,14 +5369,14 @@ export type RequestMetadataConnection = {
   __typename?: "RequestMetadataConnection";
   edges: Array<RequestMetadataEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestMetadataCreateInput = {
   hasStatusStatuses?: InputMaybe<RequestMetadataHasStatusStatusesFieldInput>;
-  igoRequestId: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  requestMetadataJson: Scalars["String"];
+  igoRequestId: Scalars["String"]["input"];
+  importDate: Scalars["BigInt"]["input"];
+  requestMetadataJson: Scalars["String"]["input"];
   requestsHasMetadata?: InputMaybe<RequestMetadataRequestsHasMetadataFieldInput>;
 };
 
@@ -5197,7 +5400,7 @@ export type RequestMetadataDisconnectInput = {
 
 export type RequestMetadataEdge = {
   __typename?: "RequestMetadataEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: RequestMetadata;
 };
 
@@ -5205,18 +5408,18 @@ export type RequestMetadataHasStatusStatusesAggregateInput = {
   AND?: InputMaybe<Array<RequestMetadataHasStatusStatusesAggregateInput>>;
   NOT?: InputMaybe<RequestMetadataHasStatusStatusesAggregateInput>;
   OR?: InputMaybe<Array<RequestMetadataHasStatusStatusesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestMetadataHasStatusStatusesNodeAggregationWhereInput>;
 };
 
 export type RequestMetadataHasStatusStatusesConnectFieldInput = {
   connect?: InputMaybe<Array<StatusConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<StatusConnectWhere>;
 };
 
@@ -5224,7 +5427,7 @@ export type RequestMetadataHasStatusStatusesConnection = {
   __typename?: "RequestMetadataHasStatusStatusesConnection";
   edges: Array<RequestMetadataHasStatusStatusesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestMetadataHasStatusStatusesConnectionSort = {
@@ -5267,26 +5470,26 @@ export type RequestMetadataHasStatusStatusesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesNodeAggregationWhereInput>
   >;
-  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestMetadataHasStatusStatusesRelationship = {
   __typename?: "RequestMetadataHasStatusStatusesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Status;
 };
 
@@ -5308,8 +5511,8 @@ export type RequestMetadataHasStatusStatusesUpdateFieldInput = {
 };
 
 export type RequestMetadataOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more RequestMetadataSort objects to sort RequestMetadata by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<RequestMetadataSort>>;
 };
@@ -5325,7 +5528,7 @@ export type RequestMetadataRelationInput = {
 
 export type RequestMetadataRequestRequestsHasMetadataAggregationSelection = {
   __typename?: "RequestMetadataRequestRequestsHasMetadataAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection>;
 };
 
@@ -5358,18 +5561,18 @@ export type RequestMetadataRequestsHasMetadataAggregateInput = {
   AND?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
   NOT?: InputMaybe<RequestMetadataRequestsHasMetadataAggregateInput>;
   OR?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>;
 };
 
 export type RequestMetadataRequestsHasMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<RequestConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestConnectWhere>;
 };
 
@@ -5377,7 +5580,7 @@ export type RequestMetadataRequestsHasMetadataConnection = {
   __typename?: "RequestMetadataRequestsHasMetadataConnection";
   edges: Array<RequestMetadataRequestsHasMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestMetadataRequestsHasMetadataConnectionSort = {
@@ -5422,331 +5625,341 @@ export type RequestMetadataRequestsHasMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>
   >;
-  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestMetadataRequestsHasMetadataRelationship = {
   __typename?: "RequestMetadataRequestsHasMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -5780,7 +5993,7 @@ export type RequestMetadataSort = {
 
 export type RequestMetadataStatusHasStatusStatusesAggregationSelection = {
   __typename?: "RequestMetadataStatusHasStatusStatusesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestMetadataStatusHasStatusStatusesNodeAggregateSelection>;
 };
 
@@ -5793,11 +6006,11 @@ export type RequestMetadataUpdateInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesUpdateFieldInput>
   >;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson?: InputMaybe<Scalars["String"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson?: InputMaybe<Scalars["String"]["input"]>;
   requestsHasMetadata?: InputMaybe<
     Array<RequestMetadataRequestsHasMetadataUpdateFieldInput>
   >;
@@ -5824,24 +6037,24 @@ export type RequestMetadataWhere = {
   hasStatusStatuses_SINGLE?: InputMaybe<StatusWhere>;
   /** Return RequestMetadata where some of the related Statuses match this filter */
   hasStatusStatuses_SOME?: InputMaybe<StatusWhere>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]>>;
-  importDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_CONTAINS?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_IN?: InputMaybe<Array<Scalars["String"]>>;
-  requestMetadataJson_MATCHES?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  importDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  requestMetadataJson_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   requestsHasMetadataAggregate?: InputMaybe<RequestMetadataRequestsHasMetadataAggregateInput>;
   /** Return RequestMetadata where all of the related RequestMetadataRequestsHasMetadataConnections match this filter */
   requestsHasMetadataConnection_ALL?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
@@ -5862,15 +6075,15 @@ export type RequestMetadataWhere = {
 };
 
 export type RequestOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more RequestSort objects to sort Requests by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<RequestSort>>;
 };
 
 export type RequestProjectProjectsHasRequestAggregationSelection = {
   __typename?: "RequestProjectProjectsHasRequestAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestProjectProjectsHasRequestNodeAggregateSelection>;
 };
 
@@ -5884,18 +6097,18 @@ export type RequestProjectsHasRequestAggregateInput = {
   AND?: InputMaybe<Array<RequestProjectsHasRequestAggregateInput>>;
   NOT?: InputMaybe<RequestProjectsHasRequestAggregateInput>;
   OR?: InputMaybe<Array<RequestProjectsHasRequestAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestProjectsHasRequestNodeAggregationWhereInput>;
 };
 
 export type RequestProjectsHasRequestConnectFieldInput = {
   connect?: InputMaybe<Array<ProjectConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<ProjectConnectWhere>;
 };
 
@@ -5903,7 +6116,7 @@ export type RequestProjectsHasRequestConnection = {
   __typename?: "RequestProjectsHasRequestConnection";
   edges: Array<RequestProjectsHasRequestRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestProjectsHasRequestConnectionSort = {
@@ -5940,41 +6153,41 @@ export type RequestProjectsHasRequestNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<RequestProjectsHasRequestNodeAggregationWhereInput>>;
   NOT?: InputMaybe<RequestProjectsHasRequestNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<RequestProjectsHasRequestNodeAggregationWhereInput>>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestProjectsHasRequestRelationship = {
   __typename?: "RequestProjectsHasRequestRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Project;
 };
 
@@ -6004,7 +6217,7 @@ export type RequestRelationInput = {
 export type RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection =
   {
     __typename?: "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection>;
   };
 
@@ -6018,7 +6231,7 @@ export type RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelecti
 
 export type RequestSampleHasSampleSamplesAggregationSelection = {
   __typename?: "RequestSampleHasSampleSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestSampleHasSampleSamplesNodeAggregateSelection>;
 };
 
@@ -6058,72 +6271,74 @@ export type RequestSort = {
 };
 
 export type RequestUpdateInput = {
-  bicAnalysis?: InputMaybe<Scalars["Boolean"]>;
-  dataAccessEmails?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail?: InputMaybe<Scalars["String"]>;
-  dataAnalystName?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
+  bicAnalysis?: InputMaybe<Scalars["Boolean"]["input"]>;
+  dataAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
   hasMetadataRequestMetadata?: InputMaybe<
     Array<RequestHasMetadataRequestMetadataUpdateFieldInput>
   >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesUpdateFieldInput>>;
-  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  ilabRequestId?: InputMaybe<Scalars["String"]>;
-  investigatorEmail?: InputMaybe<Scalars["String"]>;
-  investigatorName?: InputMaybe<Scalars["String"]>;
-  isCmoRequest?: InputMaybe<Scalars["Boolean"]>;
-  labHeadEmail?: InputMaybe<Scalars["String"]>;
-  labHeadName?: InputMaybe<Scalars["String"]>;
-  libraryType?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  otherContactEmails?: InputMaybe<Scalars["String"]>;
-  piEmail?: InputMaybe<Scalars["String"]>;
-  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pooledNormals_POP?: InputMaybe<Scalars["Int"]>;
-  pooledNormals_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  projectManagerName?: InputMaybe<Scalars["String"]>;
+  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName?: InputMaybe<Scalars["String"]["input"]>;
+  isCmoRequest?: InputMaybe<Scalars["Boolean"]["input"]>;
+  labHeadEmail?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail?: InputMaybe<Scalars["String"]["input"]>;
+  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pooledNormals_POP?: InputMaybe<Scalars["Int"]["input"]>;
+  pooledNormals_PUSH?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  projectManagerName?: InputMaybe<Scalars["String"]["input"]>;
   projectsHasRequest?: InputMaybe<
     Array<RequestProjectsHasRequestUpdateFieldInput>
   >;
-  qcAccessEmails?: InputMaybe<Scalars["String"]>;
-  requestJson?: InputMaybe<Scalars["String"]>;
-  smileRequestId?: InputMaybe<Scalars["String"]>;
-  strand?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  strand?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RequestWhere = {
   AND?: InputMaybe<Array<RequestWhere>>;
   NOT?: InputMaybe<RequestWhere>;
   OR?: InputMaybe<Array<RequestWhere>>;
-  bicAnalysis?: InputMaybe<Scalars["Boolean"]>;
-  dataAccessEmails?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dataAccessEmails_MATCHES?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dataAnalystEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystName?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dataAnalystName_MATCHES?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
-  genePanel_CONTAINS?: InputMaybe<Scalars["String"]>;
-  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel_IN?: InputMaybe<Array<Scalars["String"]>>;
-  genePanel_MATCHES?: InputMaybe<Scalars["String"]>;
-  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  bicAnalysis?: InputMaybe<Scalars["Boolean"]["input"]>;
+  dataAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dataAccessEmails_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dataAnalystEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dataAnalystName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  genePanel_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasMetadataRequestMetadataAggregate?: InputMaybe<RequestHasMetadataRequestMetadataAggregateInput>;
   /** Return Requests where all of the related RequestHasMetadataRequestMetadataConnections match this filter */
   hasMetadataRequestMetadataConnection_ALL?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
@@ -6158,87 +6373,89 @@ export type RequestWhere = {
   hasSampleSamples_SINGLE?: InputMaybe<SampleWhere>;
   /** Return Requests where some of the related Samples match this filter */
   hasSampleSamples_SOME?: InputMaybe<SampleWhere>;
-  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_IN?: InputMaybe<Array<InputMaybe<Scalars["BigInt"]>>>;
-  igoDeliveryDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  ilabRequestId?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  ilabRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorEmail?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  investigatorEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorName?: InputMaybe<Scalars["String"]>;
-  investigatorName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  investigatorName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  investigatorName_MATCHES?: InputMaybe<Scalars["String"]>;
-  investigatorName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  isCmoRequest?: InputMaybe<Scalars["Boolean"]>;
-  labHeadEmail?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  labHeadEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  labHeadName?: InputMaybe<Scalars["String"]>;
-  labHeadName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  labHeadName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  labHeadName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  labHeadName_MATCHES?: InputMaybe<Scalars["String"]>;
-  labHeadName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  libraryType?: InputMaybe<Scalars["String"]>;
-  libraryType_CONTAINS?: InputMaybe<Scalars["String"]>;
-  libraryType_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  libraryType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  libraryType_MATCHES?: InputMaybe<Scalars["String"]>;
-  libraryType_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  otherContactEmails?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_CONTAINS?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_IN?: InputMaybe<Array<Scalars["String"]>>;
-  otherContactEmails_MATCHES?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  piEmail?: InputMaybe<Scalars["String"]>;
-  piEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  piEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  piEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  piEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  piEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pooledNormals_INCLUDES?: InputMaybe<Scalars["String"]>;
-  projectManagerName?: InputMaybe<Scalars["String"]>;
-  projectManagerName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  projectManagerName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectManagerName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  projectManagerName_MATCHES?: InputMaybe<Scalars["String"]>;
-  projectManagerName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["BigInt"]["input"]>>
+  >;
+  igoDeliveryDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  ilabRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  investigatorEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  investigatorName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  isCmoRequest?: InputMaybe<Scalars["Boolean"]["input"]>;
+  labHeadEmail?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  labHeadEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  labHeadName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  libraryType_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  otherContactEmails_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  piEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pooledNormals_INCLUDES?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  projectManagerName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   projectsHasRequestAggregate?: InputMaybe<RequestProjectsHasRequestAggregateInput>;
   /** Return Requests where all of the related RequestProjectsHasRequestConnections match this filter */
   projectsHasRequestConnection_ALL?: InputMaybe<RequestProjectsHasRequestConnectionWhere>;
@@ -6256,37 +6473,37 @@ export type RequestWhere = {
   projectsHasRequest_SINGLE?: InputMaybe<ProjectWhere>;
   /** Return Requests where some of the related Projects match this filter */
   projectsHasRequest_SOME?: InputMaybe<ProjectWhere>;
-  qcAccessEmails?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_IN?: InputMaybe<Array<Scalars["String"]>>;
-  qcAccessEmails_MATCHES?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  requestJson?: InputMaybe<Scalars["String"]>;
-  requestJson_CONTAINS?: InputMaybe<Scalars["String"]>;
-  requestJson_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  requestJson_IN?: InputMaybe<Array<Scalars["String"]>>;
-  requestJson_MATCHES?: InputMaybe<Scalars["String"]>;
-  requestJson_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  smileRequestId?: InputMaybe<Scalars["String"]>;
-  smileRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileRequestId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  strand?: InputMaybe<Scalars["String"]>;
-  strand_CONTAINS?: InputMaybe<Scalars["String"]>;
-  strand_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  strand_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  strand_MATCHES?: InputMaybe<Scalars["String"]>;
-  strand_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  qcAccessEmails_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  requestJson_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  strand?: InputMaybe<Scalars["String"]["input"]>;
+  strand_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  strand_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  strand_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  strand_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  strand_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RequestsConnection = {
   __typename?: "RequestsConnection";
   edges: Array<RequestEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Sample = {
@@ -6294,7 +6511,7 @@ export type Sample = {
   cohortsHasCohortSample: Array<Cohort>;
   cohortsHasCohortSampleAggregate?: Maybe<SampleCohortCohortsHasCohortSampleAggregationSelection>;
   cohortsHasCohortSampleConnection: SampleCohortsHasCohortSampleConnection;
-  datasource: Scalars["String"];
+  datasource: Scalars["String"]["output"];
   hasDbgapDbGaps: Array<DbGap>;
   hasDbgapDbGapsAggregate?: Maybe<SampleDbGapHasDbgapDbGapsAggregationSelection>;
   hasDbgapDbGapsConnection: SampleHasDbgapDbGapsConnection;
@@ -6310,151 +6527,151 @@ export type Sample = {
   requestsHasSample: Array<Request>;
   requestsHasSampleAggregate?: Maybe<SampleRequestRequestsHasSampleAggregationSelection>;
   requestsHasSampleConnection: SampleRequestsHasSampleConnection;
-  revisable?: Maybe<Scalars["Boolean"]>;
+  revisable?: Maybe<Scalars["Boolean"]["output"]>;
   sampleAliasesIsAlias: Array<SampleAlias>;
   sampleAliasesIsAliasAggregate?: Maybe<SampleSampleAliasSampleAliasesIsAliasAggregationSelection>;
   sampleAliasesIsAliasConnection: SampleSampleAliasesIsAliasConnection;
-  sampleCategory: Scalars["String"];
-  sampleClass?: Maybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
+  sampleCategory: Scalars["String"]["output"];
+  sampleClass?: Maybe<Scalars["String"]["output"]>;
+  smileSampleId: Scalars["String"]["output"];
 };
 
 export type SampleCohortsHasCohortSampleArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<CohortOptions>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type SampleCohortsHasCohortSampleAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type SampleCohortsHasCohortSampleConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleCohortsHasCohortSampleConnectionSort>>;
   where?: InputMaybe<SampleCohortsHasCohortSampleConnectionWhere>;
 };
 
 export type SampleHasDbgapDbGapsArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<DbGapOptions>;
   where?: InputMaybe<DbGapWhere>;
 };
 
 export type SampleHasDbgapDbGapsAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<DbGapWhere>;
 };
 
 export type SampleHasDbgapDbGapsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleHasDbgapDbGapsConnectionSort>>;
   where?: InputMaybe<SampleHasDbgapDbGapsConnectionWhere>;
 };
 
 export type SampleHasMetadataSampleMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleMetadataOptions>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type SampleHasMetadataSampleMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type SampleHasMetadataSampleMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleHasMetadataSampleMetadataConnectionSort>>;
   where?: InputMaybe<SampleHasMetadataSampleMetadataConnectionWhere>;
 };
 
 export type SampleHasTempoTemposArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type SampleHasTempoTemposAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type SampleHasTempoTemposConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleHasTempoTemposConnectionSort>>;
   where?: InputMaybe<SampleHasTempoTemposConnectionWhere>;
 };
 
 export type SamplePatientsHasSampleArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<PatientOptions>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type SamplePatientsHasSampleAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type SamplePatientsHasSampleConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SamplePatientsHasSampleConnectionSort>>;
   where?: InputMaybe<SamplePatientsHasSampleConnectionWhere>;
 };
 
 export type SampleRequestsHasSampleArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type SampleRequestsHasSampleAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type SampleRequestsHasSampleConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleRequestsHasSampleConnectionSort>>;
   where?: InputMaybe<SampleRequestsHasSampleConnectionWhere>;
 };
 
 export type SampleSampleAliasesIsAliasArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleAliasOptions>;
   where?: InputMaybe<SampleAliasWhere>;
 };
 
 export type SampleSampleAliasesIsAliasAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleAliasWhere>;
 };
 
 export type SampleSampleAliasesIsAliasConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleSampleAliasesIsAliasConnectionSort>>;
   where?: InputMaybe<SampleSampleAliasesIsAliasConnectionWhere>;
 };
 
 export type SampleAggregateSelection = {
   __typename?: "SampleAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   datasource: StringAggregateSelection;
   sampleCategory: StringAggregateSelection;
   sampleClass: StringAggregateSelection;
@@ -6466,32 +6683,32 @@ export type SampleAlias = {
   isAliasSamples: Array<Sample>;
   isAliasSamplesAggregate?: Maybe<SampleAliasSampleIsAliasSamplesAggregationSelection>;
   isAliasSamplesConnection: SampleAliasIsAliasSamplesConnection;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["output"];
+  value: Scalars["String"]["output"];
 };
 
 export type SampleAliasIsAliasSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleAliasIsAliasSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleAliasIsAliasSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleAliasIsAliasSamplesConnectionSort>>;
   where?: InputMaybe<SampleAliasIsAliasSamplesConnectionWhere>;
 };
 
 export type SampleAliasAggregateSelection = {
   __typename?: "SampleAliasAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   namespace: StringAggregateSelection;
   value: StringAggregateSelection;
 };
@@ -6508,8 +6725,8 @@ export type SampleAliasConnectWhere = {
 
 export type SampleAliasCreateInput = {
   isAliasSamples?: InputMaybe<SampleAliasIsAliasSamplesFieldInput>;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["input"];
+  value: Scalars["String"]["input"];
 };
 
 export type SampleAliasDeleteInput = {
@@ -6524,7 +6741,7 @@ export type SampleAliasDisconnectInput = {
 
 export type SampleAliasEdge = {
   __typename?: "SampleAliasEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleAlias;
 };
 
@@ -6532,18 +6749,18 @@ export type SampleAliasIsAliasSamplesAggregateInput = {
   AND?: InputMaybe<Array<SampleAliasIsAliasSamplesAggregateInput>>;
   NOT?: InputMaybe<SampleAliasIsAliasSamplesAggregateInput>;
   OR?: InputMaybe<Array<SampleAliasIsAliasSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleAliasIsAliasSamplesNodeAggregationWhereInput>;
 };
 
 export type SampleAliasIsAliasSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -6551,7 +6768,7 @@ export type SampleAliasIsAliasSamplesConnection = {
   __typename?: "SampleAliasIsAliasSamplesConnection";
   edges: Array<SampleAliasIsAliasSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleAliasIsAliasSamplesConnectionSort = {
@@ -6588,71 +6805,71 @@ export type SampleAliasIsAliasSamplesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleAliasIsAliasSamplesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleAliasIsAliasSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleAliasIsAliasSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleAliasIsAliasSamplesRelationship = {
   __typename?: "SampleAliasIsAliasSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -6670,8 +6887,8 @@ export type SampleAliasIsAliasSamplesUpdateFieldInput = {
 };
 
 export type SampleAliasOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more SampleAliasSort objects to sort SampleAliases by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<SampleAliasSort>>;
 };
@@ -6682,7 +6899,7 @@ export type SampleAliasRelationInput = {
 
 export type SampleAliasSampleIsAliasSamplesAggregationSelection = {
   __typename?: "SampleAliasSampleIsAliasSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleAliasSampleIsAliasSamplesNodeAggregateSelection>;
 };
 
@@ -6702,8 +6919,8 @@ export type SampleAliasSort = {
 
 export type SampleAliasUpdateInput = {
   isAliasSamples?: InputMaybe<Array<SampleAliasIsAliasSamplesUpdateFieldInput>>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleAliasWhere = {
@@ -6727,54 +6944,55 @@ export type SampleAliasWhere = {
   isAliasSamples_SINGLE?: InputMaybe<SampleWhere>;
   /** Return SampleAliases where some of the related Samples match this filter */
   isAliasSamples_SOME?: InputMaybe<SampleWhere>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
-  value_CONTAINS?: InputMaybe<Scalars["String"]>;
-  value_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  value_IN?: InputMaybe<Array<Scalars["String"]>>;
-  value_MATCHES?: InputMaybe<Scalars["String"]>;
-  value_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
+  value_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  value_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  value_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  value_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleAliasesConnection = {
   __typename?: "SampleAliasesConnection";
   edges: Array<SampleAliasEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleCohortCohortsHasCohortSampleAggregationSelection = {
   __typename?: "SampleCohortCohortsHasCohortSampleAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleCohortCohortsHasCohortSampleNodeAggregateSelection>;
 };
 
 export type SampleCohortCohortsHasCohortSampleNodeAggregateSelection = {
   __typename?: "SampleCohortCohortsHasCohortSampleNodeAggregateSelection";
   cohortId: StringAggregateSelection;
+  cohortStatus: StringAggregateSelection;
 };
 
 export type SampleCohortsHasCohortSampleAggregateInput = {
   AND?: InputMaybe<Array<SampleCohortsHasCohortSampleAggregateInput>>;
   NOT?: InputMaybe<SampleCohortsHasCohortSampleAggregateInput>;
   OR?: InputMaybe<Array<SampleCohortsHasCohortSampleAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleCohortsHasCohortSampleNodeAggregationWhereInput>;
 };
 
 export type SampleCohortsHasCohortSampleConnectFieldInput = {
   connect?: InputMaybe<Array<CohortConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<CohortConnectWhere>;
 };
 
@@ -6782,7 +7000,7 @@ export type SampleCohortsHasCohortSampleConnection = {
   __typename?: "SampleCohortsHasCohortSampleConnection";
   edges: Array<SampleCohortsHasCohortSampleRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleCohortsHasCohortSampleConnectionSort = {
@@ -6821,26 +7039,41 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
   >;
   NOT?: InputMaybe<SampleCohortsHasCohortSampleNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleCohortsHasCohortSampleNodeAggregationWhereInput>>;
-  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleCohortsHasCohortSampleRelationship = {
   __typename?: "SampleCohortsHasCohortSampleRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Cohort;
 };
 
@@ -6885,22 +7118,22 @@ export type SampleConnectWhere = {
 
 export type SampleCreateInput = {
   cohortsHasCohortSample?: InputMaybe<SampleCohortsHasCohortSampleFieldInput>;
-  datasource: Scalars["String"];
+  datasource: Scalars["String"]["input"];
   hasDbgapDbGaps?: InputMaybe<SampleHasDbgapDbGapsFieldInput>;
   hasMetadataSampleMetadata?: InputMaybe<SampleHasMetadataSampleMetadataFieldInput>;
   hasTempoTempos?: InputMaybe<SampleHasTempoTemposFieldInput>;
   patientsHasSample?: InputMaybe<SamplePatientsHasSampleFieldInput>;
   requestsHasSample?: InputMaybe<SampleRequestsHasSampleFieldInput>;
-  revisable?: InputMaybe<Scalars["Boolean"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
   sampleAliasesIsAlias?: InputMaybe<SampleSampleAliasesIsAliasFieldInput>;
-  sampleCategory: Scalars["String"];
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
+  sampleCategory: Scalars["String"]["input"];
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId: Scalars["String"]["input"];
 };
 
 export type SampleDbGapHasDbgapDbGapsAggregationSelection = {
   __typename?: "SampleDbGapHasDbgapDbGapsAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleDbGapHasDbgapDbGapsNodeAggregateSelection>;
 };
 
@@ -6952,7 +7185,7 @@ export type SampleDisconnectInput = {
 
 export type SampleEdge = {
   __typename?: "SampleEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -6960,18 +7193,18 @@ export type SampleHasDbgapDbGapsAggregateInput = {
   AND?: InputMaybe<Array<SampleHasDbgapDbGapsAggregateInput>>;
   NOT?: InputMaybe<SampleHasDbgapDbGapsAggregateInput>;
   OR?: InputMaybe<Array<SampleHasDbgapDbGapsAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleHasDbgapDbGapsNodeAggregationWhereInput>;
 };
 
 export type SampleHasDbgapDbGapsConnectFieldInput = {
   connect?: InputMaybe<Array<DbGapConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<DbGapConnectWhere>;
 };
 
@@ -6979,7 +7212,7 @@ export type SampleHasDbgapDbGapsConnection = {
   __typename?: "SampleHasDbgapDbGapsConnection";
   edges: Array<SampleHasDbgapDbGapsRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleHasDbgapDbGapsConnectionSort = {
@@ -7016,41 +7249,41 @@ export type SampleHasDbgapDbGapsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleHasDbgapDbGapsNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleHasDbgapDbGapsNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleHasDbgapDbGapsNodeAggregationWhereInput>>;
-  dbGapStudy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dbGapStudy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleHasDbgapDbGapsRelationship = {
   __typename?: "SampleHasDbgapDbGapsRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: DbGap;
 };
 
@@ -7071,18 +7304,18 @@ export type SampleHasMetadataSampleMetadataAggregateInput = {
   AND?: InputMaybe<Array<SampleHasMetadataSampleMetadataAggregateInput>>;
   NOT?: InputMaybe<SampleHasMetadataSampleMetadataAggregateInput>;
   OR?: InputMaybe<Array<SampleHasMetadataSampleMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleHasMetadataSampleMetadataNodeAggregationWhereInput>;
 };
 
 export type SampleHasMetadataSampleMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<SampleMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleMetadataConnectWhere>;
 };
 
@@ -7090,7 +7323,7 @@ export type SampleHasMetadataSampleMetadataConnection = {
   __typename?: "SampleHasMetadataSampleMetadataConnection";
   edges: Array<SampleHasMetadataSampleMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleHasMetadataSampleMetadataConnectionSort = {
@@ -7131,406 +7364,444 @@ export type SampleHasMetadataSampleMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<SampleHasMetadataSampleMetadataNodeAggregationWhereInput>
   >;
-  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleHasMetadataSampleMetadataRelationship = {
   __typename?: "SampleHasMetadataSampleMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleMetadata;
 };
 
@@ -7553,18 +7824,18 @@ export type SampleHasTempoTemposAggregateInput = {
   AND?: InputMaybe<Array<SampleHasTempoTemposAggregateInput>>;
   NOT?: InputMaybe<SampleHasTempoTemposAggregateInput>;
   OR?: InputMaybe<Array<SampleHasTempoTemposAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleHasTempoTemposNodeAggregationWhereInput>;
 };
 
 export type SampleHasTempoTemposConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -7572,7 +7843,7 @@ export type SampleHasTempoTemposConnection = {
   __typename?: "SampleHasTempoTemposConnection";
   edges: Array<SampleHasTempoTemposRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleHasTempoTemposConnectionSort = {
@@ -7609,116 +7880,164 @@ export type SampleHasTempoTemposNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleHasTempoTemposNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleHasTempoTemposNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleHasTempoTemposNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleHasTempoTemposRelationship = {
   __typename?: "SampleHasTempoTemposRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -7737,75 +8056,75 @@ export type SampleHasTempoTemposUpdateFieldInput = {
 
 export type SampleMetadata = {
   __typename?: "SampleMetadata";
-  additionalProperties: Scalars["String"];
-  baitSet?: Maybe<Scalars["String"]>;
-  cfDNA2dBarcode?: Maybe<Scalars["String"]>;
-  cmoInfoIgoId?: Maybe<Scalars["String"]>;
-  cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleIdFields: Scalars["String"];
-  cmoSampleName?: Maybe<Scalars["String"]>;
-  collectionYear?: Maybe<Scalars["String"]>;
-  genePanel: Scalars["String"];
+  additionalProperties: Scalars["String"]["output"];
+  baitSet?: Maybe<Scalars["String"]["output"]>;
+  cfDNA2dBarcode?: Maybe<Scalars["String"]["output"]>;
+  cmoInfoIgoId?: Maybe<Scalars["String"]["output"]>;
+  cmoPatientId?: Maybe<Scalars["String"]["output"]>;
+  cmoSampleIdFields: Scalars["String"]["output"];
+  cmoSampleName?: Maybe<Scalars["String"]["output"]>;
+  collectionYear?: Maybe<Scalars["String"]["output"]>;
+  genePanel: Scalars["String"]["output"];
   hasStatusStatuses: Array<Status>;
   hasStatusStatusesAggregate?: Maybe<SampleMetadataStatusHasStatusStatusesAggregationSelection>;
   hasStatusStatusesConnection: SampleMetadataHasStatusStatusesConnection;
-  igoComplete?: Maybe<Scalars["Boolean"]>;
-  igoRequestId?: Maybe<Scalars["String"]>;
-  importDate: Scalars["BigInt"];
-  investigatorSampleId?: Maybe<Scalars["String"]>;
-  libraries: Scalars["String"];
-  oncotreeCode?: Maybe<Scalars["String"]>;
-  preservation?: Maybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
-  qcReports: Scalars["String"];
-  sampleClass?: Maybe<Scalars["String"]>;
-  sampleName?: Maybe<Scalars["String"]>;
-  sampleOrigin?: Maybe<Scalars["String"]>;
-  sampleType?: Maybe<Scalars["String"]>;
+  igoComplete?: Maybe<Scalars["Boolean"]["output"]>;
+  igoRequestId?: Maybe<Scalars["String"]["output"]>;
+  importDate: Scalars["BigInt"]["output"];
+  investigatorSampleId?: Maybe<Scalars["String"]["output"]>;
+  libraries: Scalars["String"]["output"];
+  oncotreeCode?: Maybe<Scalars["String"]["output"]>;
+  preservation?: Maybe<Scalars["String"]["output"]>;
+  primaryId: Scalars["String"]["output"];
+  qcReports: Scalars["String"]["output"];
+  sampleClass?: Maybe<Scalars["String"]["output"]>;
+  sampleName?: Maybe<Scalars["String"]["output"]>;
+  sampleOrigin?: Maybe<Scalars["String"]["output"]>;
+  sampleType?: Maybe<Scalars["String"]["output"]>;
   samplesHasMetadata: Array<Sample>;
   samplesHasMetadataAggregate?: Maybe<SampleMetadataSampleSamplesHasMetadataAggregationSelection>;
   samplesHasMetadataConnection: SampleMetadataSamplesHasMetadataConnection;
-  sex?: Maybe<Scalars["String"]>;
-  species?: Maybe<Scalars["String"]>;
-  tissueLocation?: Maybe<Scalars["String"]>;
-  tubeId?: Maybe<Scalars["String"]>;
-  tumorOrNormal?: Maybe<Scalars["String"]>;
+  sex?: Maybe<Scalars["String"]["output"]>;
+  species?: Maybe<Scalars["String"]["output"]>;
+  tissueLocation?: Maybe<Scalars["String"]["output"]>;
+  tubeId?: Maybe<Scalars["String"]["output"]>;
+  tumorOrNormal?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type SampleMetadataHasStatusStatusesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<StatusOptions>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type SampleMetadataHasStatusStatusesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type SampleMetadataHasStatusStatusesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleMetadataHasStatusStatusesConnectionSort>>;
   where?: InputMaybe<SampleMetadataHasStatusStatusesConnectionWhere>;
 };
 
 export type SampleMetadataSamplesHasMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleMetadataSamplesHasMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleMetadataSamplesHasMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleMetadataSamplesHasMetadataConnectionSort>>;
   where?: InputMaybe<SampleMetadataSamplesHasMetadataConnectionWhere>;
 };
@@ -7820,7 +8139,7 @@ export type SampleMetadataAggregateSelection = {
   cmoSampleIdFields: StringAggregateSelection;
   cmoSampleName: StringAggregateSelection;
   collectionYear: StringAggregateSelection;
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   genePanel: StringAggregateSelection;
   igoRequestId: StringAggregateSelection;
   importDate: BigIntAggregateSelection;
@@ -7858,39 +8177,39 @@ export type SampleMetadataConnection = {
   __typename?: "SampleMetadataConnection";
   edges: Array<SampleMetadataEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleMetadataCreateInput = {
-  additionalProperties: Scalars["String"];
-  baitSet?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields: Scalars["String"];
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  genePanel: Scalars["String"];
+  additionalProperties: Scalars["String"]["input"];
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields: Scalars["String"]["input"];
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel: Scalars["String"]["input"];
   hasStatusStatuses?: InputMaybe<SampleMetadataHasStatusStatusesFieldInput>;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  importDate: Scalars["BigInt"];
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  libraries: Scalars["String"];
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
-  qcReports: Scalars["String"];
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleName?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  importDate: Scalars["BigInt"]["input"];
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  libraries: Scalars["String"]["input"];
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId: Scalars["String"]["input"];
+  qcReports: Scalars["String"]["input"];
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasMetadata?: InputMaybe<SampleMetadataSamplesHasMetadataFieldInput>;
-  sex?: InputMaybe<Scalars["String"]>;
-  species?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tubeId?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleMetadataDeleteInput = {
@@ -7913,7 +8232,7 @@ export type SampleMetadataDisconnectInput = {
 
 export type SampleMetadataEdge = {
   __typename?: "SampleMetadataEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleMetadata;
 };
 
@@ -7921,18 +8240,18 @@ export type SampleMetadataHasStatusStatusesAggregateInput = {
   AND?: InputMaybe<Array<SampleMetadataHasStatusStatusesAggregateInput>>;
   NOT?: InputMaybe<SampleMetadataHasStatusStatusesAggregateInput>;
   OR?: InputMaybe<Array<SampleMetadataHasStatusStatusesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleMetadataHasStatusStatusesNodeAggregationWhereInput>;
 };
 
 export type SampleMetadataHasStatusStatusesConnectFieldInput = {
   connect?: InputMaybe<Array<StatusConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<StatusConnectWhere>;
 };
 
@@ -7940,7 +8259,7 @@ export type SampleMetadataHasStatusStatusesConnection = {
   __typename?: "SampleMetadataHasStatusStatusesConnection";
   edges: Array<SampleMetadataHasStatusStatusesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleMetadataHasStatusStatusesConnectionSort = {
@@ -7981,26 +8300,26 @@ export type SampleMetadataHasStatusStatusesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<SampleMetadataHasStatusStatusesNodeAggregationWhereInput>
   >;
-  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleMetadataHasStatusStatusesRelationship = {
   __typename?: "SampleMetadataHasStatusStatusesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Status;
 };
 
@@ -8020,8 +8339,8 @@ export type SampleMetadataHasStatusStatusesUpdateFieldInput = {
 };
 
 export type SampleMetadataOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more SampleMetadataSort objects to sort SampleMetadata by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<SampleMetadataSort>>;
 };
@@ -8037,7 +8356,7 @@ export type SampleMetadataRelationInput = {
 
 export type SampleMetadataSampleSamplesHasMetadataAggregationSelection = {
   __typename?: "SampleMetadataSampleSamplesHasMetadataAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleMetadataSampleSamplesHasMetadataNodeAggregateSelection>;
 };
 
@@ -8053,18 +8372,18 @@ export type SampleMetadataSamplesHasMetadataAggregateInput = {
   AND?: InputMaybe<Array<SampleMetadataSamplesHasMetadataAggregateInput>>;
   NOT?: InputMaybe<SampleMetadataSamplesHasMetadataAggregateInput>;
   OR?: InputMaybe<Array<SampleMetadataSamplesHasMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleMetadataSamplesHasMetadataNodeAggregationWhereInput>;
 };
 
 export type SampleMetadataSamplesHasMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -8072,7 +8391,7 @@ export type SampleMetadataSamplesHasMetadataConnection = {
   __typename?: "SampleMetadataSamplesHasMetadataConnection";
   edges: Array<SampleMetadataSamplesHasMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleMetadataSamplesHasMetadataConnectionSort = {
@@ -8115,71 +8434,71 @@ export type SampleMetadataSamplesHasMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<SampleMetadataSamplesHasMetadataNodeAggregationWhereInput>
   >;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleMetadataSamplesHasMetadataRelationship = {
   __typename?: "SampleMetadataSamplesHasMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -8233,7 +8552,7 @@ export type SampleMetadataSort = {
 
 export type SampleMetadataStatusHasStatusStatusesAggregationSelection = {
   __typename?: "SampleMetadataStatusHasStatusStatusesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleMetadataStatusHasStatusStatusesNodeAggregateSelection>;
 };
 
@@ -8243,101 +8562,101 @@ export type SampleMetadataStatusHasStatusStatusesNodeAggregateSelection = {
 };
 
 export type SampleMetadataUpdateInput = {
-  additionalProperties?: InputMaybe<Scalars["String"]>;
-  baitSet?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields?: InputMaybe<Scalars["String"]>;
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
+  additionalProperties?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
   hasStatusStatuses?: InputMaybe<
     Array<SampleMetadataHasStatusStatusesUpdateFieldInput>
   >;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  libraries?: InputMaybe<Scalars["String"]>;
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
-  qcReports?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleName?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  libraries?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasMetadata?: InputMaybe<
     Array<SampleMetadataSamplesHasMetadataUpdateFieldInput>
   >;
-  sex?: InputMaybe<Scalars["String"]>;
-  species?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tubeId?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleMetadataWhere = {
   AND?: InputMaybe<Array<SampleMetadataWhere>>;
   NOT?: InputMaybe<SampleMetadataWhere>;
   OR?: InputMaybe<Array<SampleMetadataWhere>>;
-  additionalProperties?: InputMaybe<Scalars["String"]>;
-  additionalProperties_CONTAINS?: InputMaybe<Scalars["String"]>;
-  additionalProperties_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  additionalProperties_IN?: InputMaybe<Array<Scalars["String"]>>;
-  additionalProperties_MATCHES?: InputMaybe<Scalars["String"]>;
-  additionalProperties_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  baitSet?: InputMaybe<Scalars["String"]>;
-  baitSet_CONTAINS?: InputMaybe<Scalars["String"]>;
-  baitSet_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  baitSet_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  baitSet_MATCHES?: InputMaybe<Scalars["String"]>;
-  baitSet_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cfDNA2dBarcode_MATCHES?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoInfoIgoId_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoPatientId_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_IN?: InputMaybe<Array<Scalars["String"]>>;
-  cmoSampleIdFields_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoSampleName_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  collectionYear_CONTAINS?: InputMaybe<Scalars["String"]>;
-  collectionYear_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  collectionYear_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  collectionYear_MATCHES?: InputMaybe<Scalars["String"]>;
-  collectionYear_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
-  genePanel_CONTAINS?: InputMaybe<Scalars["String"]>;
-  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel_IN?: InputMaybe<Array<Scalars["String"]>>;
-  genePanel_MATCHES?: InputMaybe<Scalars["String"]>;
-  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  additionalProperties?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  additionalProperties_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  baitSet_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cfDNA2dBarcode_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cmoInfoIgoId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cmoPatientId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  cmoSampleIdFields_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cmoSampleName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  collectionYear_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  genePanel_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasStatusStatusesAggregate?: InputMaybe<SampleMetadataHasStatusStatusesAggregateInput>;
   /** Return SampleMetadata where all of the related SampleMetadataHasStatusStatusesConnections match this filter */
   hasStatusStatusesConnection_ALL?: InputMaybe<SampleMetadataHasStatusStatusesConnectionWhere>;
@@ -8355,79 +8674,81 @@ export type SampleMetadataWhere = {
   hasStatusStatuses_SINGLE?: InputMaybe<StatusWhere>;
   /** Return SampleMetadata where some of the related Statuses match this filter */
   hasStatusStatuses_SOME?: InputMaybe<StatusWhere>;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]>>;
-  importDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  investigatorSampleId_MATCHES?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  libraries?: InputMaybe<Scalars["String"]>;
-  libraries_CONTAINS?: InputMaybe<Scalars["String"]>;
-  libraries_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  libraries_IN?: InputMaybe<Array<Scalars["String"]>>;
-  libraries_MATCHES?: InputMaybe<Scalars["String"]>;
-  libraries_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_CONTAINS?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  oncotreeCode_MATCHES?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  preservation_CONTAINS?: InputMaybe<Scalars["String"]>;
-  preservation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  preservation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  preservation_MATCHES?: InputMaybe<Scalars["String"]>;
-  preservation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
-  primaryId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  primaryId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  primaryId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  primaryId_MATCHES?: InputMaybe<Scalars["String"]>;
-  primaryId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  qcReports?: InputMaybe<Scalars["String"]>;
-  qcReports_CONTAINS?: InputMaybe<Scalars["String"]>;
-  qcReports_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  qcReports_IN?: InputMaybe<Array<Scalars["String"]>>;
-  qcReports_MATCHES?: InputMaybe<Scalars["String"]>;
-  qcReports_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleClass_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleName?: InputMaybe<Scalars["String"]>;
-  sampleName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleName_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleOrigin_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
-  sampleType_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleType_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleType_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleType_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  importDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  investigatorSampleId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraries?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  libraries_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  oncotreeCode_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  preservation_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  primaryId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  qcReports_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleClass_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleOrigin_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleType_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasMetadataAggregate?: InputMaybe<SampleMetadataSamplesHasMetadataAggregateInput>;
   /** Return SampleMetadata where all of the related SampleMetadataSamplesHasMetadataConnections match this filter */
   samplesHasMetadataConnection_ALL?: InputMaybe<SampleMetadataSamplesHasMetadataConnectionWhere>;
@@ -8445,48 +8766,48 @@ export type SampleMetadataWhere = {
   samplesHasMetadata_SINGLE?: InputMaybe<SampleWhere>;
   /** Return SampleMetadata where some of the related Samples match this filter */
   samplesHasMetadata_SOME?: InputMaybe<SampleWhere>;
-  sex?: InputMaybe<Scalars["String"]>;
-  sex_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sex_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sex_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sex_MATCHES?: InputMaybe<Scalars["String"]>;
-  sex_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  species?: InputMaybe<Scalars["String"]>;
-  species_CONTAINS?: InputMaybe<Scalars["String"]>;
-  species_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  species_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  species_MATCHES?: InputMaybe<Scalars["String"]>;
-  species_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tissueLocation_CONTAINS?: InputMaybe<Scalars["String"]>;
-  tissueLocation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  tissueLocation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  tissueLocation_MATCHES?: InputMaybe<Scalars["String"]>;
-  tissueLocation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  tubeId?: InputMaybe<Scalars["String"]>;
-  tubeId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  tubeId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  tubeId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  tubeId_MATCHES?: InputMaybe<Scalars["String"]>;
-  tubeId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_CONTAINS?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  tumorOrNormal_MATCHES?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  sex_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sex_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sex_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sex_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sex_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  species_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  species_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  species_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  species_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  species_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  tissueLocation_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  tubeId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  tumorOrNormal_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more SampleSort objects to sort Samples by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<SampleSort>>;
 };
 
 export type SamplePatientPatientsHasSampleAggregationSelection = {
   __typename?: "SamplePatientPatientsHasSampleAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SamplePatientPatientsHasSampleNodeAggregateSelection>;
 };
 
@@ -8499,18 +8820,18 @@ export type SamplePatientsHasSampleAggregateInput = {
   AND?: InputMaybe<Array<SamplePatientsHasSampleAggregateInput>>;
   NOT?: InputMaybe<SamplePatientsHasSampleAggregateInput>;
   OR?: InputMaybe<Array<SamplePatientsHasSampleAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SamplePatientsHasSampleNodeAggregationWhereInput>;
 };
 
 export type SamplePatientsHasSampleConnectFieldInput = {
   connect?: InputMaybe<Array<PatientConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<PatientConnectWhere>;
 };
 
@@ -8518,7 +8839,7 @@ export type SamplePatientsHasSampleConnection = {
   __typename?: "SamplePatientsHasSampleConnection";
   edges: Array<SamplePatientsHasSampleRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SamplePatientsHasSampleConnectionSort = {
@@ -8555,26 +8876,26 @@ export type SamplePatientsHasSampleNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SamplePatientsHasSampleNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SamplePatientsHasSampleNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SamplePatientsHasSampleNodeAggregationWhereInput>>;
-  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SamplePatientsHasSampleRelationship = {
   __typename?: "SamplePatientsHasSampleRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Patient;
 };
 
@@ -8613,7 +8934,7 @@ export type SampleRelationInput = {
 
 export type SampleRequestRequestsHasSampleAggregationSelection = {
   __typename?: "SampleRequestRequestsHasSampleAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleRequestRequestsHasSampleNodeAggregateSelection>;
 };
 
@@ -8646,18 +8967,18 @@ export type SampleRequestsHasSampleAggregateInput = {
   AND?: InputMaybe<Array<SampleRequestsHasSampleAggregateInput>>;
   NOT?: InputMaybe<SampleRequestsHasSampleAggregateInput>;
   OR?: InputMaybe<Array<SampleRequestsHasSampleAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleRequestsHasSampleNodeAggregationWhereInput>;
 };
 
 export type SampleRequestsHasSampleConnectFieldInput = {
   connect?: InputMaybe<Array<RequestConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestConnectWhere>;
 };
 
@@ -8665,7 +8986,7 @@ export type SampleRequestsHasSampleConnection = {
   __typename?: "SampleRequestsHasSampleConnection";
   edges: Array<SampleRequestsHasSampleRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleRequestsHasSampleConnectionSort = {
@@ -8702,331 +9023,341 @@ export type SampleRequestsHasSampleNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleRequestsHasSampleNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleRequestsHasSampleNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleRequestsHasSampleNodeAggregationWhereInput>>;
-  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleRequestsHasSampleRelationship = {
   __typename?: "SampleRequestsHasSampleRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -9045,7 +9376,7 @@ export type SampleRequestsHasSampleUpdateFieldInput = {
 
 export type SampleSampleAliasSampleAliasesIsAliasAggregationSelection = {
   __typename?: "SampleSampleAliasSampleAliasesIsAliasAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleSampleAliasSampleAliasesIsAliasNodeAggregateSelection>;
 };
 
@@ -9059,18 +9390,18 @@ export type SampleSampleAliasesIsAliasAggregateInput = {
   AND?: InputMaybe<Array<SampleSampleAliasesIsAliasAggregateInput>>;
   NOT?: InputMaybe<SampleSampleAliasesIsAliasAggregateInput>;
   OR?: InputMaybe<Array<SampleSampleAliasesIsAliasAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleSampleAliasesIsAliasNodeAggregationWhereInput>;
 };
 
 export type SampleSampleAliasesIsAliasConnectFieldInput = {
   connect?: InputMaybe<Array<SampleAliasConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleAliasConnectWhere>;
 };
 
@@ -9078,7 +9409,7 @@ export type SampleSampleAliasesIsAliasConnection = {
   __typename?: "SampleSampleAliasesIsAliasConnection";
   edges: Array<SampleSampleAliasesIsAliasRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleSampleAliasesIsAliasConnectionSort = {
@@ -9115,41 +9446,41 @@ export type SampleSampleAliasesIsAliasNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleSampleAliasesIsAliasNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleSampleAliasesIsAliasNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleSampleAliasesIsAliasNodeAggregationWhereInput>>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleSampleAliasesIsAliasRelationship = {
   __typename?: "SampleSampleAliasesIsAliasRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleAlias;
 };
 
@@ -9171,7 +9502,7 @@ export type SampleSampleAliasesIsAliasUpdateFieldInput = {
 export type SampleSampleMetadataHasMetadataSampleMetadataAggregationSelection =
   {
     __typename?: "SampleSampleMetadataHasMetadataSampleMetadataAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<SampleSampleMetadataHasMetadataSampleMetadataNodeAggregateSelection>;
   };
 
@@ -9217,7 +9548,7 @@ export type SampleSort = {
 
 export type SampleTempoHasTempoTemposAggregationSelection = {
   __typename?: "SampleTempoHasTempoTemposAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleTempoHasTempoTemposNodeAggregateSelection>;
 };
 
@@ -9236,7 +9567,7 @@ export type SampleUpdateInput = {
   cohortsHasCohortSample?: InputMaybe<
     Array<SampleCohortsHasCohortSampleUpdateFieldInput>
   >;
-  datasource?: InputMaybe<Scalars["String"]>;
+  datasource?: InputMaybe<Scalars["String"]["input"]>;
   hasDbgapDbGaps?: InputMaybe<Array<SampleHasDbgapDbGapsUpdateFieldInput>>;
   hasMetadataSampleMetadata?: InputMaybe<
     Array<SampleHasMetadataSampleMetadataUpdateFieldInput>
@@ -9248,13 +9579,13 @@ export type SampleUpdateInput = {
   requestsHasSample?: InputMaybe<
     Array<SampleRequestsHasSampleUpdateFieldInput>
   >;
-  revisable?: InputMaybe<Scalars["Boolean"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
   sampleAliasesIsAlias?: InputMaybe<
     Array<SampleSampleAliasesIsAliasUpdateFieldInput>
   >;
-  sampleCategory?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  smileSampleId?: InputMaybe<Scalars["String"]>;
+  sampleCategory?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleWhere = {
@@ -9278,12 +9609,12 @@ export type SampleWhere = {
   cohortsHasCohortSample_SINGLE?: InputMaybe<CohortWhere>;
   /** Return Samples where some of the related Cohorts match this filter */
   cohortsHasCohortSample_SOME?: InputMaybe<CohortWhere>;
-  datasource?: InputMaybe<Scalars["String"]>;
-  datasource_CONTAINS?: InputMaybe<Scalars["String"]>;
-  datasource_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  datasource_IN?: InputMaybe<Array<Scalars["String"]>>;
-  datasource_MATCHES?: InputMaybe<Scalars["String"]>;
-  datasource_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  datasource?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  datasource_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasDbgapDbGapsAggregate?: InputMaybe<SampleHasDbgapDbGapsAggregateInput>;
   /** Return Samples where all of the related SampleHasDbgapDbGapsConnections match this filter */
   hasDbgapDbGapsConnection_ALL?: InputMaybe<SampleHasDbgapDbGapsConnectionWhere>;
@@ -9369,7 +9700,7 @@ export type SampleWhere = {
   requestsHasSample_SINGLE?: InputMaybe<RequestWhere>;
   /** Return Samples where some of the related Requests match this filter */
   requestsHasSample_SOME?: InputMaybe<RequestWhere>;
-  revisable?: InputMaybe<Scalars["Boolean"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
   sampleAliasesIsAliasAggregate?: InputMaybe<SampleSampleAliasesIsAliasAggregateInput>;
   /** Return Samples where all of the related SampleSampleAliasesIsAliasConnections match this filter */
   sampleAliasesIsAliasConnection_ALL?: InputMaybe<SampleSampleAliasesIsAliasConnectionWhere>;
@@ -9387,38 +9718,38 @@ export type SampleWhere = {
   sampleAliasesIsAlias_SINGLE?: InputMaybe<SampleAliasWhere>;
   /** Return Samples where some of the related SampleAliases match this filter */
   sampleAliasesIsAlias_SOME?: InputMaybe<SampleAliasWhere>;
-  sampleCategory?: InputMaybe<Scalars["String"]>;
-  sampleCategory_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleCategory_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleCategory_IN?: InputMaybe<Array<Scalars["String"]>>;
-  sampleCategory_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleCategory_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleClass_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  smileSampleId?: InputMaybe<Scalars["String"]>;
-  smileSampleId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileSampleId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileSampleId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  sampleCategory?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  sampleCategory_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleClass_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileSampleId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SamplesConnection = {
   __typename?: "SamplesConnection";
   edges: Array<SampleEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SeqDateAccessionBySampleId = {
   __typename?: "SeqDateAccessionBySampleId";
-  DMP_SAMPLE_ID: Scalars["String"];
-  MOLECULAR_ACCESSION_NUMBER?: Maybe<Scalars["String"]>;
-  SEQUENCING_DATE: Scalars["String"];
+  DMP_SAMPLE_ID: Scalars["String"]["output"];
+  MOLECULAR_ACCESSION_NUMBER?: Maybe<Scalars["String"]["output"]>;
+  SEQUENCING_DATE: Scalars["String"]["output"];
 };
 
 /** An enum for sorting in either ascending or descending order. */
@@ -9437,51 +9768,51 @@ export type Status = {
   sampleMetadataHasStatus: Array<SampleMetadata>;
   sampleMetadataHasStatusAggregate?: Maybe<StatusSampleMetadataSampleMetadataHasStatusAggregationSelection>;
   sampleMetadataHasStatusConnection: StatusSampleMetadataHasStatusConnection;
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type StatusRequestMetadataHasStatusArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestMetadataOptions>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type StatusRequestMetadataHasStatusAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type StatusRequestMetadataHasStatusConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<StatusRequestMetadataHasStatusConnectionSort>>;
   where?: InputMaybe<StatusRequestMetadataHasStatusConnectionWhere>;
 };
 
 export type StatusSampleMetadataHasStatusArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleMetadataOptions>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type StatusSampleMetadataHasStatusAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type StatusSampleMetadataHasStatusConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<StatusSampleMetadataHasStatusConnectionSort>>;
   where?: InputMaybe<StatusSampleMetadataHasStatusConnectionWhere>;
 };
 
 export type StatusAggregateSelection = {
   __typename?: "StatusAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   validationReport: StringAggregateSelection;
 };
 
@@ -9501,8 +9832,8 @@ export type StatusConnectWhere = {
 export type StatusCreateInput = {
   requestMetadataHasStatus?: InputMaybe<StatusRequestMetadataHasStatusFieldInput>;
   sampleMetadataHasStatus?: InputMaybe<StatusSampleMetadataHasStatusFieldInput>;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type StatusDeleteInput = {
@@ -9525,13 +9856,13 @@ export type StatusDisconnectInput = {
 
 export type StatusEdge = {
   __typename?: "StatusEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Status;
 };
 
 export type StatusOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more StatusSort objects to sort Statuses by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<StatusSort>>;
 };
@@ -9549,18 +9880,18 @@ export type StatusRequestMetadataHasStatusAggregateInput = {
   AND?: InputMaybe<Array<StatusRequestMetadataHasStatusAggregateInput>>;
   NOT?: InputMaybe<StatusRequestMetadataHasStatusAggregateInput>;
   OR?: InputMaybe<Array<StatusRequestMetadataHasStatusAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<StatusRequestMetadataHasStatusNodeAggregationWhereInput>;
 };
 
 export type StatusRequestMetadataHasStatusConnectFieldInput = {
   connect?: InputMaybe<Array<RequestMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestMetadataConnectWhere>;
 };
 
@@ -9568,7 +9899,7 @@ export type StatusRequestMetadataHasStatusConnection = {
   __typename?: "StatusRequestMetadataHasStatusConnection";
   edges: Array<StatusRequestMetadataHasStatusRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type StatusRequestMetadataHasStatusConnectionSort = {
@@ -9609,61 +9940,71 @@ export type StatusRequestMetadataHasStatusNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<StatusRequestMetadataHasStatusNodeAggregationWhereInput>
   >;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type StatusRequestMetadataHasStatusRelationship = {
   __typename?: "StatusRequestMetadataHasStatusRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: RequestMetadata;
 };
 
@@ -9685,7 +10026,7 @@ export type StatusRequestMetadataHasStatusUpdateFieldInput = {
 export type StatusRequestMetadataRequestMetadataHasStatusAggregationSelection =
   {
     __typename?: "StatusRequestMetadataRequestMetadataHasStatusAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<StatusRequestMetadataRequestMetadataHasStatusNodeAggregateSelection>;
   };
 
@@ -9701,18 +10042,18 @@ export type StatusSampleMetadataHasStatusAggregateInput = {
   AND?: InputMaybe<Array<StatusSampleMetadataHasStatusAggregateInput>>;
   NOT?: InputMaybe<StatusSampleMetadataHasStatusAggregateInput>;
   OR?: InputMaybe<Array<StatusSampleMetadataHasStatusAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<StatusSampleMetadataHasStatusNodeAggregationWhereInput>;
 };
 
 export type StatusSampleMetadataHasStatusConnectFieldInput = {
   connect?: InputMaybe<Array<SampleMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleMetadataConnectWhere>;
 };
 
@@ -9720,7 +10061,7 @@ export type StatusSampleMetadataHasStatusConnection = {
   __typename?: "StatusSampleMetadataHasStatusConnection";
   edges: Array<StatusSampleMetadataHasStatusRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type StatusSampleMetadataHasStatusConnectionSort = {
@@ -9761,406 +10102,444 @@ export type StatusSampleMetadataHasStatusNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<StatusSampleMetadataHasStatusNodeAggregationWhereInput>
   >;
-  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type StatusSampleMetadataHasStatusRelationship = {
   __typename?: "StatusSampleMetadataHasStatusRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleMetadata;
 };
 
@@ -10181,7 +10560,7 @@ export type StatusSampleMetadataHasStatusUpdateFieldInput = {
 
 export type StatusSampleMetadataSampleMetadataHasStatusAggregationSelection = {
   __typename?: "StatusSampleMetadataSampleMetadataHasStatusAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<StatusSampleMetadataSampleMetadataHasStatusNodeAggregateSelection>;
 };
 
@@ -10229,8 +10608,8 @@ export type StatusUpdateInput = {
   sampleMetadataHasStatus?: InputMaybe<
     Array<StatusSampleMetadataHasStatusUpdateFieldInput>
   >;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type StatusWhere = {
@@ -10271,36 +10650,38 @@ export type StatusWhere = {
   sampleMetadataHasStatus_SINGLE?: InputMaybe<SampleMetadataWhere>;
   /** Return Statuses where some of the related SampleMetadata match this filter */
   sampleMetadataHasStatus_SOME?: InputMaybe<SampleMetadataWhere>;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationReport_CONTAINS?: InputMaybe<Scalars["String"]>;
-  validationReport_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  validationReport_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  validationReport_MATCHES?: InputMaybe<Scalars["String"]>;
-  validationReport_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  validationReport_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type StatusesConnection = {
   __typename?: "StatusesConnection";
   edges: Array<StatusEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type StringAggregateSelection = {
   __typename?: "StringAggregateSelection";
-  longest?: Maybe<Scalars["String"]>;
-  shortest?: Maybe<Scalars["String"]>;
+  longest?: Maybe<Scalars["String"]["output"]>;
+  shortest?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type Tempo = {
   __typename?: "Tempo";
-  accessLevel?: Maybe<Scalars["String"]>;
-  billed?: Maybe<Scalars["Boolean"]>;
-  billedBy?: Maybe<Scalars["String"]>;
-  costCenter?: Maybe<Scalars["String"]>;
-  custodianInformation?: Maybe<Scalars["String"]>;
-  embargoDate?: Maybe<Scalars["String"]>;
+  accessLevel?: Maybe<Scalars["String"]["output"]>;
+  billed?: Maybe<Scalars["Boolean"]["output"]>;
+  billedBy?: Maybe<Scalars["String"]["output"]>;
+  costCenter?: Maybe<Scalars["String"]["output"]>;
+  custodianInformation?: Maybe<Scalars["String"]["output"]>;
+  embargoDate?: Maybe<Scalars["String"]["output"]>;
   hasEventBamCompletes: Array<BamComplete>;
   hasEventBamCompletesAggregate?: Maybe<TempoBamCompleteHasEventBamCompletesAggregationSelection>;
   hasEventBamCompletesConnection: TempoHasEventBamCompletesConnection;
@@ -10310,85 +10691,85 @@ export type Tempo = {
   hasEventQcCompletes: Array<QcComplete>;
   hasEventQcCompletesAggregate?: Maybe<TempoQcCompleteHasEventQcCompletesAggregationSelection>;
   hasEventQcCompletesConnection: TempoHasEventQcCompletesConnection;
-  initialPipelineRunDate?: Maybe<Scalars["String"]>;
+  initialPipelineRunDate?: Maybe<Scalars["String"]["output"]>;
   samplesHasTempo: Array<Sample>;
   samplesHasTempoAggregate?: Maybe<TempoSampleSamplesHasTempoAggregationSelection>;
   samplesHasTempoConnection: TempoSamplesHasTempoConnection;
-  smileTempoId: Scalars["String"];
+  smileTempoId: Scalars["String"]["output"];
 };
 
 export type TempoHasEventBamCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<BamCompleteOptions>;
   where?: InputMaybe<BamCompleteWhere>;
 };
 
 export type TempoHasEventBamCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<BamCompleteWhere>;
 };
 
 export type TempoHasEventBamCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoHasEventBamCompletesConnectionSort>>;
   where?: InputMaybe<TempoHasEventBamCompletesConnectionWhere>;
 };
 
 export type TempoHasEventMafCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<MafCompleteOptions>;
   where?: InputMaybe<MafCompleteWhere>;
 };
 
 export type TempoHasEventMafCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<MafCompleteWhere>;
 };
 
 export type TempoHasEventMafCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoHasEventMafCompletesConnectionSort>>;
   where?: InputMaybe<TempoHasEventMafCompletesConnectionWhere>;
 };
 
 export type TempoHasEventQcCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<QcCompleteOptions>;
   where?: InputMaybe<QcCompleteWhere>;
 };
 
 export type TempoHasEventQcCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<QcCompleteWhere>;
 };
 
 export type TempoHasEventQcCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoHasEventQcCompletesConnectionSort>>;
   where?: InputMaybe<TempoHasEventQcCompletesConnectionWhere>;
 };
 
 export type TempoSamplesHasTempoArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type TempoSamplesHasTempoAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type TempoSamplesHasTempoConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoSamplesHasTempoConnectionSort>>;
   where?: InputMaybe<TempoSamplesHasTempoConnectionWhere>;
 };
@@ -10398,7 +10779,7 @@ export type TempoAggregateSelection = {
   accessLevel: StringAggregateSelection;
   billedBy: StringAggregateSelection;
   costCenter: StringAggregateSelection;
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   custodianInformation: StringAggregateSelection;
   embargoDate: StringAggregateSelection;
   initialPipelineRunDate: StringAggregateSelection;
@@ -10407,7 +10788,7 @@ export type TempoAggregateSelection = {
 
 export type TempoBamCompleteHasEventBamCompletesAggregationSelection = {
   __typename?: "TempoBamCompleteHasEventBamCompletesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoBamCompleteHasEventBamCompletesNodeAggregateSelection>;
 };
 
@@ -10419,36 +10800,36 @@ export type TempoBamCompleteHasEventBamCompletesNodeAggregateSelection = {
 
 export type TempoCohortRequest = {
   __typename?: "TempoCohortRequest";
-  cohortId: Scalars["String"];
-  endUsers: Scalars["String"];
-  pmUsers: Scalars["String"];
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
+  cohortId: Scalars["String"]["output"];
+  endUsers: Scalars["String"]["output"];
+  pmUsers: Scalars["String"]["output"];
+  projectSubtitle: Scalars["String"]["output"];
+  projectTitle: Scalars["String"]["output"];
   samples: Array<TempoCohortSample>;
-  type: Scalars["String"];
+  type: Scalars["String"]["output"];
 };
 
 export type TempoCohortRequestInput = {
-  cohortId: Scalars["String"];
-  endUsers: Array<Scalars["String"]>;
-  pmUsers: Array<Scalars["String"]>;
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
+  cohortId: Scalars["String"]["input"];
+  endUsers: Array<Scalars["String"]["input"]>;
+  pmUsers: Array<Scalars["String"]["input"]>;
+  projectSubtitle: Scalars["String"]["input"];
+  projectTitle: Scalars["String"]["input"];
   samples: Array<TempoCohortSampleInput>;
-  type: Scalars["String"];
+  type: Scalars["String"]["input"];
 };
 
 export type TempoCohortSample = {
   __typename?: "TempoCohortSample";
-  cmoId?: Maybe<Scalars["String"]>;
-  embargoDate?: Maybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
+  cmoId?: Maybe<Scalars["String"]["output"]>;
+  embargoDate?: Maybe<Scalars["String"]["output"]>;
+  primaryId: Scalars["String"]["output"];
 };
 
 export type TempoCohortSampleInput = {
-  cmoId?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
+  cmoId?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId: Scalars["String"]["input"];
 };
 
 export type TempoConnectInput = {
@@ -10469,18 +10850,18 @@ export type TempoConnectWhere = {
 };
 
 export type TempoCreateInput = {
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
   hasEventBamCompletes?: InputMaybe<TempoHasEventBamCompletesFieldInput>;
   hasEventMafCompletes?: InputMaybe<TempoHasEventMafCompletesFieldInput>;
   hasEventQcCompletes?: InputMaybe<TempoHasEventQcCompletesFieldInput>;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasTempo?: InputMaybe<TempoSamplesHasTempoFieldInput>;
-  smileTempoId: Scalars["String"];
+  smileTempoId: Scalars["String"]["input"];
 };
 
 export type TempoDeleteInput = {
@@ -10511,7 +10892,7 @@ export type TempoDisconnectInput = {
 
 export type TempoEdge = {
   __typename?: "TempoEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -10519,18 +10900,18 @@ export type TempoHasEventBamCompletesAggregateInput = {
   AND?: InputMaybe<Array<TempoHasEventBamCompletesAggregateInput>>;
   NOT?: InputMaybe<TempoHasEventBamCompletesAggregateInput>;
   OR?: InputMaybe<Array<TempoHasEventBamCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoHasEventBamCompletesNodeAggregationWhereInput>;
 };
 
 export type TempoHasEventBamCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<BamCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<BamCompleteConnectWhere>;
 };
 
@@ -10538,7 +10919,7 @@ export type TempoHasEventBamCompletesConnection = {
   __typename?: "TempoHasEventBamCompletesConnection";
   edges: Array<TempoHasEventBamCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoHasEventBamCompletesConnectionSort = {
@@ -10575,41 +10956,41 @@ export type TempoHasEventBamCompletesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoHasEventBamCompletesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoHasEventBamCompletesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoHasEventBamCompletesNodeAggregationWhereInput>>;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoHasEventBamCompletesRelationship = {
   __typename?: "TempoHasEventBamCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: BamComplete;
 };
 
@@ -10630,18 +11011,18 @@ export type TempoHasEventMafCompletesAggregateInput = {
   AND?: InputMaybe<Array<TempoHasEventMafCompletesAggregateInput>>;
   NOT?: InputMaybe<TempoHasEventMafCompletesAggregateInput>;
   OR?: InputMaybe<Array<TempoHasEventMafCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoHasEventMafCompletesNodeAggregationWhereInput>;
 };
 
 export type TempoHasEventMafCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<MafCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<MafCompleteConnectWhere>;
 };
 
@@ -10649,7 +11030,7 @@ export type TempoHasEventMafCompletesConnection = {
   __typename?: "TempoHasEventMafCompletesConnection";
   edges: Array<TempoHasEventMafCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoHasEventMafCompletesConnectionSort = {
@@ -10686,56 +11067,56 @@ export type TempoHasEventMafCompletesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoHasEventMafCompletesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoHasEventMafCompletesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoHasEventMafCompletesNodeAggregationWhereInput>>;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoHasEventMafCompletesRelationship = {
   __typename?: "TempoHasEventMafCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: MafComplete;
 };
 
@@ -10756,18 +11137,18 @@ export type TempoHasEventQcCompletesAggregateInput = {
   AND?: InputMaybe<Array<TempoHasEventQcCompletesAggregateInput>>;
   NOT?: InputMaybe<TempoHasEventQcCompletesAggregateInput>;
   OR?: InputMaybe<Array<TempoHasEventQcCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoHasEventQcCompletesNodeAggregationWhereInput>;
 };
 
 export type TempoHasEventQcCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<QcCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<QcCompleteConnectWhere>;
 };
 
@@ -10775,7 +11156,7 @@ export type TempoHasEventQcCompletesConnection = {
   __typename?: "TempoHasEventQcCompletesConnection";
   edges: Array<TempoHasEventQcCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoHasEventQcCompletesConnectionSort = {
@@ -10812,71 +11193,71 @@ export type TempoHasEventQcCompletesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoHasEventQcCompletesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoHasEventQcCompletesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoHasEventQcCompletesNodeAggregationWhereInput>>;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  reason_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  reason_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  result_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  result_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  result_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoHasEventQcCompletesRelationship = {
   __typename?: "TempoHasEventQcCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: QcComplete;
 };
 
@@ -10895,7 +11276,7 @@ export type TempoHasEventQcCompletesUpdateFieldInput = {
 
 export type TempoMafCompleteHasEventMafCompletesAggregationSelection = {
   __typename?: "TempoMafCompleteHasEventMafCompletesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoMafCompleteHasEventMafCompletesNodeAggregateSelection>;
 };
 
@@ -10907,15 +11288,15 @@ export type TempoMafCompleteHasEventMafCompletesNodeAggregateSelection = {
 };
 
 export type TempoOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more TempoSort objects to sort Tempos by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<TempoSort>>;
 };
 
 export type TempoQcCompleteHasEventQcCompletesAggregationSelection = {
   __typename?: "TempoQcCompleteHasEventQcCompletesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoQcCompleteHasEventQcCompletesNodeAggregateSelection>;
 };
 
@@ -10942,7 +11323,7 @@ export type TempoRelationInput = {
 
 export type TempoSampleSamplesHasTempoAggregationSelection = {
   __typename?: "TempoSampleSamplesHasTempoAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoSampleSamplesHasTempoNodeAggregateSelection>;
 };
 
@@ -10958,18 +11339,18 @@ export type TempoSamplesHasTempoAggregateInput = {
   AND?: InputMaybe<Array<TempoSamplesHasTempoAggregateInput>>;
   NOT?: InputMaybe<TempoSamplesHasTempoAggregateInput>;
   OR?: InputMaybe<Array<TempoSamplesHasTempoAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoSamplesHasTempoNodeAggregationWhereInput>;
 };
 
 export type TempoSamplesHasTempoConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -10977,7 +11358,7 @@ export type TempoSamplesHasTempoConnection = {
   __typename?: "TempoSamplesHasTempoConnection";
   edges: Array<TempoSamplesHasTempoRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoSamplesHasTempoConnectionSort = {
@@ -11014,71 +11395,71 @@ export type TempoSamplesHasTempoNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoSamplesHasTempoNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoSamplesHasTempoNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoSamplesHasTempoNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoSamplesHasTempoRelationship = {
   __typename?: "TempoSamplesHasTempoRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -11108,12 +11489,12 @@ export type TempoSort = {
 };
 
 export type TempoUpdateInput = {
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
   hasEventBamCompletes?: InputMaybe<
     Array<TempoHasEventBamCompletesUpdateFieldInput>
   >;
@@ -11123,46 +11504,48 @@ export type TempoUpdateInput = {
   hasEventQcCompletes?: InputMaybe<
     Array<TempoHasEventQcCompletesUpdateFieldInput>
   >;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasTempo?: InputMaybe<Array<TempoSamplesHasTempoUpdateFieldInput>>;
-  smileTempoId?: InputMaybe<Scalars["String"]>;
+  smileTempoId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type TempoWhere = {
   AND?: InputMaybe<Array<TempoWhere>>;
   NOT?: InputMaybe<TempoWhere>;
   OR?: InputMaybe<Array<TempoWhere>>;
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  accessLevel_CONTAINS?: InputMaybe<Scalars["String"]>;
-  accessLevel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  accessLevel_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  accessLevel_MATCHES?: InputMaybe<Scalars["String"]>;
-  accessLevel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  billedBy_CONTAINS?: InputMaybe<Scalars["String"]>;
-  billedBy_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  billedBy_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  billedBy_MATCHES?: InputMaybe<Scalars["String"]>;
-  billedBy_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  costCenter_CONTAINS?: InputMaybe<Scalars["String"]>;
-  costCenter_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  costCenter_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  costCenter_MATCHES?: InputMaybe<Scalars["String"]>;
-  costCenter_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  custodianInformation_CONTAINS?: InputMaybe<Scalars["String"]>;
-  custodianInformation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  custodianInformation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  custodianInformation_MATCHES?: InputMaybe<Scalars["String"]>;
-  custodianInformation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
-  embargoDate_CONTAINS?: InputMaybe<Scalars["String"]>;
-  embargoDate_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  embargoDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  embargoDate_MATCHES?: InputMaybe<Scalars["String"]>;
-  embargoDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  accessLevel_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  billedBy_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  costCenter_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  custodianInformation_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  embargoDate_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasEventBamCompletesAggregate?: InputMaybe<TempoHasEventBamCompletesAggregateInput>;
   /** Return Tempos where all of the related TempoHasEventBamCompletesConnections match this filter */
   hasEventBamCompletesConnection_ALL?: InputMaybe<TempoHasEventBamCompletesConnectionWhere>;
@@ -11214,12 +11597,14 @@ export type TempoWhere = {
   hasEventQcCompletes_SINGLE?: InputMaybe<QcCompleteWhere>;
   /** Return Tempos where some of the related QcCompletes match this filter */
   hasEventQcCompletes_SOME?: InputMaybe<QcCompleteWhere>;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_CONTAINS?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  initialPipelineRunDate_MATCHES?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  initialPipelineRunDate_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasTempoAggregate?: InputMaybe<TempoSamplesHasTempoAggregateInput>;
   /** Return Tempos where all of the related TempoSamplesHasTempoConnections match this filter */
   samplesHasTempoConnection_ALL?: InputMaybe<TempoSamplesHasTempoConnectionWhere>;
@@ -11237,26 +11622,26 @@ export type TempoWhere = {
   samplesHasTempo_SINGLE?: InputMaybe<SampleWhere>;
   /** Return Tempos where some of the related Samples match this filter */
   samplesHasTempo_SOME?: InputMaybe<SampleWhere>;
-  smileTempoId?: InputMaybe<Scalars["String"]>;
-  smileTempoId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileTempoId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileTempoId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileTempoId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileTempoId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smileTempoId?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileTempoId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type TemposConnection = {
   __typename?: "TemposConnection";
   edges: Array<TempoEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type ToleratedSampleValidationError = {
   __typename?: "ToleratedSampleValidationError";
-  primaryId: Scalars["String"];
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  primaryId: Scalars["String"]["output"];
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type UpdateBamCompletesMutationResponse = {
@@ -11287,11 +11672,11 @@ export type UpdateDbGapsMutationResponse = {
 export type UpdateInfo = {
   __typename?: "UpdateInfo";
   /** @deprecated This field has been deprecated because bookmarks are now handled by the driver. */
-  bookmark?: Maybe<Scalars["String"]>;
-  nodesCreated: Scalars["Int"];
-  nodesDeleted: Scalars["Int"];
-  relationshipsCreated: Scalars["Int"];
-  relationshipsDeleted: Scalars["Int"];
+  bookmark?: Maybe<Scalars["String"]["output"]>;
+  nodesCreated: Scalars["Int"]["output"];
+  nodesDeleted: Scalars["Int"]["output"];
+  relationshipsCreated: Scalars["Int"]["output"];
+  relationshipsDeleted: Scalars["Int"]["output"];
 };
 
 export type UpdateMafCompletesMutationResponse = {
@@ -11368,18 +11753,20 @@ export type UpdateTemposMutationResponse = {
 
 export type ValidationAdvice = {
   __typename?: "ValidationAdvice";
-  advice: Scalars["String"];
-  suggestedSteps: Array<Scalars["String"]>;
+  advice: Scalars["String"]["output"];
+  suggestedSteps: Array<Scalars["String"]["output"]>;
 };
 
 export type DashboardRequestsQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
 }>;
 
 export type DashboardRequestsQuery = {
@@ -11419,14 +11806,16 @@ export type DashboardRequestsQuery = {
 };
 
 export type DashboardPatientsQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
 export type DashboardPatientsQuery = {
@@ -11450,13 +11839,15 @@ export type DashboardPatientsQuery = {
 };
 
 export type DashboardCohortsQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
 }>;
 
 export type DashboardCohortsQuery = {
@@ -11482,7 +11873,9 @@ export type DashboardCohortsQuery = {
 };
 
 export type DashboardSamplesQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   recordContexts?: InputMaybe<
     | Array<InputMaybe<DashboardRecordContext>>
     | InputMaybe<DashboardRecordContext>
@@ -11491,10 +11884,10 @@ export type DashboardSamplesQueryVariables = Exact<{
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
-  includeDemographics?: InputMaybe<Scalars["Boolean"]>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  includeDemographics?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
 export type DashboardSamplesQuery = {
@@ -11573,10 +11966,10 @@ export type DashboardSamplesQuery = {
 };
 
 export type DashboardSampleHistoryQueryVariables = Exact<{
-  searchVals: Array<Scalars["String"]> | Scalars["String"];
+  searchVals: Array<Scalars["String"]["input"]> | Scalars["String"]["input"];
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
 }>;
 
 export type DashboardSampleHistoryQuery = {
@@ -11838,9 +12231,10 @@ export type AllBlockedCohortIdsQuery = {
 };
 
 export type GetValidationAdviceQueryVariables = Exact<{
-  validationReport: Scalars["String"];
-  recordType: Scalars["String"];
-  recordId?: InputMaybe<Scalars["String"]>;
+  validationReport: Scalars["String"]["input"];
+  recordType: Scalars["String"]["input"];
+  recordId?: InputMaybe<Scalars["String"]["input"]>;
+  igoQcReports?: InputMaybe<Scalars["String"]["input"]>;
 }>;
 
 export type GetValidationAdviceQuery = {
@@ -11853,7 +12247,7 @@ export type GetValidationAdviceQuery = {
 };
 
 export type AllAnchorSeqDateDataQueryVariables = Exact<{
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
 export type AllAnchorSeqDateDataQuery = {
@@ -12098,7 +12492,11 @@ export function useDashboardRequestsQuery(
   baseOptions: Apollo.QueryHookOptions<
     DashboardRequestsQuery,
     DashboardRequestsQueryVariables
-  >
+  > &
+    (
+      | { variables: DashboardRequestsQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -12118,11 +12516,52 @@ export function useDashboardRequestsLazyQuery(
     DashboardRequestsQueryVariables
   >(DashboardRequestsDocument, options);
 }
+// @ts-ignore
+export function useDashboardRequestsSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    DashboardRequestsQuery,
+    DashboardRequestsQueryVariables
+  >
+): Apollo.UseSuspenseQueryResult<
+  DashboardRequestsQuery,
+  DashboardRequestsQueryVariables
+>;
+export function useDashboardRequestsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        DashboardRequestsQuery,
+        DashboardRequestsQueryVariables
+      >
+): Apollo.UseSuspenseQueryResult<
+  DashboardRequestsQuery | undefined,
+  DashboardRequestsQueryVariables
+>;
+export function useDashboardRequestsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        DashboardRequestsQuery,
+        DashboardRequestsQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    DashboardRequestsQuery,
+    DashboardRequestsQueryVariables
+  >(DashboardRequestsDocument, options);
+}
 export type DashboardRequestsQueryHookResult = ReturnType<
   typeof useDashboardRequestsQuery
 >;
 export type DashboardRequestsLazyQueryHookResult = ReturnType<
   typeof useDashboardRequestsLazyQuery
+>;
+export type DashboardRequestsSuspenseQueryHookResult = ReturnType<
+  typeof useDashboardRequestsSuspenseQuery
 >;
 export type DashboardRequestsQueryResult = Apollo.QueryResult<
   DashboardRequestsQuery,
@@ -12187,7 +12626,11 @@ export function useDashboardPatientsQuery(
   baseOptions: Apollo.QueryHookOptions<
     DashboardPatientsQuery,
     DashboardPatientsQueryVariables
-  >
+  > &
+    (
+      | { variables: DashboardPatientsQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -12207,11 +12650,52 @@ export function useDashboardPatientsLazyQuery(
     DashboardPatientsQueryVariables
   >(DashboardPatientsDocument, options);
 }
+// @ts-ignore
+export function useDashboardPatientsSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    DashboardPatientsQuery,
+    DashboardPatientsQueryVariables
+  >
+): Apollo.UseSuspenseQueryResult<
+  DashboardPatientsQuery,
+  DashboardPatientsQueryVariables
+>;
+export function useDashboardPatientsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        DashboardPatientsQuery,
+        DashboardPatientsQueryVariables
+      >
+): Apollo.UseSuspenseQueryResult<
+  DashboardPatientsQuery | undefined,
+  DashboardPatientsQueryVariables
+>;
+export function useDashboardPatientsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        DashboardPatientsQuery,
+        DashboardPatientsQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    DashboardPatientsQuery,
+    DashboardPatientsQueryVariables
+  >(DashboardPatientsDocument, options);
+}
 export type DashboardPatientsQueryHookResult = ReturnType<
   typeof useDashboardPatientsQuery
 >;
 export type DashboardPatientsLazyQueryHookResult = ReturnType<
   typeof useDashboardPatientsLazyQuery
+>;
+export type DashboardPatientsSuspenseQueryHookResult = ReturnType<
+  typeof useDashboardPatientsSuspenseQuery
 >;
 export type DashboardPatientsQueryResult = Apollo.QueryResult<
   DashboardPatientsQuery,
@@ -12275,7 +12759,11 @@ export function useDashboardCohortsQuery(
   baseOptions: Apollo.QueryHookOptions<
     DashboardCohortsQuery,
     DashboardCohortsQueryVariables
-  >
+  > &
+    (
+      | { variables: DashboardCohortsQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<DashboardCohortsQuery, DashboardCohortsQueryVariables>(
@@ -12295,11 +12783,52 @@ export function useDashboardCohortsLazyQuery(
     DashboardCohortsQueryVariables
   >(DashboardCohortsDocument, options);
 }
+// @ts-ignore
+export function useDashboardCohortsSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    DashboardCohortsQuery,
+    DashboardCohortsQueryVariables
+  >
+): Apollo.UseSuspenseQueryResult<
+  DashboardCohortsQuery,
+  DashboardCohortsQueryVariables
+>;
+export function useDashboardCohortsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        DashboardCohortsQuery,
+        DashboardCohortsQueryVariables
+      >
+): Apollo.UseSuspenseQueryResult<
+  DashboardCohortsQuery | undefined,
+  DashboardCohortsQueryVariables
+>;
+export function useDashboardCohortsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        DashboardCohortsQuery,
+        DashboardCohortsQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    DashboardCohortsQuery,
+    DashboardCohortsQueryVariables
+  >(DashboardCohortsDocument, options);
+}
 export type DashboardCohortsQueryHookResult = ReturnType<
   typeof useDashboardCohortsQuery
 >;
 export type DashboardCohortsLazyQueryHookResult = ReturnType<
   typeof useDashboardCohortsLazyQuery
+>;
+export type DashboardCohortsSuspenseQueryHookResult = ReturnType<
+  typeof useDashboardCohortsSuspenseQuery
 >;
 export type DashboardCohortsQueryResult = Apollo.QueryResult<
   DashboardCohortsQuery,
@@ -12373,7 +12902,11 @@ export function useDashboardSamplesQuery(
   baseOptions: Apollo.QueryHookOptions<
     DashboardSamplesQuery,
     DashboardSamplesQueryVariables
-  >
+  > &
+    (
+      | { variables: DashboardSamplesQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<DashboardSamplesQuery, DashboardSamplesQueryVariables>(
@@ -12393,11 +12926,52 @@ export function useDashboardSamplesLazyQuery(
     DashboardSamplesQueryVariables
   >(DashboardSamplesDocument, options);
 }
+// @ts-ignore
+export function useDashboardSamplesSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    DashboardSamplesQuery,
+    DashboardSamplesQueryVariables
+  >
+): Apollo.UseSuspenseQueryResult<
+  DashboardSamplesQuery,
+  DashboardSamplesQueryVariables
+>;
+export function useDashboardSamplesSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        DashboardSamplesQuery,
+        DashboardSamplesQueryVariables
+      >
+): Apollo.UseSuspenseQueryResult<
+  DashboardSamplesQuery | undefined,
+  DashboardSamplesQueryVariables
+>;
+export function useDashboardSamplesSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        DashboardSamplesQuery,
+        DashboardSamplesQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    DashboardSamplesQuery,
+    DashboardSamplesQueryVariables
+  >(DashboardSamplesDocument, options);
+}
 export type DashboardSamplesQueryHookResult = ReturnType<
   typeof useDashboardSamplesQuery
 >;
 export type DashboardSamplesLazyQueryHookResult = ReturnType<
   typeof useDashboardSamplesLazyQuery
+>;
+export type DashboardSamplesSuspenseQueryHookResult = ReturnType<
+  typeof useDashboardSamplesSuspenseQuery
 >;
 export type DashboardSamplesQueryResult = Apollo.QueryResult<
   DashboardSamplesQuery,
@@ -12454,7 +13028,11 @@ export function useDashboardSampleHistoryQuery(
   baseOptions: Apollo.QueryHookOptions<
     DashboardSampleHistoryQuery,
     DashboardSampleHistoryQueryVariables
-  >
+  > &
+    (
+      | { variables: DashboardSampleHistoryQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -12474,11 +13052,52 @@ export function useDashboardSampleHistoryLazyQuery(
     DashboardSampleHistoryQueryVariables
   >(DashboardSampleHistoryDocument, options);
 }
+// @ts-ignore
+export function useDashboardSampleHistorySuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    DashboardSampleHistoryQuery,
+    DashboardSampleHistoryQueryVariables
+  >
+): Apollo.UseSuspenseQueryResult<
+  DashboardSampleHistoryQuery,
+  DashboardSampleHistoryQueryVariables
+>;
+export function useDashboardSampleHistorySuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        DashboardSampleHistoryQuery,
+        DashboardSampleHistoryQueryVariables
+      >
+): Apollo.UseSuspenseQueryResult<
+  DashboardSampleHistoryQuery | undefined,
+  DashboardSampleHistoryQueryVariables
+>;
+export function useDashboardSampleHistorySuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        DashboardSampleHistoryQuery,
+        DashboardSampleHistoryQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    DashboardSampleHistoryQuery,
+    DashboardSampleHistoryQueryVariables
+  >(DashboardSampleHistoryDocument, options);
+}
 export type DashboardSampleHistoryQueryHookResult = ReturnType<
   typeof useDashboardSampleHistoryQuery
 >;
 export type DashboardSampleHistoryLazyQueryHookResult = ReturnType<
   typeof useDashboardSampleHistoryLazyQuery
+>;
+export type DashboardSampleHistorySuspenseQueryHookResult = ReturnType<
+  typeof useDashboardSampleHistorySuspenseQuery
 >;
 export type DashboardSampleHistoryQueryResult = Apollo.QueryResult<
   DashboardSampleHistoryQuery,
@@ -12590,11 +13209,52 @@ export function useAllBlockedCohortIdsLazyQuery(
     AllBlockedCohortIdsQueryVariables
   >(AllBlockedCohortIdsDocument, options);
 }
+// @ts-ignore
+export function useAllBlockedCohortIdsSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    AllBlockedCohortIdsQuery,
+    AllBlockedCohortIdsQueryVariables
+  >
+): Apollo.UseSuspenseQueryResult<
+  AllBlockedCohortIdsQuery,
+  AllBlockedCohortIdsQueryVariables
+>;
+export function useAllBlockedCohortIdsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        AllBlockedCohortIdsQuery,
+        AllBlockedCohortIdsQueryVariables
+      >
+): Apollo.UseSuspenseQueryResult<
+  AllBlockedCohortIdsQuery | undefined,
+  AllBlockedCohortIdsQueryVariables
+>;
+export function useAllBlockedCohortIdsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        AllBlockedCohortIdsQuery,
+        AllBlockedCohortIdsQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    AllBlockedCohortIdsQuery,
+    AllBlockedCohortIdsQueryVariables
+  >(AllBlockedCohortIdsDocument, options);
+}
 export type AllBlockedCohortIdsQueryHookResult = ReturnType<
   typeof useAllBlockedCohortIdsQuery
 >;
 export type AllBlockedCohortIdsLazyQueryHookResult = ReturnType<
   typeof useAllBlockedCohortIdsLazyQuery
+>;
+export type AllBlockedCohortIdsSuspenseQueryHookResult = ReturnType<
+  typeof useAllBlockedCohortIdsSuspenseQuery
 >;
 export type AllBlockedCohortIdsQueryResult = Apollo.QueryResult<
   AllBlockedCohortIdsQuery,
@@ -12605,11 +13265,13 @@ export const GetValidationAdviceDocument = gql`
     $validationReport: String!
     $recordType: String!
     $recordId: String
+    $igoQcReports: String
   ) {
     getValidationAdvice(
       validationReport: $validationReport
       recordType: $recordType
       recordId: $recordId
+      igoQcReports: $igoQcReports
     ) {
       advice
       suggestedSteps
@@ -12632,6 +13294,7 @@ export const GetValidationAdviceDocument = gql`
  *      validationReport: // value for 'validationReport'
  *      recordType: // value for 'recordType'
  *      recordId: // value for 'recordId'
+ *      igoQcReports: // value for 'igoQcReports'
  *   },
  * });
  */
@@ -12639,7 +13302,11 @@ export function useGetValidationAdviceQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetValidationAdviceQuery,
     GetValidationAdviceQueryVariables
-  >
+  > &
+    (
+      | { variables: GetValidationAdviceQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -12659,11 +13326,52 @@ export function useGetValidationAdviceLazyQuery(
     GetValidationAdviceQueryVariables
   >(GetValidationAdviceDocument, options);
 }
+// @ts-ignore
+export function useGetValidationAdviceSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GetValidationAdviceQuery,
+    GetValidationAdviceQueryVariables
+  >
+): Apollo.UseSuspenseQueryResult<
+  GetValidationAdviceQuery,
+  GetValidationAdviceQueryVariables
+>;
+export function useGetValidationAdviceSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetValidationAdviceQuery,
+        GetValidationAdviceQueryVariables
+      >
+): Apollo.UseSuspenseQueryResult<
+  GetValidationAdviceQuery | undefined,
+  GetValidationAdviceQueryVariables
+>;
+export function useGetValidationAdviceSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetValidationAdviceQuery,
+        GetValidationAdviceQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetValidationAdviceQuery,
+    GetValidationAdviceQueryVariables
+  >(GetValidationAdviceDocument, options);
+}
 export type GetValidationAdviceQueryHookResult = ReturnType<
   typeof useGetValidationAdviceQuery
 >;
 export type GetValidationAdviceLazyQueryHookResult = ReturnType<
   typeof useGetValidationAdviceLazyQuery
+>;
+export type GetValidationAdviceSuspenseQueryHookResult = ReturnType<
+  typeof useGetValidationAdviceSuspenseQuery
 >;
 export type GetValidationAdviceQueryResult = Apollo.QueryResult<
   GetValidationAdviceQuery,
@@ -12720,11 +13428,52 @@ export function useAllAnchorSeqDateDataLazyQuery(
     AllAnchorSeqDateDataQueryVariables
   >(AllAnchorSeqDateDataDocument, options);
 }
+// @ts-ignore
+export function useAllAnchorSeqDateDataSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    AllAnchorSeqDateDataQuery,
+    AllAnchorSeqDateDataQueryVariables
+  >
+): Apollo.UseSuspenseQueryResult<
+  AllAnchorSeqDateDataQuery,
+  AllAnchorSeqDateDataQueryVariables
+>;
+export function useAllAnchorSeqDateDataSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        AllAnchorSeqDateDataQuery,
+        AllAnchorSeqDateDataQueryVariables
+      >
+): Apollo.UseSuspenseQueryResult<
+  AllAnchorSeqDateDataQuery | undefined,
+  AllAnchorSeqDateDataQueryVariables
+>;
+export function useAllAnchorSeqDateDataSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        AllAnchorSeqDateDataQuery,
+        AllAnchorSeqDateDataQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    AllAnchorSeqDateDataQuery,
+    AllAnchorSeqDateDataQueryVariables
+  >(AllAnchorSeqDateDataDocument, options);
+}
 export type AllAnchorSeqDateDataQueryHookResult = ReturnType<
   typeof useAllAnchorSeqDateDataQuery
 >;
 export type AllAnchorSeqDateDataLazyQueryHookResult = ReturnType<
   typeof useAllAnchorSeqDateDataLazyQuery
+>;
+export type AllAnchorSeqDateDataSuspenseQueryHookResult = ReturnType<
+  typeof useAllAnchorSeqDateDataSuspenseQuery
 >;
 export type AllAnchorSeqDateDataQueryResult = Apollo.QueryResult<
   AllAnchorSeqDateDataQuery,

--- a/frontend/src/pages/patients/config.tsx
+++ b/frontend/src/pages/patients/config.tsx
@@ -1,5 +1,6 @@
 import {
   AllAnchorSeqDateDataQuery,
+  AllAnchorSeqDateDataQueryVariables,
   AnchorSeqDateData,
   DashboardPatient,
   Exact,
@@ -49,7 +50,7 @@ export const allAnchorSeqDateColDefs: Array<ColDef<AnchorSeqDateData>> = [
 interface AdditionalBuildDownloadOptionsParams {
   queryAllSeqDates: LazyQueryExecFunction<
     AllAnchorSeqDateDataQuery,
-    Exact<{ phiEnabled?: InputMaybe<Scalars["Boolean"]> }>
+    AllAnchorSeqDateDataQueryVariables
   >;
   phiEnabled: boolean;
   userEmail: string | undefined;

--- a/frontend/src/pages/requests/config.tsx
+++ b/frontend/src/pages/requests/config.tsx
@@ -72,6 +72,7 @@ export const requestColDefs: ColDef<DashboardRequest>[] = [
           toleratedSampleErrors={toleratedSampleErrors}
           modalTitle={`Error report for request ${igoRequestId}`}
           recordStatusMap={REQUEST_STATUS_MAP}
+          recordId={igoRequestId}
         />
       ) : (
         <Check className="check-icon" />

--- a/frontend/src/pages/samples/config.tsx
+++ b/frontend/src/pages/samples/config.tsx
@@ -151,6 +151,7 @@ export const sampleColDefs: Array<ColDef<DashboardSample>> = [
             validationReport={validationReport}
             modalTitle={`Error report for sample ${primaryId}`}
             recordStatusMap={SAMPLE_STATUS_MAP}
+            recordId={primaryId ?? undefined}
           />
         ) : (
           <Check />
@@ -827,6 +828,7 @@ const accessSampleColDefs: Array<ColDef<DashboardSample>> = [
             validationReport={validationReport}
             modalTitle={`Error report for sample ${primaryId}`}
             recordStatusMap={SAMPLE_STATUS_MAP}
+            recordId={primaryId ?? undefined}
           />
         ) : (
           <Check />

--- a/frontend/src/pages/samples/config.tsx
+++ b/frontend/src/pages/samples/config.tsx
@@ -141,6 +141,7 @@ export const sampleColDefs: Array<ColDef<DashboardSample>> = [
         validationReport,
         sampleCategory,
         primaryId,
+        igoQcReports,
       } = params.data;
 
       if (revisable === true) {
@@ -152,6 +153,9 @@ export const sampleColDefs: Array<ColDef<DashboardSample>> = [
             modalTitle={`Error report for sample ${primaryId}`}
             recordStatusMap={SAMPLE_STATUS_MAP}
             recordId={primaryId ?? undefined}
+            igoQcReports={
+              igoQcReports ? JSON.stringify(igoQcReports) : undefined
+            }
           />
         ) : (
           <Check />
@@ -818,6 +822,7 @@ const accessSampleColDefs: Array<ColDef<DashboardSample>> = [
         validationReport,
         sampleCategory,
         primaryId,
+        igoQcReports,
       } = params.data;
 
       if (revisable === true) {
@@ -829,6 +834,9 @@ const accessSampleColDefs: Array<ColDef<DashboardSample>> = [
             modalTitle={`Error report for sample ${primaryId}`}
             recordStatusMap={SAMPLE_STATUS_MAP}
             recordId={primaryId ?? undefined}
+            igoQcReports={
+              igoQcReports ? JSON.stringify(igoQcReports) : undefined
+            }
           />
         ) : (
           <Check />

--- a/graphql-server/Dockerfile
+++ b/graphql-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.10.0
+FROM node:18
 ADD ./ /server
 WORKDIR /server
 RUN yarn

--- a/graphql-server/package.json
+++ b/graphql-server/package.json
@@ -1,6 +1,9 @@
 {
   "name": "graphql-server",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=18"
+  },
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -14,10 +17,13 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.91.1",
     "@apollo/client": "^3.7.4",
     "@databricks/sql": "^1.11.0",
+    "@google/genai": "^1.50.1",
     "@graphql-tools/merge": "^9.0.1",
     "@graphql-tools/schema": "^10.0.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@neo4j/graphql": "^5.6.2",
     "@neo4j/graphql-ogm": "^5.6.2",
     "@neo4j/introspector": "^1.0.1",
@@ -40,13 +46,15 @@
     "nats": "^2.7.1",
     "neo4j-driver": "^5.8.0",
     "node-cache": "^5.1.2",
+    "openai": "^6.34.0",
     "openid-client": "^5.6.1",
     "passport": "^0.6.0",
     "prettier": "1.19.1",
     "properties-reader": "^2.2.0",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "apollo": "^2.34.0"

--- a/graphql-server/src/env/application.properties.EXAMPLE
+++ b/graphql-server/src/env/application.properties.EXAMPLE
@@ -53,3 +53,20 @@ databricks_phi_mol_accession_table=
 
 [ccs]
 blocked_cohort_ids=
+
+# --- AI Validation Advice (optional) ---
+# Set provider to "anthropic", "gemini", or "openai"
+[llm]
+provider=gemini
+
+[anthropic]
+anthropic_api_key=
+anthropic_model=claude-3-5-haiku-20241022
+
+[gemini]
+gemini_api_key=
+gemini_model=gemini-2.5-flash
+
+[openai]
+openai_api_key=
+openai_model=gpt-4o-mini

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -4265,6 +4265,7 @@ export type Query = {
   dbGaps: Array<DbGap>;
   dbGapsAggregate: DbGapAggregateSelection;
   dbGapsConnection: DbGapsConnection;
+  getValidationAdvice?: Maybe<ValidationAdvice>;
   mafCompletes: Array<MafComplete>;
   mafCompletesAggregate: MafCompleteAggregateSelection;
   mafCompletesConnection: MafCompletesConnection;
@@ -4412,6 +4413,12 @@ export type QueryDbGapsConnectionArgs = {
   first?: InputMaybe<Scalars["Int"]>;
   sort?: InputMaybe<Array<InputMaybe<DbGapSort>>>;
   where?: InputMaybe<DbGapWhere>;
+};
+
+export type QueryGetValidationAdviceArgs = {
+  recordId?: InputMaybe<Scalars["String"]>;
+  recordType: Scalars["String"];
+  validationReport: Scalars["String"];
 };
 
 export type QueryMafCompletesArgs = {
@@ -11358,6 +11365,12 @@ export type UpdateTemposMutationResponse = {
   tempos: Array<Tempo>;
 };
 
+export type ValidationAdvice = {
+  __typename?: "ValidationAdvice";
+  advice: Scalars["String"];
+  suggestedSteps: Array<Scalars["String"]>;
+};
+
 export type DashboardRequestsQueryVariables = Exact<{
   searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
   columnFilters?: InputMaybe<
@@ -11823,6 +11836,21 @@ export type AllBlockedCohortIdsQuery = {
   allBlockedCohortIds: Array<string>;
 };
 
+export type GetValidationAdviceQueryVariables = Exact<{
+  validationReport: Scalars["String"];
+  recordType: Scalars["String"];
+  recordId?: InputMaybe<Scalars["String"]>;
+}>;
+
+export type GetValidationAdviceQuery = {
+  __typename?: "Query";
+  getValidationAdvice?: {
+    __typename?: "ValidationAdvice";
+    advice: string;
+    suggestedSteps: Array<string>;
+  } | null;
+};
+
 export type AllAnchorSeqDateDataQueryVariables = Exact<{
   phiEnabled?: InputMaybe<Scalars["Boolean"]>;
 }>;
@@ -12233,6 +12261,26 @@ export const AllBlockedCohortIdsDocument = gql`
 export type AllBlockedCohortIdsQueryResult = Apollo.QueryResult<
   AllBlockedCohortIdsQuery,
   AllBlockedCohortIdsQueryVariables
+>;
+export const GetValidationAdviceDocument = gql`
+  query GetValidationAdvice(
+    $validationReport: String!
+    $recordType: String!
+    $recordId: String
+  ) {
+    getValidationAdvice(
+      validationReport: $validationReport
+      recordType: $recordType
+      recordId: $recordId
+    ) {
+      advice
+      suggestedSteps
+    }
+  }
+`;
+export type GetValidationAdviceQueryResult = Apollo.QueryResult<
+  GetValidationAdviceQuery,
+  GetValidationAdviceQueryVariables
 >;
 export const AllAnchorSeqDateDataDocument = gql`
   query AllAnchorSeqDateData($phiEnabled: Boolean = false) {

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -11,14 +11,23 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never;
+    };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  BigInt: any;
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  BigInt: { input: any; output: any };
 };
 
 export enum AgGridSortDirection {
@@ -28,43 +37,43 @@ export enum AgGridSortDirection {
 
 export type AnchorSeqDateData = {
   __typename?: "AnchorSeqDateData";
-  ANCHOR_ONCOTREE_CODE: Scalars["String"];
-  ANCHOR_SEQUENCING_DATE: Scalars["String"];
-  DMP_PATIENT_ID: Scalars["String"];
-  MRN: Scalars["String"];
+  ANCHOR_ONCOTREE_CODE: Scalars["String"]["output"];
+  ANCHOR_SEQUENCING_DATE: Scalars["String"]["output"];
+  DMP_PATIENT_ID: Scalars["String"]["output"];
+  MRN: Scalars["String"]["output"];
 };
 
 export type BamComplete = {
   __typename?: "BamComplete";
-  date: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
   temposHasEvent: Array<Tempo>;
   temposHasEventAggregate?: Maybe<BamCompleteTempoTemposHasEventAggregationSelection>;
   temposHasEventConnection: BamCompleteTemposHasEventConnection;
 };
 
 export type BamCompleteTemposHasEventArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type BamCompleteTemposHasEventAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type BamCompleteTemposHasEventConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<BamCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<BamCompleteTemposHasEventConnectionWhere>;
 };
 
 export type BamCompleteAggregateSelection = {
   __typename?: "BamCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   status: StringAggregateSelection;
 };
@@ -80,8 +89,8 @@ export type BamCompleteConnectWhere = {
 };
 
 export type BamCompleteCreateInput = {
-  date: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
   temposHasEvent?: InputMaybe<BamCompleteTemposHasEventFieldInput>;
 };
 
@@ -97,13 +106,13 @@ export type BamCompleteDisconnectInput = {
 
 export type BamCompleteEdge = {
   __typename?: "BamCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: BamComplete;
 };
 
 export type BamCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more BamCompleteSort objects to sort BamCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<BamCompleteSort>>;
 };
@@ -120,7 +129,7 @@ export type BamCompleteSort = {
 
 export type BamCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "BamCompleteTempoTemposHasEventAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<BamCompleteTempoTemposHasEventNodeAggregateSelection>;
 };
 
@@ -139,18 +148,18 @@ export type BamCompleteTemposHasEventAggregateInput = {
   AND?: InputMaybe<Array<BamCompleteTemposHasEventAggregateInput>>;
   NOT?: InputMaybe<BamCompleteTemposHasEventAggregateInput>;
   OR?: InputMaybe<Array<BamCompleteTemposHasEventAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<BamCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type BamCompleteTemposHasEventConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -158,7 +167,7 @@ export type BamCompleteTemposHasEventConnection = {
   __typename?: "BamCompleteTemposHasEventConnection";
   edges: Array<BamCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type BamCompleteTemposHasEventConnectionSort = {
@@ -195,116 +204,164 @@ export type BamCompleteTemposHasEventNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<BamCompleteTemposHasEventNodeAggregationWhereInput>>;
   NOT?: InputMaybe<BamCompleteTemposHasEventNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<BamCompleteTemposHasEventNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type BamCompleteTemposHasEventRelationship = {
   __typename?: "BamCompleteTemposHasEventRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -322,8 +379,8 @@ export type BamCompleteTemposHasEventUpdateFieldInput = {
 };
 
 export type BamCompleteUpdateInput = {
-  date?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEvent?: InputMaybe<Array<BamCompleteTemposHasEventUpdateFieldInput>>;
 };
 
@@ -331,18 +388,18 @@ export type BamCompleteWhere = {
   AND?: InputMaybe<Array<BamCompleteWhere>>;
   NOT?: InputMaybe<BamCompleteWhere>;
   OR?: InputMaybe<Array<BamCompleteWhere>>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEventAggregate?: InputMaybe<BamCompleteTemposHasEventAggregateInput>;
   /** Return BamCompletes where all of the related BamCompleteTemposHasEventConnections match this filter */
   temposHasEventConnection_ALL?: InputMaybe<BamCompleteTemposHasEventConnectionWhere>;
@@ -366,20 +423,21 @@ export type BamCompletesConnection = {
   __typename?: "BamCompletesConnection";
   edges: Array<BamCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type BigIntAggregateSelection = {
   __typename?: "BigIntAggregateSelection";
-  average?: Maybe<Scalars["BigInt"]>;
-  max?: Maybe<Scalars["BigInt"]>;
-  min?: Maybe<Scalars["BigInt"]>;
-  sum?: Maybe<Scalars["BigInt"]>;
+  average?: Maybe<Scalars["BigInt"]["output"]>;
+  max?: Maybe<Scalars["BigInt"]["output"]>;
+  min?: Maybe<Scalars["BigInt"]["output"]>;
+  sum?: Maybe<Scalars["BigInt"]["output"]>;
 };
 
 export type Cohort = {
   __typename?: "Cohort";
-  cohortId: Scalars["String"];
+  cohortId: Scalars["String"]["output"];
+  cohortStatus: Scalars["String"]["output"];
   hasCohortCompleteCohortCompletes: Array<CohortComplete>;
   hasCohortCompleteCohortCompletesAggregate?: Maybe<CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection>;
   hasCohortCompleteCohortCompletesConnection: CohortHasCohortCompleteCohortCompletesConnection;
@@ -389,20 +447,20 @@ export type Cohort = {
 };
 
 export type CohortHasCohortCompleteCohortCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<CohortCompleteOptions>;
   where?: InputMaybe<CohortCompleteWhere>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<CohortCompleteWhere>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesConnectionSort>
   >;
@@ -410,20 +468,20 @@ export type CohortHasCohortCompleteCohortCompletesConnectionArgs = {
 };
 
 export type CohortHasCohortSampleSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type CohortHasCohortSampleSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type CohortHasCohortSampleSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<CohortHasCohortSampleSamplesConnectionSort>>;
   where?: InputMaybe<CohortHasCohortSampleSamplesConnectionWhere>;
 };
@@ -431,13 +489,14 @@ export type CohortHasCohortSampleSamplesConnectionArgs = {
 export type CohortAggregateSelection = {
   __typename?: "CohortAggregateSelection";
   cohortId: StringAggregateSelection;
-  count: Scalars["Int"];
+  cohortStatus: StringAggregateSelection;
+  count: Scalars["Int"]["output"];
 };
 
 export type CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection =
   {
     __typename?: "CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSelection>;
   };
 
@@ -460,32 +519,32 @@ export type CohortComplete = {
   cohortsHasCohortComplete: Array<Cohort>;
   cohortsHasCohortCompleteAggregate?: Maybe<CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection>;
   cohortsHasCohortCompleteConnection: CohortCompleteCohortsHasCohortCompleteConnection;
-  date: Scalars["String"];
-  endUsers: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  pipelineVersion?: Maybe<Scalars["String"]>;
-  pmUsers: Scalars["String"];
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
-  status: Scalars["String"];
-  type: Scalars["String"];
+  date: Scalars["String"]["output"];
+  endUsers: Scalars["String"]["output"];
+  importDate: Scalars["BigInt"]["output"];
+  pipelineVersion?: Maybe<Scalars["String"]["output"]>;
+  pmUsers: Scalars["String"]["output"];
+  projectSubtitle: Scalars["String"]["output"];
+  projectTitle: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
+  type: Scalars["String"]["output"];
 };
 
 export type CohortCompleteCohortsHasCohortCompleteArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<CohortOptions>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteConnectionSort>
   >;
@@ -494,7 +553,7 @@ export type CohortCompleteCohortsHasCohortCompleteConnectionArgs = {
 
 export type CohortCompleteAggregateSelection = {
   __typename?: "CohortCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   endUsers: StringAggregateSelection;
   importDate: BigIntAggregateSelection;
@@ -508,7 +567,7 @@ export type CohortCompleteAggregateSelection = {
 
 export type CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection = {
   __typename?: "CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection>;
 };
 
@@ -516,24 +575,25 @@ export type CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection =
   {
     __typename?: "CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection";
     cohortId: StringAggregateSelection;
+    cohortStatus: StringAggregateSelection;
   };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateInput = {
   AND?: InputMaybe<Array<CohortCompleteCohortsHasCohortCompleteAggregateInput>>;
   NOT?: InputMaybe<CohortCompleteCohortsHasCohortCompleteAggregateInput>;
   OR?: InputMaybe<Array<CohortCompleteCohortsHasCohortCompleteAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteConnectFieldInput = {
   connect?: InputMaybe<Array<CohortConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<CohortConnectWhere>;
 };
 
@@ -541,7 +601,7 @@ export type CohortCompleteCohortsHasCohortCompleteConnection = {
   __typename?: "CohortCompleteCohortsHasCohortCompleteConnection";
   edges: Array<CohortCompleteCohortsHasCohortCompleteRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortCompleteCohortsHasCohortCompleteConnectionSort = {
@@ -588,26 +648,41 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput>
   >;
-  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteRelationship = {
   __typename?: "CohortCompleteCohortsHasCohortCompleteRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Cohort;
 };
 
@@ -644,15 +719,15 @@ export type CohortCompleteConnectWhere = {
 
 export type CohortCompleteCreateInput = {
   cohortsHasCohortComplete?: InputMaybe<CohortCompleteCohortsHasCohortCompleteFieldInput>;
-  date: Scalars["String"];
-  endUsers: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pmUsers: Scalars["String"];
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
-  status: Scalars["String"];
-  type: Scalars["String"];
+  date: Scalars["String"]["input"];
+  endUsers: Scalars["String"]["input"];
+  importDate: Scalars["BigInt"]["input"];
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers: Scalars["String"]["input"];
+  projectSubtitle: Scalars["String"]["input"];
+  projectTitle: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
+  type: Scalars["String"]["input"];
 };
 
 export type CohortCompleteDeleteInput = {
@@ -669,13 +744,13 @@ export type CohortCompleteDisconnectInput = {
 
 export type CohortCompleteEdge = {
   __typename?: "CohortCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: CohortComplete;
 };
 
 export type CohortCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more CohortCompleteSort objects to sort CohortCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<CohortCompleteSort>>;
 };
@@ -703,17 +778,17 @@ export type CohortCompleteUpdateInput = {
   cohortsHasCohortComplete?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteUpdateFieldInput>
   >;
-  date?: InputMaybe<Scalars["String"]>;
-  endUsers?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Scalars["String"]>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  type?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type CohortCompleteWhere = {
@@ -737,67 +812,69 @@ export type CohortCompleteWhere = {
   cohortsHasCohortComplete_SINGLE?: InputMaybe<CohortWhere>;
   /** Return CohortCompletes where some of the related Cohorts match this filter */
   cohortsHasCohortComplete_SOME?: InputMaybe<CohortWhere>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  endUsers?: InputMaybe<Scalars["String"]>;
-  endUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
-  endUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  endUsers_IN?: InputMaybe<Array<Scalars["String"]>>;
-  endUsers_MATCHES?: InputMaybe<Scalars["String"]>;
-  endUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]>>;
-  importDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_CONTAINS?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pipelineVersion_MATCHES?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Scalars["String"]>;
-  pmUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
-  pmUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  pmUsers_IN?: InputMaybe<Array<Scalars["String"]>>;
-  pmUsers_MATCHES?: InputMaybe<Scalars["String"]>;
-  pmUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_IN?: InputMaybe<Array<Scalars["String"]>>;
-  projectSubtitle_MATCHES?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
-  projectTitle_CONTAINS?: InputMaybe<Scalars["String"]>;
-  projectTitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectTitle_IN?: InputMaybe<Array<Scalars["String"]>>;
-  projectTitle_MATCHES?: InputMaybe<Scalars["String"]>;
-  projectTitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  type?: InputMaybe<Scalars["String"]>;
-  type_CONTAINS?: InputMaybe<Scalars["String"]>;
-  type_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  type_IN?: InputMaybe<Array<Scalars["String"]>>;
-  type_MATCHES?: InputMaybe<Scalars["String"]>;
-  type_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  endUsers_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  importDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  pipelineVersion_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  pmUsers_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  projectSubtitle_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  projectTitle_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
+  type_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  type_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  type_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  type_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  type_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type CohortCompletesConnection = {
   __typename?: "CohortCompletesConnection";
   edges: Array<CohortCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortConnectInput = {
@@ -814,7 +891,8 @@ export type CohortConnectWhere = {
 };
 
 export type CohortCreateInput = {
-  cohortId: Scalars["String"];
+  cohortId: Scalars["String"]["input"];
+  cohortStatus: Scalars["String"]["input"];
   hasCohortCompleteCohortCompletes?: InputMaybe<CohortHasCohortCompleteCohortCompletesFieldInput>;
   hasCohortSampleSamples?: InputMaybe<CohortHasCohortSampleSamplesFieldInput>;
 };
@@ -839,7 +917,7 @@ export type CohortDisconnectInput = {
 
 export type CohortEdge = {
   __typename?: "CohortEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Cohort;
 };
 
@@ -847,18 +925,18 @@ export type CohortHasCohortCompleteCohortCompletesAggregateInput = {
   AND?: InputMaybe<Array<CohortHasCohortCompleteCohortCompletesAggregateInput>>;
   NOT?: InputMaybe<CohortHasCohortCompleteCohortCompletesAggregateInput>;
   OR?: InputMaybe<Array<CohortHasCohortCompleteCohortCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<CohortCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<CohortCompleteConnectWhere>;
 };
 
@@ -866,7 +944,7 @@ export type CohortHasCohortCompleteCohortCompletesConnection = {
   __typename?: "CohortHasCohortCompleteCohortCompletesConnection";
   edges: Array<CohortHasCohortCompleteCohortCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortHasCohortCompleteCohortCompletesConnectionSort = {
@@ -913,151 +991,151 @@ export type CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput>
   >;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  endUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  pipelineVersion_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  pmUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectTitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  type_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  type_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  type_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesRelationship = {
   __typename?: "CohortHasCohortCompleteCohortCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: CohortComplete;
 };
 
@@ -1086,18 +1164,18 @@ export type CohortHasCohortSampleSamplesAggregateInput = {
   AND?: InputMaybe<Array<CohortHasCohortSampleSamplesAggregateInput>>;
   NOT?: InputMaybe<CohortHasCohortSampleSamplesAggregateInput>;
   OR?: InputMaybe<Array<CohortHasCohortSampleSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<CohortHasCohortSampleSamplesNodeAggregationWhereInput>;
 };
 
 export type CohortHasCohortSampleSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -1105,7 +1183,7 @@ export type CohortHasCohortSampleSamplesConnection = {
   __typename?: "CohortHasCohortSampleSamplesConnection";
   edges: Array<CohortHasCohortSampleSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortHasCohortSampleSamplesConnectionSort = {
@@ -1144,71 +1222,71 @@ export type CohortHasCohortSampleSamplesNodeAggregationWhereInput = {
   >;
   NOT?: InputMaybe<CohortHasCohortSampleSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<CohortHasCohortSampleSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type CohortHasCohortSampleSamplesRelationship = {
   __typename?: "CohortHasCohortSampleSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -1228,8 +1306,8 @@ export type CohortHasCohortSampleSamplesUpdateFieldInput = {
 };
 
 export type CohortOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more CohortSort objects to sort Cohorts by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<CohortSort>>;
 };
@@ -1245,7 +1323,7 @@ export type CohortRelationInput = {
 
 export type CohortSampleHasCohortSampleSamplesAggregationSelection = {
   __typename?: "CohortSampleHasCohortSampleSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<CohortSampleHasCohortSampleSamplesNodeAggregateSelection>;
 };
 
@@ -1260,10 +1338,12 @@ export type CohortSampleHasCohortSampleSamplesNodeAggregateSelection = {
 /** Fields to sort Cohorts by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortSort object. */
 export type CohortSort = {
   cohortId?: InputMaybe<SortDirection>;
+  cohortStatus?: InputMaybe<SortDirection>;
 };
 
 export type CohortUpdateInput = {
-  cohortId?: InputMaybe<Scalars["String"]>;
+  cohortId?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus?: InputMaybe<Scalars["String"]["input"]>;
   hasCohortCompleteCohortCompletes?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesUpdateFieldInput>
   >;
@@ -1276,12 +1356,18 @@ export type CohortWhere = {
   AND?: InputMaybe<Array<CohortWhere>>;
   NOT?: InputMaybe<CohortWhere>;
   OR?: InputMaybe<Array<CohortWhere>>;
-  cohortId?: InputMaybe<Scalars["String"]>;
-  cohortId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cohortId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cohortId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  cohortId_MATCHES?: InputMaybe<Scalars["String"]>;
-  cohortId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cohortId?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  cohortId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  cohortStatus_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasCohortCompleteCohortCompletesAggregate?: InputMaybe<CohortHasCohortCompleteCohortCompletesAggregateInput>;
   /** Return Cohorts where all of the related CohortHasCohortCompleteCohortCompletesConnections match this filter */
   hasCohortCompleteCohortCompletesConnection_ALL?: InputMaybe<CohortHasCohortCompleteCohortCompletesConnectionWhere>;
@@ -1322,7 +1408,7 @@ export type CohortsConnection = {
   __typename?: "CohortsConnection";
   edges: Array<CohortEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CreateBamCompletesMutationResponse = {
@@ -1353,9 +1439,9 @@ export type CreateDbGapsMutationResponse = {
 export type CreateInfo = {
   __typename?: "CreateInfo";
   /** @deprecated This field has been deprecated because bookmarks are now handled by the driver. */
-  bookmark?: Maybe<Scalars["String"]>;
-  nodesCreated: Scalars["Int"];
-  relationshipsCreated: Scalars["Int"];
+  bookmark?: Maybe<Scalars["String"]["output"]>;
+  nodesCreated: Scalars["Int"]["output"];
+  relationshipsCreated: Scalars["Int"]["output"];
 };
 
 export type CreateMafCompletesMutationResponse = {
@@ -1432,265 +1518,265 @@ export type CreateTemposMutationResponse = {
 
 export type DashboardCohort = {
   __typename?: "DashboardCohort";
-  _total?: Maybe<Scalars["Int"]>;
-  _uniqueSampleCount?: Maybe<Scalars["Int"]>;
-  billed?: Maybe<Scalars["String"]>;
-  cohortId: Scalars["String"];
-  endUsers?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
-  initialCohortDeliveryDate?: Maybe<Scalars["String"]>;
-  pipelineVersion?: Maybe<Scalars["String"]>;
-  pmUsers?: Maybe<Scalars["String"]>;
-  projectSubtitle?: Maybe<Scalars["String"]>;
-  projectTitle?: Maybe<Scalars["String"]>;
-  searchableSampleIds?: Maybe<Scalars["String"]>;
-  status?: Maybe<Scalars["String"]>;
-  totalSampleCount?: Maybe<Scalars["Int"]>;
-  type?: Maybe<Scalars["String"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  _uniqueSampleCount?: Maybe<Scalars["Int"]["output"]>;
+  billed?: Maybe<Scalars["String"]["output"]>;
+  cohortId: Scalars["String"]["output"];
+  endUsers?: Maybe<Scalars["String"]["output"]>;
+  importDate?: Maybe<Scalars["String"]["output"]>;
+  initialCohortDeliveryDate?: Maybe<Scalars["String"]["output"]>;
+  pipelineVersion?: Maybe<Scalars["String"]["output"]>;
+  pmUsers?: Maybe<Scalars["String"]["output"]>;
+  projectSubtitle?: Maybe<Scalars["String"]["output"]>;
+  projectTitle?: Maybe<Scalars["String"]["output"]>;
+  searchableSampleIds?: Maybe<Scalars["String"]["output"]>;
+  status?: Maybe<Scalars["String"]["output"]>;
+  totalSampleCount?: Maybe<Scalars["Int"]["output"]>;
+  type?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type DashboardCohortInput = {
-  _total?: InputMaybe<Scalars["Int"]>;
-  _uniqueSampleCount?: InputMaybe<Scalars["Int"]>;
-  billed?: InputMaybe<Scalars["String"]>;
-  changedFieldNames: Array<Scalars["String"]>;
-  changelog?: InputMaybe<Scalars["String"]>;
-  cohortId: Scalars["String"];
-  endUsers?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["String"]>;
-  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Scalars["String"]>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
-  searchableSampleIds?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  totalSampleCount?: InputMaybe<Scalars["Int"]>;
-  type?: InputMaybe<Scalars["String"]>;
+  _total?: InputMaybe<Scalars["Int"]["input"]>;
+  _uniqueSampleCount?: InputMaybe<Scalars["Int"]["input"]>;
+  billed?: InputMaybe<Scalars["String"]["input"]>;
+  changedFieldNames: Array<Scalars["String"]["input"]>;
+  changelog?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId: Scalars["String"]["input"];
+  endUsers?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["String"]["input"]>;
+  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle?: InputMaybe<Scalars["String"]["input"]>;
+  searchableSampleIds?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type DashboardPatient = {
   __typename?: "DashboardPatient";
-  _total?: Maybe<Scalars["Int"]>;
-  anchorOncotreeCode?: Maybe<Scalars["String"]>;
-  anchorSequencingDate?: Maybe<Scalars["String"]>;
-  cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleIds?: Maybe<Scalars["String"]>;
-  consentPartA?: Maybe<Scalars["String"]>;
-  consentPartC?: Maybe<Scalars["String"]>;
-  dmpPatientId?: Maybe<Scalars["String"]>;
-  inDbGap?: Maybe<Scalars["Boolean"]>;
-  mrn?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  smilePatientId: Scalars["String"];
-  totalSampleCount?: Maybe<Scalars["Int"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  anchorOncotreeCode?: Maybe<Scalars["String"]["output"]>;
+  anchorSequencingDate?: Maybe<Scalars["String"]["output"]>;
+  cmoPatientId?: Maybe<Scalars["String"]["output"]>;
+  cmoSampleIds?: Maybe<Scalars["String"]["output"]>;
+  consentPartA?: Maybe<Scalars["String"]["output"]>;
+  consentPartC?: Maybe<Scalars["String"]["output"]>;
+  dmpPatientId?: Maybe<Scalars["String"]["output"]>;
+  inDbGap?: Maybe<Scalars["Boolean"]["output"]>;
+  mrn?: Maybe<Scalars["String"]["output"]>;
+  race?: Maybe<Scalars["String"]["output"]>;
+  smilePatientId: Scalars["String"]["output"];
+  totalSampleCount?: Maybe<Scalars["Int"]["output"]>;
 };
 
 export type DashboardRecordColumnFilter = {
-  field: Scalars["String"];
-  filter: Scalars["String"];
+  field: Scalars["String"]["input"];
+  filter: Scalars["String"]["input"];
 };
 
 export type DashboardRecordContext = {
-  fieldName?: InputMaybe<Scalars["String"]>;
-  values: Array<Scalars["String"]>;
+  fieldName?: InputMaybe<Scalars["String"]["input"]>;
+  values: Array<Scalars["String"]["input"]>;
 };
 
 export type DashboardRecordSort = {
-  colId: Scalars["String"];
+  colId: Scalars["String"]["input"];
   sort: AgGridSortDirection;
 };
 
 export type DashboardRequest = {
   __typename?: "DashboardRequest";
-  _total?: Maybe<Scalars["Int"]>;
-  bicAnalysis?: Maybe<Scalars["Boolean"]>;
-  dataAccessEmails?: Maybe<Scalars["String"]>;
-  dataAnalystEmail?: Maybe<Scalars["String"]>;
-  dataAnalystName?: Maybe<Scalars["String"]>;
-  genePanel?: Maybe<Scalars["String"]>;
-  igoDeliveryDate?: Maybe<Scalars["String"]>;
-  igoProjectId?: Maybe<Scalars["String"]>;
-  igoRequestId: Scalars["String"];
-  ilabRequestId?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
-  investigatorEmail?: Maybe<Scalars["String"]>;
-  investigatorName?: Maybe<Scalars["String"]>;
-  isCmoRequest?: Maybe<Scalars["Boolean"]>;
-  labHeadEmail?: Maybe<Scalars["String"]>;
-  labHeadName?: Maybe<Scalars["String"]>;
-  otherContactEmails?: Maybe<Scalars["String"]>;
-  piEmail?: Maybe<Scalars["String"]>;
-  projectManagerName?: Maybe<Scalars["String"]>;
-  qcAccessEmails?: Maybe<Scalars["String"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  bicAnalysis?: Maybe<Scalars["Boolean"]["output"]>;
+  dataAccessEmails?: Maybe<Scalars["String"]["output"]>;
+  dataAnalystEmail?: Maybe<Scalars["String"]["output"]>;
+  dataAnalystName?: Maybe<Scalars["String"]["output"]>;
+  genePanel?: Maybe<Scalars["String"]["output"]>;
+  igoDeliveryDate?: Maybe<Scalars["String"]["output"]>;
+  igoProjectId?: Maybe<Scalars["String"]["output"]>;
+  igoRequestId: Scalars["String"]["output"];
+  ilabRequestId?: Maybe<Scalars["String"]["output"]>;
+  importDate?: Maybe<Scalars["String"]["output"]>;
+  investigatorEmail?: Maybe<Scalars["String"]["output"]>;
+  investigatorName?: Maybe<Scalars["String"]["output"]>;
+  isCmoRequest?: Maybe<Scalars["Boolean"]["output"]>;
+  labHeadEmail?: Maybe<Scalars["String"]["output"]>;
+  labHeadName?: Maybe<Scalars["String"]["output"]>;
+  otherContactEmails?: Maybe<Scalars["String"]["output"]>;
+  piEmail?: Maybe<Scalars["String"]["output"]>;
+  projectManagerName?: Maybe<Scalars["String"]["output"]>;
+  qcAccessEmails?: Maybe<Scalars["String"]["output"]>;
   toleratedSampleErrors?: Maybe<Array<Maybe<ToleratedSampleValidationError>>>;
-  totalSampleCount?: Maybe<Scalars["Int"]>;
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  totalSampleCount?: Maybe<Scalars["Int"]["output"]>;
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type DashboardSample = {
   __typename?: "DashboardSample";
-  _total?: Maybe<Scalars["Int"]>;
-  accessLevel?: Maybe<Scalars["String"]>;
-  altId?: Maybe<Scalars["String"]>;
-  analyteType?: Maybe<Scalars["String"]>;
-  baitSet?: Maybe<Scalars["String"]>;
-  bamCompleteDate?: Maybe<Scalars["String"]>;
-  bamCompleteStatus?: Maybe<Scalars["String"]>;
-  billed?: Maybe<Scalars["Boolean"]>;
-  billedBy?: Maybe<Scalars["String"]>;
-  cancerType?: Maybe<Scalars["String"]>;
-  cancerTypeDetailed?: Maybe<Scalars["String"]>;
-  cfDNA2dBarcode?: Maybe<Scalars["String"]>;
-  changelog?: Maybe<Scalars["String"]>;
-  cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleName?: Maybe<Scalars["String"]>;
-  collectionYear?: Maybe<Scalars["String"]>;
-  costCenter?: Maybe<Scalars["String"]>;
-  custodianInformation?: Maybe<Scalars["String"]>;
-  dbGapStudy?: Maybe<Scalars["String"]>;
-  dmpPatientAlias?: Maybe<Scalars["String"]>;
-  dmpRecommendedCoverage?: Maybe<Scalars["String"]>;
-  embargoDate?: Maybe<Scalars["String"]>;
-  genePanel?: Maybe<Scalars["String"]>;
-  historicalCmoSampleNames?: Maybe<Scalars["String"]>;
-  igoComplete?: Maybe<Scalars["Boolean"]>;
-  igoDeliveryDate?: Maybe<Scalars["String"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  accessLevel?: Maybe<Scalars["String"]["output"]>;
+  altId?: Maybe<Scalars["String"]["output"]>;
+  analyteType?: Maybe<Scalars["String"]["output"]>;
+  baitSet?: Maybe<Scalars["String"]["output"]>;
+  bamCompleteDate?: Maybe<Scalars["String"]["output"]>;
+  bamCompleteStatus?: Maybe<Scalars["String"]["output"]>;
+  billed?: Maybe<Scalars["Boolean"]["output"]>;
+  billedBy?: Maybe<Scalars["String"]["output"]>;
+  cancerType?: Maybe<Scalars["String"]["output"]>;
+  cancerTypeDetailed?: Maybe<Scalars["String"]["output"]>;
+  cfDNA2dBarcode?: Maybe<Scalars["String"]["output"]>;
+  changelog?: Maybe<Scalars["String"]["output"]>;
+  cmoPatientId?: Maybe<Scalars["String"]["output"]>;
+  cmoSampleName?: Maybe<Scalars["String"]["output"]>;
+  collectionYear?: Maybe<Scalars["String"]["output"]>;
+  costCenter?: Maybe<Scalars["String"]["output"]>;
+  custodianInformation?: Maybe<Scalars["String"]["output"]>;
+  dbGapStudy?: Maybe<Scalars["String"]["output"]>;
+  dmpPatientAlias?: Maybe<Scalars["String"]["output"]>;
+  dmpRecommendedCoverage?: Maybe<Scalars["String"]["output"]>;
+  embargoDate?: Maybe<Scalars["String"]["output"]>;
+  genePanel?: Maybe<Scalars["String"]["output"]>;
+  historicalCmoSampleNames?: Maybe<Scalars["String"]["output"]>;
+  igoComplete?: Maybe<Scalars["Boolean"]["output"]>;
+  igoDeliveryDate?: Maybe<Scalars["String"]["output"]>;
   igoQcReports?: Maybe<Array<Maybe<IgoQcReport>>>;
-  igoSampleStatus?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
-  initialPipelineRunDate?: Maybe<Scalars["String"]>;
-  instrumentModel?: Maybe<Scalars["String"]>;
-  investigatorSampleId?: Maybe<Scalars["String"]>;
-  irbConsentProtocol?: Maybe<Scalars["String"]>;
-  mafCompleteDate?: Maybe<Scalars["String"]>;
-  mafCompleteNormalPrimaryId?: Maybe<Scalars["String"]>;
-  mafCompleteStatus?: Maybe<Scalars["String"]>;
-  molecularAccessionNumber?: Maybe<Scalars["String"]>;
-  oncotreeCode?: Maybe<Scalars["String"]>;
-  platform?: Maybe<Scalars["String"]>;
-  preservation?: Maybe<Scalars["String"]>;
-  primaryId?: Maybe<Scalars["String"]>;
-  qcCompleteDate?: Maybe<Scalars["String"]>;
-  qcCompleteReason?: Maybe<Scalars["String"]>;
-  qcCompleteResult?: Maybe<Scalars["String"]>;
-  qcCompleteStatus?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  recipe?: Maybe<Scalars["String"]>;
-  recordId: Scalars["String"];
-  revisable?: Maybe<Scalars["Boolean"]>;
-  sampleCategory: Scalars["String"];
-  sampleClass?: Maybe<Scalars["String"]>;
-  sampleCohortIds?: Maybe<Scalars["String"]>;
-  sampleOrigin?: Maybe<Scalars["String"]>;
-  sampleType?: Maybe<Scalars["String"]>;
-  sequencingDate?: Maybe<Scalars["String"]>;
-  sex?: Maybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
-  species?: Maybe<Scalars["String"]>;
-  tissueLocation?: Maybe<Scalars["String"]>;
-  tumorOrNormal?: Maybe<Scalars["String"]>;
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  igoSampleStatus?: Maybe<Scalars["String"]["output"]>;
+  importDate?: Maybe<Scalars["String"]["output"]>;
+  initialPipelineRunDate?: Maybe<Scalars["String"]["output"]>;
+  instrumentModel?: Maybe<Scalars["String"]["output"]>;
+  investigatorSampleId?: Maybe<Scalars["String"]["output"]>;
+  irbConsentProtocol?: Maybe<Scalars["String"]["output"]>;
+  mafCompleteDate?: Maybe<Scalars["String"]["output"]>;
+  mafCompleteNormalPrimaryId?: Maybe<Scalars["String"]["output"]>;
+  mafCompleteStatus?: Maybe<Scalars["String"]["output"]>;
+  molecularAccessionNumber?: Maybe<Scalars["String"]["output"]>;
+  oncotreeCode?: Maybe<Scalars["String"]["output"]>;
+  platform?: Maybe<Scalars["String"]["output"]>;
+  preservation?: Maybe<Scalars["String"]["output"]>;
+  primaryId?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteDate?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteReason?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteResult?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteStatus?: Maybe<Scalars["String"]["output"]>;
+  race?: Maybe<Scalars["String"]["output"]>;
+  recipe?: Maybe<Scalars["String"]["output"]>;
+  recordId: Scalars["String"]["output"];
+  revisable?: Maybe<Scalars["Boolean"]["output"]>;
+  sampleCategory: Scalars["String"]["output"];
+  sampleClass?: Maybe<Scalars["String"]["output"]>;
+  sampleCohortIds?: Maybe<Scalars["String"]["output"]>;
+  sampleOrigin?: Maybe<Scalars["String"]["output"]>;
+  sampleType?: Maybe<Scalars["String"]["output"]>;
+  sequencingDate?: Maybe<Scalars["String"]["output"]>;
+  sex?: Maybe<Scalars["String"]["output"]>;
+  smileSampleId: Scalars["String"]["output"];
+  species?: Maybe<Scalars["String"]["output"]>;
+  tissueLocation?: Maybe<Scalars["String"]["output"]>;
+  tumorOrNormal?: Maybe<Scalars["String"]["output"]>;
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type DashboardSampleInput = {
-  _total?: InputMaybe<Scalars["Int"]>;
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  altId?: InputMaybe<Scalars["String"]>;
-  analyteType?: InputMaybe<Scalars["String"]>;
-  baitSet?: InputMaybe<Scalars["String"]>;
-  bamCompleteDate?: InputMaybe<Scalars["String"]>;
-  bamCompleteStatus?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  cancerType?: InputMaybe<Scalars["String"]>;
-  cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  changedFieldNames: Array<Scalars["String"]>;
-  changelog?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  dbGapStudy?: InputMaybe<Scalars["String"]>;
-  dmpPatientAlias?: InputMaybe<Scalars["String"]>;
-  dmpRecommendedCoverage?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
-  historicalCmoSampleNames?: InputMaybe<Scalars["String"]>;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoDeliveryDate?: InputMaybe<Scalars["String"]>;
-  igoSampleStatus?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
-  instrumentModel?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  irbConsentProtocol?: InputMaybe<Scalars["String"]>;
-  mafCompleteDate?: InputMaybe<Scalars["String"]>;
-  mafCompleteNormalPrimaryId?: InputMaybe<Scalars["String"]>;
-  mafCompleteStatus?: InputMaybe<Scalars["String"]>;
-  molecularAccessionNumber?: InputMaybe<Scalars["String"]>;
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  platform?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
-  qcCompleteDate?: InputMaybe<Scalars["String"]>;
-  qcCompleteReason?: InputMaybe<Scalars["String"]>;
-  qcCompleteResult?: InputMaybe<Scalars["String"]>;
-  qcCompleteStatus?: InputMaybe<Scalars["String"]>;
-  race?: InputMaybe<Scalars["String"]>;
-  recipe?: InputMaybe<Scalars["String"]>;
-  recordId: Scalars["String"];
-  revisable?: InputMaybe<Scalars["Boolean"]>;
-  sampleCategory: Scalars["String"];
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleCohortIds?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
-  sequencingDate?: InputMaybe<Scalars["String"]>;
-  sex?: InputMaybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
-  species?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  _total?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  altId?: InputMaybe<Scalars["String"]["input"]>;
+  analyteType?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  bamCompleteDate?: InputMaybe<Scalars["String"]["input"]>;
+  bamCompleteStatus?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  cancerType?: InputMaybe<Scalars["String"]["input"]>;
+  cancerTypeDetailed?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  changedFieldNames: Array<Scalars["String"]["input"]>;
+  changelog?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy?: InputMaybe<Scalars["String"]["input"]>;
+  dmpPatientAlias?: InputMaybe<Scalars["String"]["input"]>;
+  dmpRecommendedCoverage?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
+  historicalCmoSampleNames?: InputMaybe<Scalars["String"]["input"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoDeliveryDate?: InputMaybe<Scalars["String"]["input"]>;
+  igoSampleStatus?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
+  instrumentModel?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  irbConsentProtocol?: InputMaybe<Scalars["String"]["input"]>;
+  mafCompleteDate?: InputMaybe<Scalars["String"]["input"]>;
+  mafCompleteNormalPrimaryId?: InputMaybe<Scalars["String"]["input"]>;
+  mafCompleteStatus?: InputMaybe<Scalars["String"]["input"]>;
+  molecularAccessionNumber?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  platform?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteDate?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteReason?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteResult?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteStatus?: InputMaybe<Scalars["String"]["input"]>;
+  race?: InputMaybe<Scalars["String"]["input"]>;
+  recipe?: InputMaybe<Scalars["String"]["input"]>;
+  recordId: Scalars["String"]["input"];
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
+  sampleCategory: Scalars["String"]["input"];
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCohortIds?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
+  sequencingDate?: InputMaybe<Scalars["String"]["input"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId: Scalars["String"]["input"];
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type DbGap = {
   __typename?: "DbGap";
-  dbGapStudy: Scalars["String"];
+  dbGapStudy: Scalars["String"]["output"];
   samplesHasDbgap: Array<Sample>;
   samplesHasDbgapAggregate?: Maybe<DbGapSampleSamplesHasDbgapAggregationSelection>;
   samplesHasDbgapConnection: DbGapSamplesHasDbgapConnection;
-  smileDbGapId: Scalars["String"];
+  smileDbGapId: Scalars["String"]["output"];
 };
 
 export type DbGapSamplesHasDbgapArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type DbGapSamplesHasDbgapAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type DbGapSamplesHasDbgapConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<DbGapSamplesHasDbgapConnectionSort>>;
   where?: InputMaybe<DbGapSamplesHasDbgapConnectionWhere>;
 };
 
 export type DbGapAggregateSelection = {
   __typename?: "DbGapAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   dbGapStudy: StringAggregateSelection;
   smileDbGapId: StringAggregateSelection;
 };
@@ -1704,9 +1790,9 @@ export type DbGapConnectWhere = {
 };
 
 export type DbGapCreateInput = {
-  dbGapStudy: Scalars["String"];
+  dbGapStudy: Scalars["String"]["input"];
   samplesHasDbgap?: InputMaybe<DbGapSamplesHasDbgapFieldInput>;
-  smileDbGapId: Scalars["String"];
+  smileDbGapId: Scalars["String"]["input"];
 };
 
 export type DbGapDeleteInput = {
@@ -1719,13 +1805,13 @@ export type DbGapDisconnectInput = {
 
 export type DbGapEdge = {
   __typename?: "DbGapEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: DbGap;
 };
 
 export type DbGapOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more DbGapSort objects to sort DbGaps by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<DbGapSort>>;
 };
@@ -1736,7 +1822,7 @@ export type DbGapRelationInput = {
 
 export type DbGapSampleSamplesHasDbgapAggregationSelection = {
   __typename?: "DbGapSampleSamplesHasDbgapAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<DbGapSampleSamplesHasDbgapNodeAggregateSelection>;
 };
 
@@ -1752,18 +1838,18 @@ export type DbGapSamplesHasDbgapAggregateInput = {
   AND?: InputMaybe<Array<DbGapSamplesHasDbgapAggregateInput>>;
   NOT?: InputMaybe<DbGapSamplesHasDbgapAggregateInput>;
   OR?: InputMaybe<Array<DbGapSamplesHasDbgapAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<DbGapSamplesHasDbgapNodeAggregationWhereInput>;
 };
 
 export type DbGapSamplesHasDbgapConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -1771,7 +1857,7 @@ export type DbGapSamplesHasDbgapConnection = {
   __typename?: "DbGapSamplesHasDbgapConnection";
   edges: Array<DbGapSamplesHasDbgapRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type DbGapSamplesHasDbgapConnectionSort = {
@@ -1808,71 +1894,71 @@ export type DbGapSamplesHasDbgapNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<DbGapSamplesHasDbgapNodeAggregationWhereInput>>;
   NOT?: InputMaybe<DbGapSamplesHasDbgapNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<DbGapSamplesHasDbgapNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type DbGapSamplesHasDbgapRelationship = {
   __typename?: "DbGapSamplesHasDbgapRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -1896,21 +1982,21 @@ export type DbGapSort = {
 };
 
 export type DbGapUpdateInput = {
-  dbGapStudy?: InputMaybe<Scalars["String"]>;
+  dbGapStudy?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasDbgap?: InputMaybe<Array<DbGapSamplesHasDbgapUpdateFieldInput>>;
-  smileDbGapId?: InputMaybe<Scalars["String"]>;
+  smileDbGapId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type DbGapWhere = {
   AND?: InputMaybe<Array<DbGapWhere>>;
   NOT?: InputMaybe<DbGapWhere>;
   OR?: InputMaybe<Array<DbGapWhere>>;
-  dbGapStudy?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dbGapStudy_MATCHES?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  dbGapStudy?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dbGapStudy_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasDbgapAggregate?: InputMaybe<DbGapSamplesHasDbgapAggregateInput>;
   /** Return DbGaps where all of the related DbGapSamplesHasDbgapConnections match this filter */
   samplesHasDbgapConnection_ALL?: InputMaybe<DbGapSamplesHasDbgapConnectionWhere>;
@@ -1928,70 +2014,70 @@ export type DbGapWhere = {
   samplesHasDbgap_SINGLE?: InputMaybe<SampleWhere>;
   /** Return DbGaps where some of the related Samples match this filter */
   samplesHasDbgap_SOME?: InputMaybe<SampleWhere>;
-  smileDbGapId?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileDbGapId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smileDbGapId?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileDbGapId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type DbGapsConnection = {
   __typename?: "DbGapsConnection";
   edges: Array<DbGapEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 /** Information about the number of nodes and relationships deleted during a delete mutation */
 export type DeleteInfo = {
   __typename?: "DeleteInfo";
   /** @deprecated This field has been deprecated because bookmarks are now handled by the driver. */
-  bookmark?: Maybe<Scalars["String"]>;
-  nodesDeleted: Scalars["Int"];
-  relationshipsDeleted: Scalars["Int"];
+  bookmark?: Maybe<Scalars["String"]["output"]>;
+  nodesDeleted: Scalars["Int"]["output"];
+  relationshipsDeleted: Scalars["Int"]["output"];
 };
 
 export type IgoQcReport = {
   __typename?: "IgoQcReport";
-  IGORecommendation?: Maybe<Scalars["String"]>;
-  comments?: Maybe<Scalars["String"]>;
-  investigatorDecision?: Maybe<Scalars["String"]>;
-  qcReportType?: Maybe<Scalars["String"]>;
+  IGORecommendation?: Maybe<Scalars["String"]["output"]>;
+  comments?: Maybe<Scalars["String"]["output"]>;
+  investigatorDecision?: Maybe<Scalars["String"]["output"]>;
+  qcReportType?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type MafComplete = {
   __typename?: "MafComplete";
-  date: Scalars["String"];
-  normalPrimaryId: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["output"];
+  normalPrimaryId: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
   temposHasEvent: Array<Tempo>;
   temposHasEventAggregate?: Maybe<MafCompleteTempoTemposHasEventAggregationSelection>;
   temposHasEventConnection: MafCompleteTemposHasEventConnection;
 };
 
 export type MafCompleteTemposHasEventArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type MafCompleteTemposHasEventAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type MafCompleteTemposHasEventConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<MafCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<MafCompleteTemposHasEventConnectionWhere>;
 };
 
 export type MafCompleteAggregateSelection = {
   __typename?: "MafCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   normalPrimaryId: StringAggregateSelection;
   status: StringAggregateSelection;
@@ -2008,9 +2094,9 @@ export type MafCompleteConnectWhere = {
 };
 
 export type MafCompleteCreateInput = {
-  date: Scalars["String"];
-  normalPrimaryId: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["input"];
+  normalPrimaryId: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
   temposHasEvent?: InputMaybe<MafCompleteTemposHasEventFieldInput>;
 };
 
@@ -2026,13 +2112,13 @@ export type MafCompleteDisconnectInput = {
 
 export type MafCompleteEdge = {
   __typename?: "MafCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: MafComplete;
 };
 
 export type MafCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more MafCompleteSort objects to sort MafCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<MafCompleteSort>>;
 };
@@ -2050,7 +2136,7 @@ export type MafCompleteSort = {
 
 export type MafCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "MafCompleteTempoTemposHasEventAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<MafCompleteTempoTemposHasEventNodeAggregateSelection>;
 };
 
@@ -2069,18 +2155,18 @@ export type MafCompleteTemposHasEventAggregateInput = {
   AND?: InputMaybe<Array<MafCompleteTemposHasEventAggregateInput>>;
   NOT?: InputMaybe<MafCompleteTemposHasEventAggregateInput>;
   OR?: InputMaybe<Array<MafCompleteTemposHasEventAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<MafCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type MafCompleteTemposHasEventConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -2088,7 +2174,7 @@ export type MafCompleteTemposHasEventConnection = {
   __typename?: "MafCompleteTemposHasEventConnection";
   edges: Array<MafCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type MafCompleteTemposHasEventConnectionSort = {
@@ -2125,116 +2211,164 @@ export type MafCompleteTemposHasEventNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<MafCompleteTemposHasEventNodeAggregationWhereInput>>;
   NOT?: InputMaybe<MafCompleteTemposHasEventNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<MafCompleteTemposHasEventNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type MafCompleteTemposHasEventRelationship = {
   __typename?: "MafCompleteTemposHasEventRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -2252,9 +2386,9 @@ export type MafCompleteTemposHasEventUpdateFieldInput = {
 };
 
 export type MafCompleteUpdateInput = {
-  date?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEvent?: InputMaybe<Array<MafCompleteTemposHasEventUpdateFieldInput>>;
 };
 
@@ -2262,24 +2396,24 @@ export type MafCompleteWhere = {
   AND?: InputMaybe<Array<MafCompleteWhere>>;
   NOT?: InputMaybe<MafCompleteWhere>;
   OR?: InputMaybe<Array<MafCompleteWhere>>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  normalPrimaryId_MATCHES?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  normalPrimaryId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEventAggregate?: InputMaybe<MafCompleteTemposHasEventAggregateInput>;
   /** Return MafCompletes where all of the related MafCompleteTemposHasEventConnections match this filter */
   temposHasEventConnection_ALL?: InputMaybe<MafCompleteTemposHasEventConnectionWhere>;
@@ -2303,7 +2437,7 @@ export type MafCompletesConnection = {
   __typename?: "MafCompletesConnection";
   edges: Array<MafCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Mutation = {
@@ -2600,10 +2734,10 @@ export type MutationUpdateTemposArgs = {
 /** Pagination information (Relay) */
 export type PageInfo = {
   __typename?: "PageInfo";
-  endCursor?: Maybe<Scalars["String"]>;
-  hasNextPage: Scalars["Boolean"];
-  hasPreviousPage: Scalars["Boolean"];
-  startCursor?: Maybe<Scalars["String"]>;
+  endCursor?: Maybe<Scalars["String"]["output"]>;
+  hasNextPage: Scalars["Boolean"]["output"];
+  hasPreviousPage: Scalars["Boolean"]["output"];
+  startCursor?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type Patient = {
@@ -2614,50 +2748,50 @@ export type Patient = {
   patientAliasesIsAlias: Array<PatientAlias>;
   patientAliasesIsAliasAggregate?: Maybe<PatientPatientAliasPatientAliasesIsAliasAggregationSelection>;
   patientAliasesIsAliasConnection: PatientPatientAliasesIsAliasConnection;
-  smilePatientId: Scalars["String"];
+  smilePatientId: Scalars["String"]["output"];
 };
 
 export type PatientHasSampleSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type PatientHasSampleSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type PatientHasSampleSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<PatientHasSampleSamplesConnectionSort>>;
   where?: InputMaybe<PatientHasSampleSamplesConnectionWhere>;
 };
 
 export type PatientPatientAliasesIsAliasArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<PatientAliasOptions>;
   where?: InputMaybe<PatientAliasWhere>;
 };
 
 export type PatientPatientAliasesIsAliasAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PatientAliasWhere>;
 };
 
 export type PatientPatientAliasesIsAliasConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<PatientPatientAliasesIsAliasConnectionSort>>;
   where?: InputMaybe<PatientPatientAliasesIsAliasConnectionWhere>;
 };
 
 export type PatientAggregateSelection = {
   __typename?: "PatientAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   smilePatientId: StringAggregateSelection;
 };
 
@@ -2666,32 +2800,32 @@ export type PatientAlias = {
   isAliasPatients: Array<Patient>;
   isAliasPatientsAggregate?: Maybe<PatientAliasPatientIsAliasPatientsAggregationSelection>;
   isAliasPatientsConnection: PatientAliasIsAliasPatientsConnection;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["output"];
+  value: Scalars["String"]["output"];
 };
 
 export type PatientAliasIsAliasPatientsArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<PatientOptions>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type PatientAliasIsAliasPatientsAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type PatientAliasIsAliasPatientsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<PatientAliasIsAliasPatientsConnectionSort>>;
   where?: InputMaybe<PatientAliasIsAliasPatientsConnectionWhere>;
 };
 
 export type PatientAliasAggregateSelection = {
   __typename?: "PatientAliasAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   namespace: StringAggregateSelection;
   value: StringAggregateSelection;
 };
@@ -2708,8 +2842,8 @@ export type PatientAliasConnectWhere = {
 
 export type PatientAliasCreateInput = {
   isAliasPatients?: InputMaybe<PatientAliasIsAliasPatientsFieldInput>;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["input"];
+  value: Scalars["String"]["input"];
 };
 
 export type PatientAliasDeleteInput = {
@@ -2726,7 +2860,7 @@ export type PatientAliasDisconnectInput = {
 
 export type PatientAliasEdge = {
   __typename?: "PatientAliasEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: PatientAlias;
 };
 
@@ -2734,18 +2868,18 @@ export type PatientAliasIsAliasPatientsAggregateInput = {
   AND?: InputMaybe<Array<PatientAliasIsAliasPatientsAggregateInput>>;
   NOT?: InputMaybe<PatientAliasIsAliasPatientsAggregateInput>;
   OR?: InputMaybe<Array<PatientAliasIsAliasPatientsAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<PatientAliasIsAliasPatientsNodeAggregationWhereInput>;
 };
 
 export type PatientAliasIsAliasPatientsConnectFieldInput = {
   connect?: InputMaybe<Array<PatientConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<PatientConnectWhere>;
 };
 
@@ -2753,7 +2887,7 @@ export type PatientAliasIsAliasPatientsConnection = {
   __typename?: "PatientAliasIsAliasPatientsConnection";
   edges: Array<PatientAliasIsAliasPatientsRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientAliasIsAliasPatientsConnectionSort = {
@@ -2790,26 +2924,26 @@ export type PatientAliasIsAliasPatientsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<PatientAliasIsAliasPatientsNodeAggregationWhereInput>>;
   NOT?: InputMaybe<PatientAliasIsAliasPatientsNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<PatientAliasIsAliasPatientsNodeAggregationWhereInput>>;
-  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PatientAliasIsAliasPatientsRelationship = {
   __typename?: "PatientAliasIsAliasPatientsRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Patient;
 };
 
@@ -2829,15 +2963,15 @@ export type PatientAliasIsAliasPatientsUpdateFieldInput = {
 };
 
 export type PatientAliasOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more PatientAliasSort objects to sort PatientAliases by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<PatientAliasSort>>;
 };
 
 export type PatientAliasPatientIsAliasPatientsAggregationSelection = {
   __typename?: "PatientAliasPatientIsAliasPatientsAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<PatientAliasPatientIsAliasPatientsNodeAggregateSelection>;
 };
 
@@ -2862,8 +2996,8 @@ export type PatientAliasUpdateInput = {
   isAliasPatients?: InputMaybe<
     Array<PatientAliasIsAliasPatientsUpdateFieldInput>
   >;
-  namespace?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientAliasWhere = {
@@ -2887,25 +3021,25 @@ export type PatientAliasWhere = {
   isAliasPatients_SINGLE?: InputMaybe<PatientWhere>;
   /** Return PatientAliases where some of the related Patients match this filter */
   isAliasPatients_SOME?: InputMaybe<PatientWhere>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
-  value_CONTAINS?: InputMaybe<Scalars["String"]>;
-  value_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  value_IN?: InputMaybe<Array<Scalars["String"]>>;
-  value_MATCHES?: InputMaybe<Scalars["String"]>;
-  value_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
+  value_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  value_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  value_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  value_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientAliasesConnection = {
   __typename?: "PatientAliasesConnection";
   edges: Array<PatientAliasEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientConnectInput = {
@@ -2924,7 +3058,7 @@ export type PatientConnectWhere = {
 export type PatientCreateInput = {
   hasSampleSamples?: InputMaybe<PatientHasSampleSamplesFieldInput>;
   patientAliasesIsAlias?: InputMaybe<PatientPatientAliasesIsAliasFieldInput>;
-  smilePatientId: Scalars["String"];
+  smilePatientId: Scalars["String"]["input"];
 };
 
 export type PatientDeleteInput = {
@@ -2945,7 +3079,7 @@ export type PatientDisconnectInput = {
 
 export type PatientEdge = {
   __typename?: "PatientEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Patient;
 };
 
@@ -2953,18 +3087,18 @@ export type PatientHasSampleSamplesAggregateInput = {
   AND?: InputMaybe<Array<PatientHasSampleSamplesAggregateInput>>;
   NOT?: InputMaybe<PatientHasSampleSamplesAggregateInput>;
   OR?: InputMaybe<Array<PatientHasSampleSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<PatientHasSampleSamplesNodeAggregationWhereInput>;
 };
 
 export type PatientHasSampleSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -2972,7 +3106,7 @@ export type PatientHasSampleSamplesConnection = {
   __typename?: "PatientHasSampleSamplesConnection";
   edges: Array<PatientHasSampleSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientHasSampleSamplesConnectionSort = {
@@ -3009,71 +3143,71 @@ export type PatientHasSampleSamplesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<PatientHasSampleSamplesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<PatientHasSampleSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<PatientHasSampleSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PatientHasSampleSamplesRelationship = {
   __typename?: "PatientHasSampleSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -3092,22 +3226,22 @@ export type PatientHasSampleSamplesUpdateFieldInput = {
 
 export type PatientIdsTriplet = {
   __typename?: "PatientIdsTriplet";
-  CMO_PATIENT_ID: Scalars["String"];
-  DMP_PATIENT_ID?: Maybe<Scalars["String"]>;
-  MRN: Scalars["String"];
-  RACE?: Maybe<Scalars["String"]>;
+  CMO_PATIENT_ID: Scalars["String"]["output"];
+  DMP_PATIENT_ID?: Maybe<Scalars["String"]["output"]>;
+  MRN: Scalars["String"]["output"];
+  RACE?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type PatientOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more PatientSort objects to sort Patients by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<PatientSort>>;
 };
 
 export type PatientPatientAliasPatientAliasesIsAliasAggregationSelection = {
   __typename?: "PatientPatientAliasPatientAliasesIsAliasAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<PatientPatientAliasPatientAliasesIsAliasNodeAggregateSelection>;
 };
 
@@ -3121,18 +3255,18 @@ export type PatientPatientAliasesIsAliasAggregateInput = {
   AND?: InputMaybe<Array<PatientPatientAliasesIsAliasAggregateInput>>;
   NOT?: InputMaybe<PatientPatientAliasesIsAliasAggregateInput>;
   OR?: InputMaybe<Array<PatientPatientAliasesIsAliasAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<PatientPatientAliasesIsAliasNodeAggregationWhereInput>;
 };
 
 export type PatientPatientAliasesIsAliasConnectFieldInput = {
   connect?: InputMaybe<Array<PatientAliasConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<PatientAliasConnectWhere>;
 };
 
@@ -3140,7 +3274,7 @@ export type PatientPatientAliasesIsAliasConnection = {
   __typename?: "PatientPatientAliasesIsAliasConnection";
   edges: Array<PatientPatientAliasesIsAliasRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientPatientAliasesIsAliasConnectionSort = {
@@ -3179,41 +3313,41 @@ export type PatientPatientAliasesIsAliasNodeAggregationWhereInput = {
   >;
   NOT?: InputMaybe<PatientPatientAliasesIsAliasNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<PatientPatientAliasesIsAliasNodeAggregationWhereInput>>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PatientPatientAliasesIsAliasRelationship = {
   __typename?: "PatientPatientAliasesIsAliasRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: PatientAlias;
 };
 
@@ -3241,7 +3375,7 @@ export type PatientRelationInput = {
 
 export type PatientSampleHasSampleSamplesAggregationSelection = {
   __typename?: "PatientSampleHasSampleSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<PatientSampleHasSampleSamplesNodeAggregateSelection>;
 };
 
@@ -3263,7 +3397,7 @@ export type PatientUpdateInput = {
   patientAliasesIsAlias?: InputMaybe<
     Array<PatientPatientAliasesIsAliasUpdateFieldInput>
   >;
-  smilePatientId?: InputMaybe<Scalars["String"]>;
+  smilePatientId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientWhere = {
@@ -3304,19 +3438,19 @@ export type PatientWhere = {
   patientAliasesIsAlias_SINGLE?: InputMaybe<PatientAliasWhere>;
   /** Return Patients where some of the related PatientAliases match this filter */
   patientAliasesIsAlias_SOME?: InputMaybe<PatientAliasWhere>;
-  smilePatientId?: InputMaybe<Scalars["String"]>;
-  smilePatientId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smilePatientId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smilePatientId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smilePatientId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smilePatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smilePatientId?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smilePatientId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientsConnection = {
   __typename?: "PatientsConnection";
   edges: Array<PatientEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Project = {
@@ -3324,32 +3458,32 @@ export type Project = {
   hasRequestRequests: Array<Request>;
   hasRequestRequestsAggregate?: Maybe<ProjectRequestHasRequestRequestsAggregationSelection>;
   hasRequestRequestsConnection: ProjectHasRequestRequestsConnection;
-  igoProjectId: Scalars["String"];
-  namespace: Scalars["String"];
+  igoProjectId: Scalars["String"]["output"];
+  namespace: Scalars["String"]["output"];
 };
 
 export type ProjectHasRequestRequestsArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type ProjectHasRequestRequestsAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type ProjectHasRequestRequestsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<ProjectHasRequestRequestsConnectionSort>>;
   where?: InputMaybe<ProjectHasRequestRequestsConnectionWhere>;
 };
 
 export type ProjectAggregateSelection = {
   __typename?: "ProjectAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   igoProjectId: StringAggregateSelection;
   namespace: StringAggregateSelection;
 };
@@ -3366,8 +3500,8 @@ export type ProjectConnectWhere = {
 
 export type ProjectCreateInput = {
   hasRequestRequests?: InputMaybe<ProjectHasRequestRequestsFieldInput>;
-  igoProjectId: Scalars["String"];
-  namespace: Scalars["String"];
+  igoProjectId: Scalars["String"]["input"];
+  namespace: Scalars["String"]["input"];
 };
 
 export type ProjectDeleteInput = {
@@ -3384,7 +3518,7 @@ export type ProjectDisconnectInput = {
 
 export type ProjectEdge = {
   __typename?: "ProjectEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Project;
 };
 
@@ -3392,18 +3526,18 @@ export type ProjectHasRequestRequestsAggregateInput = {
   AND?: InputMaybe<Array<ProjectHasRequestRequestsAggregateInput>>;
   NOT?: InputMaybe<ProjectHasRequestRequestsAggregateInput>;
   OR?: InputMaybe<Array<ProjectHasRequestRequestsAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<ProjectHasRequestRequestsNodeAggregationWhereInput>;
 };
 
 export type ProjectHasRequestRequestsConnectFieldInput = {
   connect?: InputMaybe<Array<RequestConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestConnectWhere>;
 };
 
@@ -3411,7 +3545,7 @@ export type ProjectHasRequestRequestsConnection = {
   __typename?: "ProjectHasRequestRequestsConnection";
   edges: Array<ProjectHasRequestRequestsRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type ProjectHasRequestRequestsConnectionSort = {
@@ -3448,331 +3582,341 @@ export type ProjectHasRequestRequestsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<ProjectHasRequestRequestsNodeAggregationWhereInput>>;
   NOT?: InputMaybe<ProjectHasRequestRequestsNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<ProjectHasRequestRequestsNodeAggregationWhereInput>>;
-  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type ProjectHasRequestRequestsRelationship = {
   __typename?: "ProjectHasRequestRequestsRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -3790,8 +3934,8 @@ export type ProjectHasRequestRequestsUpdateFieldInput = {
 };
 
 export type ProjectOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more ProjectSort objects to sort Projects by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<ProjectSort>>;
 };
@@ -3804,7 +3948,7 @@ export type ProjectRelationInput = {
 
 export type ProjectRequestHasRequestRequestsAggregationSelection = {
   __typename?: "ProjectRequestHasRequestRequestsAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<ProjectRequestHasRequestRequestsNodeAggregateSelection>;
 };
 
@@ -3843,8 +3987,8 @@ export type ProjectUpdateInput = {
   hasRequestRequests?: InputMaybe<
     Array<ProjectHasRequestRequestsUpdateFieldInput>
   >;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type ProjectWhere = {
@@ -3868,60 +4012,60 @@ export type ProjectWhere = {
   hasRequestRequests_SINGLE?: InputMaybe<RequestWhere>;
   /** Return Projects where some of the related Requests match this filter */
   hasRequestRequests_SOME?: InputMaybe<RequestWhere>;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type ProjectsConnection = {
   __typename?: "ProjectsConnection";
   edges: Array<ProjectEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type QcComplete = {
   __typename?: "QcComplete";
-  date: Scalars["String"];
-  reason: Scalars["String"];
-  result: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["output"];
+  reason: Scalars["String"]["output"];
+  result: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
   temposHasEvent: Array<Tempo>;
   temposHasEventAggregate?: Maybe<QcCompleteTempoTemposHasEventAggregationSelection>;
   temposHasEventConnection: QcCompleteTemposHasEventConnection;
 };
 
 export type QcCompleteTemposHasEventArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type QcCompleteTemposHasEventAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type QcCompleteTemposHasEventConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<QcCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<QcCompleteTemposHasEventConnectionWhere>;
 };
 
 export type QcCompleteAggregateSelection = {
   __typename?: "QcCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   reason: StringAggregateSelection;
   result: StringAggregateSelection;
@@ -3937,10 +4081,10 @@ export type QcCompleteConnectWhere = {
 };
 
 export type QcCompleteCreateInput = {
-  date: Scalars["String"];
-  reason: Scalars["String"];
-  result: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["input"];
+  reason: Scalars["String"]["input"];
+  result: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
   temposHasEvent?: InputMaybe<QcCompleteTemposHasEventFieldInput>;
 };
 
@@ -3956,13 +4100,13 @@ export type QcCompleteDisconnectInput = {
 
 export type QcCompleteEdge = {
   __typename?: "QcCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: QcComplete;
 };
 
 export type QcCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more QcCompleteSort objects to sort QcCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<QcCompleteSort>>;
 };
@@ -3981,7 +4125,7 @@ export type QcCompleteSort = {
 
 export type QcCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "QcCompleteTempoTemposHasEventAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<QcCompleteTempoTemposHasEventNodeAggregateSelection>;
 };
 
@@ -4000,18 +4144,18 @@ export type QcCompleteTemposHasEventAggregateInput = {
   AND?: InputMaybe<Array<QcCompleteTemposHasEventAggregateInput>>;
   NOT?: InputMaybe<QcCompleteTemposHasEventAggregateInput>;
   OR?: InputMaybe<Array<QcCompleteTemposHasEventAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<QcCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type QcCompleteTemposHasEventConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -4019,7 +4163,7 @@ export type QcCompleteTemposHasEventConnection = {
   __typename?: "QcCompleteTemposHasEventConnection";
   edges: Array<QcCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type QcCompleteTemposHasEventConnectionSort = {
@@ -4056,116 +4200,164 @@ export type QcCompleteTemposHasEventNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<QcCompleteTemposHasEventNodeAggregationWhereInput>>;
   NOT?: InputMaybe<QcCompleteTemposHasEventNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<QcCompleteTemposHasEventNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QcCompleteTemposHasEventRelationship = {
   __typename?: "QcCompleteTemposHasEventRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -4183,10 +4375,10 @@ export type QcCompleteTemposHasEventUpdateFieldInput = {
 };
 
 export type QcCompleteUpdateInput = {
-  date?: InputMaybe<Scalars["String"]>;
-  reason?: InputMaybe<Scalars["String"]>;
-  result?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  reason?: InputMaybe<Scalars["String"]["input"]>;
+  result?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEvent?: InputMaybe<Array<QcCompleteTemposHasEventUpdateFieldInput>>;
 };
 
@@ -4194,30 +4386,30 @@ export type QcCompleteWhere = {
   AND?: InputMaybe<Array<QcCompleteWhere>>;
   NOT?: InputMaybe<QcCompleteWhere>;
   OR?: InputMaybe<Array<QcCompleteWhere>>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  reason?: InputMaybe<Scalars["String"]>;
-  reason_CONTAINS?: InputMaybe<Scalars["String"]>;
-  reason_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  reason_IN?: InputMaybe<Array<Scalars["String"]>>;
-  reason_MATCHES?: InputMaybe<Scalars["String"]>;
-  reason_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  result?: InputMaybe<Scalars["String"]>;
-  result_CONTAINS?: InputMaybe<Scalars["String"]>;
-  result_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  result_IN?: InputMaybe<Array<Scalars["String"]>>;
-  result_MATCHES?: InputMaybe<Scalars["String"]>;
-  result_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  reason?: InputMaybe<Scalars["String"]["input"]>;
+  reason_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  reason_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  reason_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  reason_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  reason_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  result?: InputMaybe<Scalars["String"]["input"]>;
+  result_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  result_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  result_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  result_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  result_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEventAggregate?: InputMaybe<QcCompleteTemposHasEventAggregateInput>;
   /** Return QcCompletes where all of the related QcCompleteTemposHasEventConnections match this filter */
   temposHasEventConnection_ALL?: InputMaybe<QcCompleteTemposHasEventConnectionWhere>;
@@ -4241,13 +4433,13 @@ export type QcCompletesConnection = {
   __typename?: "QcCompletesConnection";
   edges: Array<QcCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Query = {
   __typename?: "Query";
   allAnchorSeqDateData: Array<AnchorSeqDateData>;
-  allBlockedCohortIds: Array<Scalars["String"]>;
+  allBlockedCohortIds: Array<Scalars["String"]["output"]>;
   bamCompletes: Array<BamComplete>;
   bamCompletesAggregate: BamCompleteAggregateSelection;
   bamCompletesConnection: BamCompletesConnection;
@@ -4305,7 +4497,7 @@ export type Query = {
 };
 
 export type QueryAllAnchorSeqDateDataArgs = {
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type QueryBamCompletesArgs = {
@@ -4318,8 +4510,8 @@ export type QueryBamCompletesAggregateArgs = {
 };
 
 export type QueryBamCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<BamCompleteSort>>>;
   where?: InputMaybe<BamCompleteWhere>;
 };
@@ -4334,8 +4526,8 @@ export type QueryCohortCompletesAggregateArgs = {
 };
 
 export type QueryCohortCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<CohortCompleteSort>>>;
   where?: InputMaybe<CohortCompleteWhere>;
 };
@@ -4350,52 +4542,52 @@ export type QueryCohortsAggregateArgs = {
 };
 
 export type QueryCohortsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<CohortSort>>>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type QueryDashboardCohortsArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardPatientsArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardRequestsArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardSampleHistoryArgs = {
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  searchVals: Array<Scalars["String"]>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  searchVals: Array<Scalars["String"]["input"]>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardSamplesArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  includeDemographics: Scalars["Boolean"];
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  includeDemographics: Scalars["Boolean"]["input"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   recordContexts?: InputMaybe<Array<InputMaybe<DashboardRecordContext>>>;
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
@@ -4409,16 +4601,17 @@ export type QueryDbGapsAggregateArgs = {
 };
 
 export type QueryDbGapsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<DbGapSort>>>;
   where?: InputMaybe<DbGapWhere>;
 };
 
 export type QueryGetValidationAdviceArgs = {
-  recordId?: InputMaybe<Scalars["String"]>;
-  recordType: Scalars["String"];
-  validationReport: Scalars["String"];
+  igoQcReports?: InputMaybe<Scalars["String"]["input"]>;
+  recordId?: InputMaybe<Scalars["String"]["input"]>;
+  recordType: Scalars["String"]["input"];
+  validationReport: Scalars["String"]["input"];
 };
 
 export type QueryMafCompletesArgs = {
@@ -4431,8 +4624,8 @@ export type QueryMafCompletesAggregateArgs = {
 };
 
 export type QueryMafCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<MafCompleteSort>>>;
   where?: InputMaybe<MafCompleteWhere>;
 };
@@ -4447,8 +4640,8 @@ export type QueryPatientAliasesAggregateArgs = {
 };
 
 export type QueryPatientAliasesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<PatientAliasSort>>>;
   where?: InputMaybe<PatientAliasWhere>;
 };
@@ -4463,8 +4656,8 @@ export type QueryPatientsAggregateArgs = {
 };
 
 export type QueryPatientsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<PatientSort>>>;
   where?: InputMaybe<PatientWhere>;
 };
@@ -4479,8 +4672,8 @@ export type QueryProjectsAggregateArgs = {
 };
 
 export type QueryProjectsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<ProjectSort>>>;
   where?: InputMaybe<ProjectWhere>;
 };
@@ -4495,8 +4688,8 @@ export type QueryQcCompletesAggregateArgs = {
 };
 
 export type QueryQcCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<QcCompleteSort>>>;
   where?: InputMaybe<QcCompleteWhere>;
 };
@@ -4511,8 +4704,8 @@ export type QueryRequestMetadataAggregateArgs = {
 };
 
 export type QueryRequestMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<RequestMetadataSort>>>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
@@ -4527,8 +4720,8 @@ export type QueryRequestsAggregateArgs = {
 };
 
 export type QueryRequestsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<RequestSort>>>;
   where?: InputMaybe<RequestWhere>;
 };
@@ -4543,8 +4736,8 @@ export type QuerySampleAliasesAggregateArgs = {
 };
 
 export type QuerySampleAliasesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<SampleAliasSort>>>;
   where?: InputMaybe<SampleAliasWhere>;
 };
@@ -4559,8 +4752,8 @@ export type QuerySampleMetadataAggregateArgs = {
 };
 
 export type QuerySampleMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<SampleMetadataSort>>>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
@@ -4575,8 +4768,8 @@ export type QuerySamplesAggregateArgs = {
 };
 
 export type QuerySamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<SampleSort>>>;
   where?: InputMaybe<SampleWhere>;
 };
@@ -4591,8 +4784,8 @@ export type QueryStatusesAggregateArgs = {
 };
 
 export type QueryStatusesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<StatusSort>>>;
   where?: InputMaybe<StatusWhere>;
 };
@@ -4607,109 +4800,109 @@ export type QueryTemposAggregateArgs = {
 };
 
 export type QueryTemposConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<TempoSort>>>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type Request = {
   __typename?: "Request";
-  bicAnalysis: Scalars["Boolean"];
-  dataAccessEmails: Scalars["String"];
-  dataAnalystEmail: Scalars["String"];
-  dataAnalystName: Scalars["String"];
-  genePanel: Scalars["String"];
+  bicAnalysis: Scalars["Boolean"]["output"];
+  dataAccessEmails: Scalars["String"]["output"];
+  dataAnalystEmail: Scalars["String"]["output"];
+  dataAnalystName: Scalars["String"]["output"];
+  genePanel: Scalars["String"]["output"];
   hasMetadataRequestMetadata: Array<RequestMetadata>;
   hasMetadataRequestMetadataAggregate?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection>;
   hasMetadataRequestMetadataConnection: RequestHasMetadataRequestMetadataConnection;
   hasSampleSamples: Array<Sample>;
   hasSampleSamplesAggregate?: Maybe<RequestSampleHasSampleSamplesAggregationSelection>;
   hasSampleSamplesConnection: RequestHasSampleSamplesConnection;
-  igoDeliveryDate?: Maybe<Scalars["BigInt"]>;
-  igoProjectId: Scalars["String"];
-  igoRequestId: Scalars["String"];
-  ilabRequestId?: Maybe<Scalars["String"]>;
-  investigatorEmail: Scalars["String"];
-  investigatorName: Scalars["String"];
-  isCmoRequest: Scalars["Boolean"];
-  labHeadEmail: Scalars["String"];
-  labHeadName: Scalars["String"];
-  libraryType?: Maybe<Scalars["String"]>;
-  namespace: Scalars["String"];
-  otherContactEmails: Scalars["String"];
-  piEmail: Scalars["String"];
-  pooledNormals?: Maybe<Array<Maybe<Scalars["String"]>>>;
-  projectManagerName: Scalars["String"];
+  igoDeliveryDate?: Maybe<Scalars["BigInt"]["output"]>;
+  igoProjectId: Scalars["String"]["output"];
+  igoRequestId: Scalars["String"]["output"];
+  ilabRequestId?: Maybe<Scalars["String"]["output"]>;
+  investigatorEmail: Scalars["String"]["output"];
+  investigatorName: Scalars["String"]["output"];
+  isCmoRequest: Scalars["Boolean"]["output"];
+  labHeadEmail: Scalars["String"]["output"];
+  labHeadName: Scalars["String"]["output"];
+  libraryType?: Maybe<Scalars["String"]["output"]>;
+  namespace: Scalars["String"]["output"];
+  otherContactEmails: Scalars["String"]["output"];
+  piEmail: Scalars["String"]["output"];
+  pooledNormals?: Maybe<Array<Maybe<Scalars["String"]["output"]>>>;
+  projectManagerName: Scalars["String"]["output"];
   projectsHasRequest: Array<Project>;
   projectsHasRequestAggregate?: Maybe<RequestProjectProjectsHasRequestAggregationSelection>;
   projectsHasRequestConnection: RequestProjectsHasRequestConnection;
-  qcAccessEmails: Scalars["String"];
-  requestJson: Scalars["String"];
-  smileRequestId: Scalars["String"];
-  strand?: Maybe<Scalars["String"]>;
+  qcAccessEmails: Scalars["String"]["output"];
+  requestJson: Scalars["String"]["output"];
+  smileRequestId: Scalars["String"]["output"];
+  strand?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type RequestHasMetadataRequestMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestMetadataOptions>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type RequestHasMetadataRequestMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type RequestHasMetadataRequestMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionSort>>;
   where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
 };
 
 export type RequestHasSampleSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type RequestHasSampleSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type RequestHasSampleSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestHasSampleSamplesConnectionSort>>;
   where?: InputMaybe<RequestHasSampleSamplesConnectionWhere>;
 };
 
 export type RequestProjectsHasRequestArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<ProjectOptions>;
   where?: InputMaybe<ProjectWhere>;
 };
 
 export type RequestProjectsHasRequestAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ProjectWhere>;
 };
 
 export type RequestProjectsHasRequestConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestProjectsHasRequestConnectionSort>>;
   where?: InputMaybe<RequestProjectsHasRequestConnectionWhere>;
 };
 
 export type RequestAggregateSelection = {
   __typename?: "RequestAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   dataAccessEmails: StringAggregateSelection;
   dataAnalystEmail: StringAggregateSelection;
   dataAnalystName: StringAggregateSelection;
@@ -4750,33 +4943,33 @@ export type RequestConnectWhere = {
 };
 
 export type RequestCreateInput = {
-  bicAnalysis: Scalars["Boolean"];
-  dataAccessEmails: Scalars["String"];
-  dataAnalystEmail: Scalars["String"];
-  dataAnalystName: Scalars["String"];
-  genePanel: Scalars["String"];
+  bicAnalysis: Scalars["Boolean"]["input"];
+  dataAccessEmails: Scalars["String"]["input"];
+  dataAnalystEmail: Scalars["String"]["input"];
+  dataAnalystName: Scalars["String"]["input"];
+  genePanel: Scalars["String"]["input"];
   hasMetadataRequestMetadata?: InputMaybe<RequestHasMetadataRequestMetadataFieldInput>;
   hasSampleSamples?: InputMaybe<RequestHasSampleSamplesFieldInput>;
-  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId: Scalars["String"];
-  igoRequestId: Scalars["String"];
-  ilabRequestId?: InputMaybe<Scalars["String"]>;
-  investigatorEmail: Scalars["String"];
-  investigatorName: Scalars["String"];
-  isCmoRequest: Scalars["Boolean"];
-  labHeadEmail: Scalars["String"];
-  labHeadName: Scalars["String"];
-  libraryType?: InputMaybe<Scalars["String"]>;
-  namespace: Scalars["String"];
-  otherContactEmails: Scalars["String"];
-  piEmail: Scalars["String"];
-  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  projectManagerName: Scalars["String"];
+  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId: Scalars["String"]["input"];
+  igoRequestId: Scalars["String"]["input"];
+  ilabRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail: Scalars["String"]["input"];
+  investigatorName: Scalars["String"]["input"];
+  isCmoRequest: Scalars["Boolean"]["input"];
+  labHeadEmail: Scalars["String"]["input"];
+  labHeadName: Scalars["String"]["input"];
+  libraryType?: InputMaybe<Scalars["String"]["input"]>;
+  namespace: Scalars["String"]["input"];
+  otherContactEmails: Scalars["String"]["input"];
+  piEmail: Scalars["String"]["input"];
+  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  projectManagerName: Scalars["String"]["input"];
   projectsHasRequest?: InputMaybe<RequestProjectsHasRequestFieldInput>;
-  qcAccessEmails: Scalars["String"];
-  requestJson: Scalars["String"];
-  smileRequestId: Scalars["String"];
-  strand?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails: Scalars["String"]["input"];
+  requestJson: Scalars["String"]["input"];
+  smileRequestId: Scalars["String"]["input"];
+  strand?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RequestDeleteInput = {
@@ -4803,7 +4996,7 @@ export type RequestDisconnectInput = {
 
 export type RequestEdge = {
   __typename?: "RequestEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -4811,18 +5004,18 @@ export type RequestHasMetadataRequestMetadataAggregateInput = {
   AND?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
   NOT?: InputMaybe<RequestHasMetadataRequestMetadataAggregateInput>;
   OR?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>;
 };
 
 export type RequestHasMetadataRequestMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<RequestMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestMetadataConnectWhere>;
 };
 
@@ -4830,7 +5023,7 @@ export type RequestHasMetadataRequestMetadataConnection = {
   __typename?: "RequestHasMetadataRequestMetadataConnection";
   edges: Array<RequestHasMetadataRequestMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestHasMetadataRequestMetadataConnectionSort = {
@@ -4873,61 +5066,71 @@ export type RequestHasMetadataRequestMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>
   >;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestHasMetadataRequestMetadataRelationship = {
   __typename?: "RequestHasMetadataRequestMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: RequestMetadata;
 };
 
@@ -4952,18 +5155,18 @@ export type RequestHasSampleSamplesAggregateInput = {
   AND?: InputMaybe<Array<RequestHasSampleSamplesAggregateInput>>;
   NOT?: InputMaybe<RequestHasSampleSamplesAggregateInput>;
   OR?: InputMaybe<Array<RequestHasSampleSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestHasSampleSamplesNodeAggregationWhereInput>;
 };
 
 export type RequestHasSampleSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -4971,7 +5174,7 @@ export type RequestHasSampleSamplesConnection = {
   __typename?: "RequestHasSampleSamplesConnection";
   edges: Array<RequestHasSampleSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestHasSampleSamplesConnectionSort = {
@@ -5008,71 +5211,71 @@ export type RequestHasSampleSamplesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<RequestHasSampleSamplesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<RequestHasSampleSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<RequestHasSampleSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestHasSampleSamplesRelationship = {
   __typename?: "RequestHasSampleSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -5094,55 +5297,55 @@ export type RequestMetadata = {
   hasStatusStatuses: Array<Status>;
   hasStatusStatusesAggregate?: Maybe<RequestMetadataStatusHasStatusStatusesAggregationSelection>;
   hasStatusStatusesConnection: RequestMetadataHasStatusStatusesConnection;
-  igoRequestId: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  requestMetadataJson: Scalars["String"];
+  igoRequestId: Scalars["String"]["output"];
+  importDate: Scalars["BigInt"]["output"];
+  requestMetadataJson: Scalars["String"]["output"];
   requestsHasMetadata: Array<Request>;
   requestsHasMetadataAggregate?: Maybe<RequestMetadataRequestRequestsHasMetadataAggregationSelection>;
   requestsHasMetadataConnection: RequestMetadataRequestsHasMetadataConnection;
 };
 
 export type RequestMetadataHasStatusStatusesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<StatusOptions>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type RequestMetadataHasStatusStatusesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type RequestMetadataHasStatusStatusesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestMetadataHasStatusStatusesConnectionSort>>;
   where?: InputMaybe<RequestMetadataHasStatusStatusesConnectionWhere>;
 };
 
 export type RequestMetadataRequestsHasMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type RequestMetadataRequestsHasMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type RequestMetadataRequestsHasMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionSort>>;
   where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
 };
 
 export type RequestMetadataAggregateSelection = {
   __typename?: "RequestMetadataAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   igoRequestId: StringAggregateSelection;
   importDate: BigIntAggregateSelection;
   requestMetadataJson: StringAggregateSelection;
@@ -5165,14 +5368,14 @@ export type RequestMetadataConnection = {
   __typename?: "RequestMetadataConnection";
   edges: Array<RequestMetadataEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestMetadataCreateInput = {
   hasStatusStatuses?: InputMaybe<RequestMetadataHasStatusStatusesFieldInput>;
-  igoRequestId: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  requestMetadataJson: Scalars["String"];
+  igoRequestId: Scalars["String"]["input"];
+  importDate: Scalars["BigInt"]["input"];
+  requestMetadataJson: Scalars["String"]["input"];
   requestsHasMetadata?: InputMaybe<RequestMetadataRequestsHasMetadataFieldInput>;
 };
 
@@ -5196,7 +5399,7 @@ export type RequestMetadataDisconnectInput = {
 
 export type RequestMetadataEdge = {
   __typename?: "RequestMetadataEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: RequestMetadata;
 };
 
@@ -5204,18 +5407,18 @@ export type RequestMetadataHasStatusStatusesAggregateInput = {
   AND?: InputMaybe<Array<RequestMetadataHasStatusStatusesAggregateInput>>;
   NOT?: InputMaybe<RequestMetadataHasStatusStatusesAggregateInput>;
   OR?: InputMaybe<Array<RequestMetadataHasStatusStatusesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestMetadataHasStatusStatusesNodeAggregationWhereInput>;
 };
 
 export type RequestMetadataHasStatusStatusesConnectFieldInput = {
   connect?: InputMaybe<Array<StatusConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<StatusConnectWhere>;
 };
 
@@ -5223,7 +5426,7 @@ export type RequestMetadataHasStatusStatusesConnection = {
   __typename?: "RequestMetadataHasStatusStatusesConnection";
   edges: Array<RequestMetadataHasStatusStatusesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestMetadataHasStatusStatusesConnectionSort = {
@@ -5266,26 +5469,26 @@ export type RequestMetadataHasStatusStatusesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesNodeAggregationWhereInput>
   >;
-  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestMetadataHasStatusStatusesRelationship = {
   __typename?: "RequestMetadataHasStatusStatusesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Status;
 };
 
@@ -5307,8 +5510,8 @@ export type RequestMetadataHasStatusStatusesUpdateFieldInput = {
 };
 
 export type RequestMetadataOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more RequestMetadataSort objects to sort RequestMetadata by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<RequestMetadataSort>>;
 };
@@ -5324,7 +5527,7 @@ export type RequestMetadataRelationInput = {
 
 export type RequestMetadataRequestRequestsHasMetadataAggregationSelection = {
   __typename?: "RequestMetadataRequestRequestsHasMetadataAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection>;
 };
 
@@ -5357,18 +5560,18 @@ export type RequestMetadataRequestsHasMetadataAggregateInput = {
   AND?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
   NOT?: InputMaybe<RequestMetadataRequestsHasMetadataAggregateInput>;
   OR?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>;
 };
 
 export type RequestMetadataRequestsHasMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<RequestConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestConnectWhere>;
 };
 
@@ -5376,7 +5579,7 @@ export type RequestMetadataRequestsHasMetadataConnection = {
   __typename?: "RequestMetadataRequestsHasMetadataConnection";
   edges: Array<RequestMetadataRequestsHasMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestMetadataRequestsHasMetadataConnectionSort = {
@@ -5421,331 +5624,341 @@ export type RequestMetadataRequestsHasMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>
   >;
-  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestMetadataRequestsHasMetadataRelationship = {
   __typename?: "RequestMetadataRequestsHasMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -5779,7 +5992,7 @@ export type RequestMetadataSort = {
 
 export type RequestMetadataStatusHasStatusStatusesAggregationSelection = {
   __typename?: "RequestMetadataStatusHasStatusStatusesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestMetadataStatusHasStatusStatusesNodeAggregateSelection>;
 };
 
@@ -5792,11 +6005,11 @@ export type RequestMetadataUpdateInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesUpdateFieldInput>
   >;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson?: InputMaybe<Scalars["String"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson?: InputMaybe<Scalars["String"]["input"]>;
   requestsHasMetadata?: InputMaybe<
     Array<RequestMetadataRequestsHasMetadataUpdateFieldInput>
   >;
@@ -5823,24 +6036,24 @@ export type RequestMetadataWhere = {
   hasStatusStatuses_SINGLE?: InputMaybe<StatusWhere>;
   /** Return RequestMetadata where some of the related Statuses match this filter */
   hasStatusStatuses_SOME?: InputMaybe<StatusWhere>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]>>;
-  importDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_CONTAINS?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_IN?: InputMaybe<Array<Scalars["String"]>>;
-  requestMetadataJson_MATCHES?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  importDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  requestMetadataJson_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   requestsHasMetadataAggregate?: InputMaybe<RequestMetadataRequestsHasMetadataAggregateInput>;
   /** Return RequestMetadata where all of the related RequestMetadataRequestsHasMetadataConnections match this filter */
   requestsHasMetadataConnection_ALL?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
@@ -5861,15 +6074,15 @@ export type RequestMetadataWhere = {
 };
 
 export type RequestOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more RequestSort objects to sort Requests by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<RequestSort>>;
 };
 
 export type RequestProjectProjectsHasRequestAggregationSelection = {
   __typename?: "RequestProjectProjectsHasRequestAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestProjectProjectsHasRequestNodeAggregateSelection>;
 };
 
@@ -5883,18 +6096,18 @@ export type RequestProjectsHasRequestAggregateInput = {
   AND?: InputMaybe<Array<RequestProjectsHasRequestAggregateInput>>;
   NOT?: InputMaybe<RequestProjectsHasRequestAggregateInput>;
   OR?: InputMaybe<Array<RequestProjectsHasRequestAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestProjectsHasRequestNodeAggregationWhereInput>;
 };
 
 export type RequestProjectsHasRequestConnectFieldInput = {
   connect?: InputMaybe<Array<ProjectConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<ProjectConnectWhere>;
 };
 
@@ -5902,7 +6115,7 @@ export type RequestProjectsHasRequestConnection = {
   __typename?: "RequestProjectsHasRequestConnection";
   edges: Array<RequestProjectsHasRequestRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestProjectsHasRequestConnectionSort = {
@@ -5939,41 +6152,41 @@ export type RequestProjectsHasRequestNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<RequestProjectsHasRequestNodeAggregationWhereInput>>;
   NOT?: InputMaybe<RequestProjectsHasRequestNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<RequestProjectsHasRequestNodeAggregationWhereInput>>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestProjectsHasRequestRelationship = {
   __typename?: "RequestProjectsHasRequestRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Project;
 };
 
@@ -6003,7 +6216,7 @@ export type RequestRelationInput = {
 export type RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection =
   {
     __typename?: "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection>;
   };
 
@@ -6017,7 +6230,7 @@ export type RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelecti
 
 export type RequestSampleHasSampleSamplesAggregationSelection = {
   __typename?: "RequestSampleHasSampleSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestSampleHasSampleSamplesNodeAggregateSelection>;
 };
 
@@ -6057,72 +6270,74 @@ export type RequestSort = {
 };
 
 export type RequestUpdateInput = {
-  bicAnalysis?: InputMaybe<Scalars["Boolean"]>;
-  dataAccessEmails?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail?: InputMaybe<Scalars["String"]>;
-  dataAnalystName?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
+  bicAnalysis?: InputMaybe<Scalars["Boolean"]["input"]>;
+  dataAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
   hasMetadataRequestMetadata?: InputMaybe<
     Array<RequestHasMetadataRequestMetadataUpdateFieldInput>
   >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesUpdateFieldInput>>;
-  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  ilabRequestId?: InputMaybe<Scalars["String"]>;
-  investigatorEmail?: InputMaybe<Scalars["String"]>;
-  investigatorName?: InputMaybe<Scalars["String"]>;
-  isCmoRequest?: InputMaybe<Scalars["Boolean"]>;
-  labHeadEmail?: InputMaybe<Scalars["String"]>;
-  labHeadName?: InputMaybe<Scalars["String"]>;
-  libraryType?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  otherContactEmails?: InputMaybe<Scalars["String"]>;
-  piEmail?: InputMaybe<Scalars["String"]>;
-  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pooledNormals_POP?: InputMaybe<Scalars["Int"]>;
-  pooledNormals_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  projectManagerName?: InputMaybe<Scalars["String"]>;
+  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName?: InputMaybe<Scalars["String"]["input"]>;
+  isCmoRequest?: InputMaybe<Scalars["Boolean"]["input"]>;
+  labHeadEmail?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail?: InputMaybe<Scalars["String"]["input"]>;
+  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pooledNormals_POP?: InputMaybe<Scalars["Int"]["input"]>;
+  pooledNormals_PUSH?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  projectManagerName?: InputMaybe<Scalars["String"]["input"]>;
   projectsHasRequest?: InputMaybe<
     Array<RequestProjectsHasRequestUpdateFieldInput>
   >;
-  qcAccessEmails?: InputMaybe<Scalars["String"]>;
-  requestJson?: InputMaybe<Scalars["String"]>;
-  smileRequestId?: InputMaybe<Scalars["String"]>;
-  strand?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  strand?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RequestWhere = {
   AND?: InputMaybe<Array<RequestWhere>>;
   NOT?: InputMaybe<RequestWhere>;
   OR?: InputMaybe<Array<RequestWhere>>;
-  bicAnalysis?: InputMaybe<Scalars["Boolean"]>;
-  dataAccessEmails?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dataAccessEmails_MATCHES?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dataAnalystEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystName?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dataAnalystName_MATCHES?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
-  genePanel_CONTAINS?: InputMaybe<Scalars["String"]>;
-  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel_IN?: InputMaybe<Array<Scalars["String"]>>;
-  genePanel_MATCHES?: InputMaybe<Scalars["String"]>;
-  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  bicAnalysis?: InputMaybe<Scalars["Boolean"]["input"]>;
+  dataAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dataAccessEmails_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dataAnalystEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dataAnalystName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  genePanel_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasMetadataRequestMetadataAggregate?: InputMaybe<RequestHasMetadataRequestMetadataAggregateInput>;
   /** Return Requests where all of the related RequestHasMetadataRequestMetadataConnections match this filter */
   hasMetadataRequestMetadataConnection_ALL?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
@@ -6157,87 +6372,89 @@ export type RequestWhere = {
   hasSampleSamples_SINGLE?: InputMaybe<SampleWhere>;
   /** Return Requests where some of the related Samples match this filter */
   hasSampleSamples_SOME?: InputMaybe<SampleWhere>;
-  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_IN?: InputMaybe<Array<InputMaybe<Scalars["BigInt"]>>>;
-  igoDeliveryDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  ilabRequestId?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  ilabRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorEmail?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  investigatorEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorName?: InputMaybe<Scalars["String"]>;
-  investigatorName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  investigatorName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  investigatorName_MATCHES?: InputMaybe<Scalars["String"]>;
-  investigatorName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  isCmoRequest?: InputMaybe<Scalars["Boolean"]>;
-  labHeadEmail?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  labHeadEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  labHeadName?: InputMaybe<Scalars["String"]>;
-  labHeadName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  labHeadName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  labHeadName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  labHeadName_MATCHES?: InputMaybe<Scalars["String"]>;
-  labHeadName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  libraryType?: InputMaybe<Scalars["String"]>;
-  libraryType_CONTAINS?: InputMaybe<Scalars["String"]>;
-  libraryType_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  libraryType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  libraryType_MATCHES?: InputMaybe<Scalars["String"]>;
-  libraryType_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  otherContactEmails?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_CONTAINS?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_IN?: InputMaybe<Array<Scalars["String"]>>;
-  otherContactEmails_MATCHES?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  piEmail?: InputMaybe<Scalars["String"]>;
-  piEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  piEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  piEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  piEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  piEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pooledNormals_INCLUDES?: InputMaybe<Scalars["String"]>;
-  projectManagerName?: InputMaybe<Scalars["String"]>;
-  projectManagerName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  projectManagerName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectManagerName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  projectManagerName_MATCHES?: InputMaybe<Scalars["String"]>;
-  projectManagerName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["BigInt"]["input"]>>
+  >;
+  igoDeliveryDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  ilabRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  investigatorEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  investigatorName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  isCmoRequest?: InputMaybe<Scalars["Boolean"]["input"]>;
+  labHeadEmail?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  labHeadEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  labHeadName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  libraryType_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  otherContactEmails_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  piEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pooledNormals_INCLUDES?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  projectManagerName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   projectsHasRequestAggregate?: InputMaybe<RequestProjectsHasRequestAggregateInput>;
   /** Return Requests where all of the related RequestProjectsHasRequestConnections match this filter */
   projectsHasRequestConnection_ALL?: InputMaybe<RequestProjectsHasRequestConnectionWhere>;
@@ -6255,37 +6472,37 @@ export type RequestWhere = {
   projectsHasRequest_SINGLE?: InputMaybe<ProjectWhere>;
   /** Return Requests where some of the related Projects match this filter */
   projectsHasRequest_SOME?: InputMaybe<ProjectWhere>;
-  qcAccessEmails?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_IN?: InputMaybe<Array<Scalars["String"]>>;
-  qcAccessEmails_MATCHES?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  requestJson?: InputMaybe<Scalars["String"]>;
-  requestJson_CONTAINS?: InputMaybe<Scalars["String"]>;
-  requestJson_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  requestJson_IN?: InputMaybe<Array<Scalars["String"]>>;
-  requestJson_MATCHES?: InputMaybe<Scalars["String"]>;
-  requestJson_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  smileRequestId?: InputMaybe<Scalars["String"]>;
-  smileRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileRequestId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  strand?: InputMaybe<Scalars["String"]>;
-  strand_CONTAINS?: InputMaybe<Scalars["String"]>;
-  strand_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  strand_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  strand_MATCHES?: InputMaybe<Scalars["String"]>;
-  strand_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  qcAccessEmails_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  requestJson_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  strand?: InputMaybe<Scalars["String"]["input"]>;
+  strand_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  strand_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  strand_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  strand_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  strand_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RequestsConnection = {
   __typename?: "RequestsConnection";
   edges: Array<RequestEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Sample = {
@@ -6293,7 +6510,7 @@ export type Sample = {
   cohortsHasCohortSample: Array<Cohort>;
   cohortsHasCohortSampleAggregate?: Maybe<SampleCohortCohortsHasCohortSampleAggregationSelection>;
   cohortsHasCohortSampleConnection: SampleCohortsHasCohortSampleConnection;
-  datasource: Scalars["String"];
+  datasource: Scalars["String"]["output"];
   hasDbgapDbGaps: Array<DbGap>;
   hasDbgapDbGapsAggregate?: Maybe<SampleDbGapHasDbgapDbGapsAggregationSelection>;
   hasDbgapDbGapsConnection: SampleHasDbgapDbGapsConnection;
@@ -6309,151 +6526,151 @@ export type Sample = {
   requestsHasSample: Array<Request>;
   requestsHasSampleAggregate?: Maybe<SampleRequestRequestsHasSampleAggregationSelection>;
   requestsHasSampleConnection: SampleRequestsHasSampleConnection;
-  revisable?: Maybe<Scalars["Boolean"]>;
+  revisable?: Maybe<Scalars["Boolean"]["output"]>;
   sampleAliasesIsAlias: Array<SampleAlias>;
   sampleAliasesIsAliasAggregate?: Maybe<SampleSampleAliasSampleAliasesIsAliasAggregationSelection>;
   sampleAliasesIsAliasConnection: SampleSampleAliasesIsAliasConnection;
-  sampleCategory: Scalars["String"];
-  sampleClass?: Maybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
+  sampleCategory: Scalars["String"]["output"];
+  sampleClass?: Maybe<Scalars["String"]["output"]>;
+  smileSampleId: Scalars["String"]["output"];
 };
 
 export type SampleCohortsHasCohortSampleArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<CohortOptions>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type SampleCohortsHasCohortSampleAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type SampleCohortsHasCohortSampleConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleCohortsHasCohortSampleConnectionSort>>;
   where?: InputMaybe<SampleCohortsHasCohortSampleConnectionWhere>;
 };
 
 export type SampleHasDbgapDbGapsArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<DbGapOptions>;
   where?: InputMaybe<DbGapWhere>;
 };
 
 export type SampleHasDbgapDbGapsAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<DbGapWhere>;
 };
 
 export type SampleHasDbgapDbGapsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleHasDbgapDbGapsConnectionSort>>;
   where?: InputMaybe<SampleHasDbgapDbGapsConnectionWhere>;
 };
 
 export type SampleHasMetadataSampleMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleMetadataOptions>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type SampleHasMetadataSampleMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type SampleHasMetadataSampleMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleHasMetadataSampleMetadataConnectionSort>>;
   where?: InputMaybe<SampleHasMetadataSampleMetadataConnectionWhere>;
 };
 
 export type SampleHasTempoTemposArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type SampleHasTempoTemposAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type SampleHasTempoTemposConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleHasTempoTemposConnectionSort>>;
   where?: InputMaybe<SampleHasTempoTemposConnectionWhere>;
 };
 
 export type SamplePatientsHasSampleArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<PatientOptions>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type SamplePatientsHasSampleAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type SamplePatientsHasSampleConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SamplePatientsHasSampleConnectionSort>>;
   where?: InputMaybe<SamplePatientsHasSampleConnectionWhere>;
 };
 
 export type SampleRequestsHasSampleArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type SampleRequestsHasSampleAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type SampleRequestsHasSampleConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleRequestsHasSampleConnectionSort>>;
   where?: InputMaybe<SampleRequestsHasSampleConnectionWhere>;
 };
 
 export type SampleSampleAliasesIsAliasArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleAliasOptions>;
   where?: InputMaybe<SampleAliasWhere>;
 };
 
 export type SampleSampleAliasesIsAliasAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleAliasWhere>;
 };
 
 export type SampleSampleAliasesIsAliasConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleSampleAliasesIsAliasConnectionSort>>;
   where?: InputMaybe<SampleSampleAliasesIsAliasConnectionWhere>;
 };
 
 export type SampleAggregateSelection = {
   __typename?: "SampleAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   datasource: StringAggregateSelection;
   sampleCategory: StringAggregateSelection;
   sampleClass: StringAggregateSelection;
@@ -6465,32 +6682,32 @@ export type SampleAlias = {
   isAliasSamples: Array<Sample>;
   isAliasSamplesAggregate?: Maybe<SampleAliasSampleIsAliasSamplesAggregationSelection>;
   isAliasSamplesConnection: SampleAliasIsAliasSamplesConnection;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["output"];
+  value: Scalars["String"]["output"];
 };
 
 export type SampleAliasIsAliasSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleAliasIsAliasSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleAliasIsAliasSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleAliasIsAliasSamplesConnectionSort>>;
   where?: InputMaybe<SampleAliasIsAliasSamplesConnectionWhere>;
 };
 
 export type SampleAliasAggregateSelection = {
   __typename?: "SampleAliasAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   namespace: StringAggregateSelection;
   value: StringAggregateSelection;
 };
@@ -6507,8 +6724,8 @@ export type SampleAliasConnectWhere = {
 
 export type SampleAliasCreateInput = {
   isAliasSamples?: InputMaybe<SampleAliasIsAliasSamplesFieldInput>;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["input"];
+  value: Scalars["String"]["input"];
 };
 
 export type SampleAliasDeleteInput = {
@@ -6523,7 +6740,7 @@ export type SampleAliasDisconnectInput = {
 
 export type SampleAliasEdge = {
   __typename?: "SampleAliasEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleAlias;
 };
 
@@ -6531,18 +6748,18 @@ export type SampleAliasIsAliasSamplesAggregateInput = {
   AND?: InputMaybe<Array<SampleAliasIsAliasSamplesAggregateInput>>;
   NOT?: InputMaybe<SampleAliasIsAliasSamplesAggregateInput>;
   OR?: InputMaybe<Array<SampleAliasIsAliasSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleAliasIsAliasSamplesNodeAggregationWhereInput>;
 };
 
 export type SampleAliasIsAliasSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -6550,7 +6767,7 @@ export type SampleAliasIsAliasSamplesConnection = {
   __typename?: "SampleAliasIsAliasSamplesConnection";
   edges: Array<SampleAliasIsAliasSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleAliasIsAliasSamplesConnectionSort = {
@@ -6587,71 +6804,71 @@ export type SampleAliasIsAliasSamplesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleAliasIsAliasSamplesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleAliasIsAliasSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleAliasIsAliasSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleAliasIsAliasSamplesRelationship = {
   __typename?: "SampleAliasIsAliasSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -6669,8 +6886,8 @@ export type SampleAliasIsAliasSamplesUpdateFieldInput = {
 };
 
 export type SampleAliasOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more SampleAliasSort objects to sort SampleAliases by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<SampleAliasSort>>;
 };
@@ -6681,7 +6898,7 @@ export type SampleAliasRelationInput = {
 
 export type SampleAliasSampleIsAliasSamplesAggregationSelection = {
   __typename?: "SampleAliasSampleIsAliasSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleAliasSampleIsAliasSamplesNodeAggregateSelection>;
 };
 
@@ -6701,8 +6918,8 @@ export type SampleAliasSort = {
 
 export type SampleAliasUpdateInput = {
   isAliasSamples?: InputMaybe<Array<SampleAliasIsAliasSamplesUpdateFieldInput>>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleAliasWhere = {
@@ -6726,54 +6943,55 @@ export type SampleAliasWhere = {
   isAliasSamples_SINGLE?: InputMaybe<SampleWhere>;
   /** Return SampleAliases where some of the related Samples match this filter */
   isAliasSamples_SOME?: InputMaybe<SampleWhere>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
-  value_CONTAINS?: InputMaybe<Scalars["String"]>;
-  value_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  value_IN?: InputMaybe<Array<Scalars["String"]>>;
-  value_MATCHES?: InputMaybe<Scalars["String"]>;
-  value_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
+  value_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  value_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  value_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  value_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleAliasesConnection = {
   __typename?: "SampleAliasesConnection";
   edges: Array<SampleAliasEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleCohortCohortsHasCohortSampleAggregationSelection = {
   __typename?: "SampleCohortCohortsHasCohortSampleAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleCohortCohortsHasCohortSampleNodeAggregateSelection>;
 };
 
 export type SampleCohortCohortsHasCohortSampleNodeAggregateSelection = {
   __typename?: "SampleCohortCohortsHasCohortSampleNodeAggregateSelection";
   cohortId: StringAggregateSelection;
+  cohortStatus: StringAggregateSelection;
 };
 
 export type SampleCohortsHasCohortSampleAggregateInput = {
   AND?: InputMaybe<Array<SampleCohortsHasCohortSampleAggregateInput>>;
   NOT?: InputMaybe<SampleCohortsHasCohortSampleAggregateInput>;
   OR?: InputMaybe<Array<SampleCohortsHasCohortSampleAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleCohortsHasCohortSampleNodeAggregationWhereInput>;
 };
 
 export type SampleCohortsHasCohortSampleConnectFieldInput = {
   connect?: InputMaybe<Array<CohortConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<CohortConnectWhere>;
 };
 
@@ -6781,7 +6999,7 @@ export type SampleCohortsHasCohortSampleConnection = {
   __typename?: "SampleCohortsHasCohortSampleConnection";
   edges: Array<SampleCohortsHasCohortSampleRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleCohortsHasCohortSampleConnectionSort = {
@@ -6820,26 +7038,41 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
   >;
   NOT?: InputMaybe<SampleCohortsHasCohortSampleNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleCohortsHasCohortSampleNodeAggregationWhereInput>>;
-  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleCohortsHasCohortSampleRelationship = {
   __typename?: "SampleCohortsHasCohortSampleRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Cohort;
 };
 
@@ -6884,22 +7117,22 @@ export type SampleConnectWhere = {
 
 export type SampleCreateInput = {
   cohortsHasCohortSample?: InputMaybe<SampleCohortsHasCohortSampleFieldInput>;
-  datasource: Scalars["String"];
+  datasource: Scalars["String"]["input"];
   hasDbgapDbGaps?: InputMaybe<SampleHasDbgapDbGapsFieldInput>;
   hasMetadataSampleMetadata?: InputMaybe<SampleHasMetadataSampleMetadataFieldInput>;
   hasTempoTempos?: InputMaybe<SampleHasTempoTemposFieldInput>;
   patientsHasSample?: InputMaybe<SamplePatientsHasSampleFieldInput>;
   requestsHasSample?: InputMaybe<SampleRequestsHasSampleFieldInput>;
-  revisable?: InputMaybe<Scalars["Boolean"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
   sampleAliasesIsAlias?: InputMaybe<SampleSampleAliasesIsAliasFieldInput>;
-  sampleCategory: Scalars["String"];
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
+  sampleCategory: Scalars["String"]["input"];
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId: Scalars["String"]["input"];
 };
 
 export type SampleDbGapHasDbgapDbGapsAggregationSelection = {
   __typename?: "SampleDbGapHasDbgapDbGapsAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleDbGapHasDbgapDbGapsNodeAggregateSelection>;
 };
 
@@ -6951,7 +7184,7 @@ export type SampleDisconnectInput = {
 
 export type SampleEdge = {
   __typename?: "SampleEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -6959,18 +7192,18 @@ export type SampleHasDbgapDbGapsAggregateInput = {
   AND?: InputMaybe<Array<SampleHasDbgapDbGapsAggregateInput>>;
   NOT?: InputMaybe<SampleHasDbgapDbGapsAggregateInput>;
   OR?: InputMaybe<Array<SampleHasDbgapDbGapsAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleHasDbgapDbGapsNodeAggregationWhereInput>;
 };
 
 export type SampleHasDbgapDbGapsConnectFieldInput = {
   connect?: InputMaybe<Array<DbGapConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<DbGapConnectWhere>;
 };
 
@@ -6978,7 +7211,7 @@ export type SampleHasDbgapDbGapsConnection = {
   __typename?: "SampleHasDbgapDbGapsConnection";
   edges: Array<SampleHasDbgapDbGapsRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleHasDbgapDbGapsConnectionSort = {
@@ -7015,41 +7248,41 @@ export type SampleHasDbgapDbGapsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleHasDbgapDbGapsNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleHasDbgapDbGapsNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleHasDbgapDbGapsNodeAggregationWhereInput>>;
-  dbGapStudy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dbGapStudy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleHasDbgapDbGapsRelationship = {
   __typename?: "SampleHasDbgapDbGapsRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: DbGap;
 };
 
@@ -7070,18 +7303,18 @@ export type SampleHasMetadataSampleMetadataAggregateInput = {
   AND?: InputMaybe<Array<SampleHasMetadataSampleMetadataAggregateInput>>;
   NOT?: InputMaybe<SampleHasMetadataSampleMetadataAggregateInput>;
   OR?: InputMaybe<Array<SampleHasMetadataSampleMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleHasMetadataSampleMetadataNodeAggregationWhereInput>;
 };
 
 export type SampleHasMetadataSampleMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<SampleMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleMetadataConnectWhere>;
 };
 
@@ -7089,7 +7322,7 @@ export type SampleHasMetadataSampleMetadataConnection = {
   __typename?: "SampleHasMetadataSampleMetadataConnection";
   edges: Array<SampleHasMetadataSampleMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleHasMetadataSampleMetadataConnectionSort = {
@@ -7130,406 +7363,444 @@ export type SampleHasMetadataSampleMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<SampleHasMetadataSampleMetadataNodeAggregationWhereInput>
   >;
-  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleHasMetadataSampleMetadataRelationship = {
   __typename?: "SampleHasMetadataSampleMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleMetadata;
 };
 
@@ -7552,18 +7823,18 @@ export type SampleHasTempoTemposAggregateInput = {
   AND?: InputMaybe<Array<SampleHasTempoTemposAggregateInput>>;
   NOT?: InputMaybe<SampleHasTempoTemposAggregateInput>;
   OR?: InputMaybe<Array<SampleHasTempoTemposAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleHasTempoTemposNodeAggregationWhereInput>;
 };
 
 export type SampleHasTempoTemposConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -7571,7 +7842,7 @@ export type SampleHasTempoTemposConnection = {
   __typename?: "SampleHasTempoTemposConnection";
   edges: Array<SampleHasTempoTemposRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleHasTempoTemposConnectionSort = {
@@ -7608,116 +7879,164 @@ export type SampleHasTempoTemposNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleHasTempoTemposNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleHasTempoTemposNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleHasTempoTemposNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleHasTempoTemposRelationship = {
   __typename?: "SampleHasTempoTemposRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -7736,75 +8055,75 @@ export type SampleHasTempoTemposUpdateFieldInput = {
 
 export type SampleMetadata = {
   __typename?: "SampleMetadata";
-  additionalProperties: Scalars["String"];
-  baitSet?: Maybe<Scalars["String"]>;
-  cfDNA2dBarcode?: Maybe<Scalars["String"]>;
-  cmoInfoIgoId?: Maybe<Scalars["String"]>;
-  cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleIdFields: Scalars["String"];
-  cmoSampleName?: Maybe<Scalars["String"]>;
-  collectionYear?: Maybe<Scalars["String"]>;
-  genePanel: Scalars["String"];
+  additionalProperties: Scalars["String"]["output"];
+  baitSet?: Maybe<Scalars["String"]["output"]>;
+  cfDNA2dBarcode?: Maybe<Scalars["String"]["output"]>;
+  cmoInfoIgoId?: Maybe<Scalars["String"]["output"]>;
+  cmoPatientId?: Maybe<Scalars["String"]["output"]>;
+  cmoSampleIdFields: Scalars["String"]["output"];
+  cmoSampleName?: Maybe<Scalars["String"]["output"]>;
+  collectionYear?: Maybe<Scalars["String"]["output"]>;
+  genePanel: Scalars["String"]["output"];
   hasStatusStatuses: Array<Status>;
   hasStatusStatusesAggregate?: Maybe<SampleMetadataStatusHasStatusStatusesAggregationSelection>;
   hasStatusStatusesConnection: SampleMetadataHasStatusStatusesConnection;
-  igoComplete?: Maybe<Scalars["Boolean"]>;
-  igoRequestId?: Maybe<Scalars["String"]>;
-  importDate: Scalars["BigInt"];
-  investigatorSampleId?: Maybe<Scalars["String"]>;
-  libraries: Scalars["String"];
-  oncotreeCode?: Maybe<Scalars["String"]>;
-  preservation?: Maybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
-  qcReports: Scalars["String"];
-  sampleClass?: Maybe<Scalars["String"]>;
-  sampleName?: Maybe<Scalars["String"]>;
-  sampleOrigin?: Maybe<Scalars["String"]>;
-  sampleType?: Maybe<Scalars["String"]>;
+  igoComplete?: Maybe<Scalars["Boolean"]["output"]>;
+  igoRequestId?: Maybe<Scalars["String"]["output"]>;
+  importDate: Scalars["BigInt"]["output"];
+  investigatorSampleId?: Maybe<Scalars["String"]["output"]>;
+  libraries: Scalars["String"]["output"];
+  oncotreeCode?: Maybe<Scalars["String"]["output"]>;
+  preservation?: Maybe<Scalars["String"]["output"]>;
+  primaryId: Scalars["String"]["output"];
+  qcReports: Scalars["String"]["output"];
+  sampleClass?: Maybe<Scalars["String"]["output"]>;
+  sampleName?: Maybe<Scalars["String"]["output"]>;
+  sampleOrigin?: Maybe<Scalars["String"]["output"]>;
+  sampleType?: Maybe<Scalars["String"]["output"]>;
   samplesHasMetadata: Array<Sample>;
   samplesHasMetadataAggregate?: Maybe<SampleMetadataSampleSamplesHasMetadataAggregationSelection>;
   samplesHasMetadataConnection: SampleMetadataSamplesHasMetadataConnection;
-  sex?: Maybe<Scalars["String"]>;
-  species?: Maybe<Scalars["String"]>;
-  tissueLocation?: Maybe<Scalars["String"]>;
-  tubeId?: Maybe<Scalars["String"]>;
-  tumorOrNormal?: Maybe<Scalars["String"]>;
+  sex?: Maybe<Scalars["String"]["output"]>;
+  species?: Maybe<Scalars["String"]["output"]>;
+  tissueLocation?: Maybe<Scalars["String"]["output"]>;
+  tubeId?: Maybe<Scalars["String"]["output"]>;
+  tumorOrNormal?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type SampleMetadataHasStatusStatusesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<StatusOptions>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type SampleMetadataHasStatusStatusesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type SampleMetadataHasStatusStatusesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleMetadataHasStatusStatusesConnectionSort>>;
   where?: InputMaybe<SampleMetadataHasStatusStatusesConnectionWhere>;
 };
 
 export type SampleMetadataSamplesHasMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleMetadataSamplesHasMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleMetadataSamplesHasMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleMetadataSamplesHasMetadataConnectionSort>>;
   where?: InputMaybe<SampleMetadataSamplesHasMetadataConnectionWhere>;
 };
@@ -7819,7 +8138,7 @@ export type SampleMetadataAggregateSelection = {
   cmoSampleIdFields: StringAggregateSelection;
   cmoSampleName: StringAggregateSelection;
   collectionYear: StringAggregateSelection;
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   genePanel: StringAggregateSelection;
   igoRequestId: StringAggregateSelection;
   importDate: BigIntAggregateSelection;
@@ -7857,39 +8176,39 @@ export type SampleMetadataConnection = {
   __typename?: "SampleMetadataConnection";
   edges: Array<SampleMetadataEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleMetadataCreateInput = {
-  additionalProperties: Scalars["String"];
-  baitSet?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields: Scalars["String"];
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  genePanel: Scalars["String"];
+  additionalProperties: Scalars["String"]["input"];
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields: Scalars["String"]["input"];
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel: Scalars["String"]["input"];
   hasStatusStatuses?: InputMaybe<SampleMetadataHasStatusStatusesFieldInput>;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  importDate: Scalars["BigInt"];
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  libraries: Scalars["String"];
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
-  qcReports: Scalars["String"];
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleName?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  importDate: Scalars["BigInt"]["input"];
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  libraries: Scalars["String"]["input"];
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId: Scalars["String"]["input"];
+  qcReports: Scalars["String"]["input"];
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasMetadata?: InputMaybe<SampleMetadataSamplesHasMetadataFieldInput>;
-  sex?: InputMaybe<Scalars["String"]>;
-  species?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tubeId?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleMetadataDeleteInput = {
@@ -7912,7 +8231,7 @@ export type SampleMetadataDisconnectInput = {
 
 export type SampleMetadataEdge = {
   __typename?: "SampleMetadataEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleMetadata;
 };
 
@@ -7920,18 +8239,18 @@ export type SampleMetadataHasStatusStatusesAggregateInput = {
   AND?: InputMaybe<Array<SampleMetadataHasStatusStatusesAggregateInput>>;
   NOT?: InputMaybe<SampleMetadataHasStatusStatusesAggregateInput>;
   OR?: InputMaybe<Array<SampleMetadataHasStatusStatusesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleMetadataHasStatusStatusesNodeAggregationWhereInput>;
 };
 
 export type SampleMetadataHasStatusStatusesConnectFieldInput = {
   connect?: InputMaybe<Array<StatusConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<StatusConnectWhere>;
 };
 
@@ -7939,7 +8258,7 @@ export type SampleMetadataHasStatusStatusesConnection = {
   __typename?: "SampleMetadataHasStatusStatusesConnection";
   edges: Array<SampleMetadataHasStatusStatusesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleMetadataHasStatusStatusesConnectionSort = {
@@ -7980,26 +8299,26 @@ export type SampleMetadataHasStatusStatusesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<SampleMetadataHasStatusStatusesNodeAggregationWhereInput>
   >;
-  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleMetadataHasStatusStatusesRelationship = {
   __typename?: "SampleMetadataHasStatusStatusesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Status;
 };
 
@@ -8019,8 +8338,8 @@ export type SampleMetadataHasStatusStatusesUpdateFieldInput = {
 };
 
 export type SampleMetadataOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more SampleMetadataSort objects to sort SampleMetadata by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<SampleMetadataSort>>;
 };
@@ -8036,7 +8355,7 @@ export type SampleMetadataRelationInput = {
 
 export type SampleMetadataSampleSamplesHasMetadataAggregationSelection = {
   __typename?: "SampleMetadataSampleSamplesHasMetadataAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleMetadataSampleSamplesHasMetadataNodeAggregateSelection>;
 };
 
@@ -8052,18 +8371,18 @@ export type SampleMetadataSamplesHasMetadataAggregateInput = {
   AND?: InputMaybe<Array<SampleMetadataSamplesHasMetadataAggregateInput>>;
   NOT?: InputMaybe<SampleMetadataSamplesHasMetadataAggregateInput>;
   OR?: InputMaybe<Array<SampleMetadataSamplesHasMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleMetadataSamplesHasMetadataNodeAggregationWhereInput>;
 };
 
 export type SampleMetadataSamplesHasMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -8071,7 +8390,7 @@ export type SampleMetadataSamplesHasMetadataConnection = {
   __typename?: "SampleMetadataSamplesHasMetadataConnection";
   edges: Array<SampleMetadataSamplesHasMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleMetadataSamplesHasMetadataConnectionSort = {
@@ -8114,71 +8433,71 @@ export type SampleMetadataSamplesHasMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<SampleMetadataSamplesHasMetadataNodeAggregationWhereInput>
   >;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleMetadataSamplesHasMetadataRelationship = {
   __typename?: "SampleMetadataSamplesHasMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -8232,7 +8551,7 @@ export type SampleMetadataSort = {
 
 export type SampleMetadataStatusHasStatusStatusesAggregationSelection = {
   __typename?: "SampleMetadataStatusHasStatusStatusesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleMetadataStatusHasStatusStatusesNodeAggregateSelection>;
 };
 
@@ -8242,101 +8561,101 @@ export type SampleMetadataStatusHasStatusStatusesNodeAggregateSelection = {
 };
 
 export type SampleMetadataUpdateInput = {
-  additionalProperties?: InputMaybe<Scalars["String"]>;
-  baitSet?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields?: InputMaybe<Scalars["String"]>;
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
+  additionalProperties?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
   hasStatusStatuses?: InputMaybe<
     Array<SampleMetadataHasStatusStatusesUpdateFieldInput>
   >;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  libraries?: InputMaybe<Scalars["String"]>;
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
-  qcReports?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleName?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  libraries?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasMetadata?: InputMaybe<
     Array<SampleMetadataSamplesHasMetadataUpdateFieldInput>
   >;
-  sex?: InputMaybe<Scalars["String"]>;
-  species?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tubeId?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleMetadataWhere = {
   AND?: InputMaybe<Array<SampleMetadataWhere>>;
   NOT?: InputMaybe<SampleMetadataWhere>;
   OR?: InputMaybe<Array<SampleMetadataWhere>>;
-  additionalProperties?: InputMaybe<Scalars["String"]>;
-  additionalProperties_CONTAINS?: InputMaybe<Scalars["String"]>;
-  additionalProperties_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  additionalProperties_IN?: InputMaybe<Array<Scalars["String"]>>;
-  additionalProperties_MATCHES?: InputMaybe<Scalars["String"]>;
-  additionalProperties_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  baitSet?: InputMaybe<Scalars["String"]>;
-  baitSet_CONTAINS?: InputMaybe<Scalars["String"]>;
-  baitSet_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  baitSet_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  baitSet_MATCHES?: InputMaybe<Scalars["String"]>;
-  baitSet_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cfDNA2dBarcode_MATCHES?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoInfoIgoId_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoPatientId_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_IN?: InputMaybe<Array<Scalars["String"]>>;
-  cmoSampleIdFields_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoSampleName_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  collectionYear_CONTAINS?: InputMaybe<Scalars["String"]>;
-  collectionYear_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  collectionYear_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  collectionYear_MATCHES?: InputMaybe<Scalars["String"]>;
-  collectionYear_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
-  genePanel_CONTAINS?: InputMaybe<Scalars["String"]>;
-  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel_IN?: InputMaybe<Array<Scalars["String"]>>;
-  genePanel_MATCHES?: InputMaybe<Scalars["String"]>;
-  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  additionalProperties?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  additionalProperties_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  baitSet_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cfDNA2dBarcode_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cmoInfoIgoId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cmoPatientId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  cmoSampleIdFields_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cmoSampleName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  collectionYear_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  genePanel_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasStatusStatusesAggregate?: InputMaybe<SampleMetadataHasStatusStatusesAggregateInput>;
   /** Return SampleMetadata where all of the related SampleMetadataHasStatusStatusesConnections match this filter */
   hasStatusStatusesConnection_ALL?: InputMaybe<SampleMetadataHasStatusStatusesConnectionWhere>;
@@ -8354,79 +8673,81 @@ export type SampleMetadataWhere = {
   hasStatusStatuses_SINGLE?: InputMaybe<StatusWhere>;
   /** Return SampleMetadata where some of the related Statuses match this filter */
   hasStatusStatuses_SOME?: InputMaybe<StatusWhere>;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]>>;
-  importDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  investigatorSampleId_MATCHES?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  libraries?: InputMaybe<Scalars["String"]>;
-  libraries_CONTAINS?: InputMaybe<Scalars["String"]>;
-  libraries_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  libraries_IN?: InputMaybe<Array<Scalars["String"]>>;
-  libraries_MATCHES?: InputMaybe<Scalars["String"]>;
-  libraries_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_CONTAINS?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  oncotreeCode_MATCHES?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  preservation_CONTAINS?: InputMaybe<Scalars["String"]>;
-  preservation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  preservation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  preservation_MATCHES?: InputMaybe<Scalars["String"]>;
-  preservation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
-  primaryId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  primaryId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  primaryId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  primaryId_MATCHES?: InputMaybe<Scalars["String"]>;
-  primaryId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  qcReports?: InputMaybe<Scalars["String"]>;
-  qcReports_CONTAINS?: InputMaybe<Scalars["String"]>;
-  qcReports_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  qcReports_IN?: InputMaybe<Array<Scalars["String"]>>;
-  qcReports_MATCHES?: InputMaybe<Scalars["String"]>;
-  qcReports_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleClass_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleName?: InputMaybe<Scalars["String"]>;
-  sampleName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleName_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleOrigin_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
-  sampleType_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleType_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleType_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleType_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  importDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  investigatorSampleId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraries?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  libraries_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  oncotreeCode_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  preservation_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  primaryId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  qcReports_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleClass_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleOrigin_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleType_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasMetadataAggregate?: InputMaybe<SampleMetadataSamplesHasMetadataAggregateInput>;
   /** Return SampleMetadata where all of the related SampleMetadataSamplesHasMetadataConnections match this filter */
   samplesHasMetadataConnection_ALL?: InputMaybe<SampleMetadataSamplesHasMetadataConnectionWhere>;
@@ -8444,48 +8765,48 @@ export type SampleMetadataWhere = {
   samplesHasMetadata_SINGLE?: InputMaybe<SampleWhere>;
   /** Return SampleMetadata where some of the related Samples match this filter */
   samplesHasMetadata_SOME?: InputMaybe<SampleWhere>;
-  sex?: InputMaybe<Scalars["String"]>;
-  sex_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sex_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sex_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sex_MATCHES?: InputMaybe<Scalars["String"]>;
-  sex_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  species?: InputMaybe<Scalars["String"]>;
-  species_CONTAINS?: InputMaybe<Scalars["String"]>;
-  species_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  species_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  species_MATCHES?: InputMaybe<Scalars["String"]>;
-  species_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tissueLocation_CONTAINS?: InputMaybe<Scalars["String"]>;
-  tissueLocation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  tissueLocation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  tissueLocation_MATCHES?: InputMaybe<Scalars["String"]>;
-  tissueLocation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  tubeId?: InputMaybe<Scalars["String"]>;
-  tubeId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  tubeId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  tubeId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  tubeId_MATCHES?: InputMaybe<Scalars["String"]>;
-  tubeId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_CONTAINS?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  tumorOrNormal_MATCHES?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  sex_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sex_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sex_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sex_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sex_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  species_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  species_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  species_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  species_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  species_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  tissueLocation_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  tubeId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  tumorOrNormal_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more SampleSort objects to sort Samples by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<SampleSort>>;
 };
 
 export type SamplePatientPatientsHasSampleAggregationSelection = {
   __typename?: "SamplePatientPatientsHasSampleAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SamplePatientPatientsHasSampleNodeAggregateSelection>;
 };
 
@@ -8498,18 +8819,18 @@ export type SamplePatientsHasSampleAggregateInput = {
   AND?: InputMaybe<Array<SamplePatientsHasSampleAggregateInput>>;
   NOT?: InputMaybe<SamplePatientsHasSampleAggregateInput>;
   OR?: InputMaybe<Array<SamplePatientsHasSampleAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SamplePatientsHasSampleNodeAggregationWhereInput>;
 };
 
 export type SamplePatientsHasSampleConnectFieldInput = {
   connect?: InputMaybe<Array<PatientConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<PatientConnectWhere>;
 };
 
@@ -8517,7 +8838,7 @@ export type SamplePatientsHasSampleConnection = {
   __typename?: "SamplePatientsHasSampleConnection";
   edges: Array<SamplePatientsHasSampleRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SamplePatientsHasSampleConnectionSort = {
@@ -8554,26 +8875,26 @@ export type SamplePatientsHasSampleNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SamplePatientsHasSampleNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SamplePatientsHasSampleNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SamplePatientsHasSampleNodeAggregationWhereInput>>;
-  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SamplePatientsHasSampleRelationship = {
   __typename?: "SamplePatientsHasSampleRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Patient;
 };
 
@@ -8612,7 +8933,7 @@ export type SampleRelationInput = {
 
 export type SampleRequestRequestsHasSampleAggregationSelection = {
   __typename?: "SampleRequestRequestsHasSampleAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleRequestRequestsHasSampleNodeAggregateSelection>;
 };
 
@@ -8645,18 +8966,18 @@ export type SampleRequestsHasSampleAggregateInput = {
   AND?: InputMaybe<Array<SampleRequestsHasSampleAggregateInput>>;
   NOT?: InputMaybe<SampleRequestsHasSampleAggregateInput>;
   OR?: InputMaybe<Array<SampleRequestsHasSampleAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleRequestsHasSampleNodeAggregationWhereInput>;
 };
 
 export type SampleRequestsHasSampleConnectFieldInput = {
   connect?: InputMaybe<Array<RequestConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestConnectWhere>;
 };
 
@@ -8664,7 +8985,7 @@ export type SampleRequestsHasSampleConnection = {
   __typename?: "SampleRequestsHasSampleConnection";
   edges: Array<SampleRequestsHasSampleRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleRequestsHasSampleConnectionSort = {
@@ -8701,331 +9022,341 @@ export type SampleRequestsHasSampleNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleRequestsHasSampleNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleRequestsHasSampleNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleRequestsHasSampleNodeAggregationWhereInput>>;
-  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleRequestsHasSampleRelationship = {
   __typename?: "SampleRequestsHasSampleRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -9044,7 +9375,7 @@ export type SampleRequestsHasSampleUpdateFieldInput = {
 
 export type SampleSampleAliasSampleAliasesIsAliasAggregationSelection = {
   __typename?: "SampleSampleAliasSampleAliasesIsAliasAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleSampleAliasSampleAliasesIsAliasNodeAggregateSelection>;
 };
 
@@ -9058,18 +9389,18 @@ export type SampleSampleAliasesIsAliasAggregateInput = {
   AND?: InputMaybe<Array<SampleSampleAliasesIsAliasAggregateInput>>;
   NOT?: InputMaybe<SampleSampleAliasesIsAliasAggregateInput>;
   OR?: InputMaybe<Array<SampleSampleAliasesIsAliasAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleSampleAliasesIsAliasNodeAggregationWhereInput>;
 };
 
 export type SampleSampleAliasesIsAliasConnectFieldInput = {
   connect?: InputMaybe<Array<SampleAliasConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleAliasConnectWhere>;
 };
 
@@ -9077,7 +9408,7 @@ export type SampleSampleAliasesIsAliasConnection = {
   __typename?: "SampleSampleAliasesIsAliasConnection";
   edges: Array<SampleSampleAliasesIsAliasRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleSampleAliasesIsAliasConnectionSort = {
@@ -9114,41 +9445,41 @@ export type SampleSampleAliasesIsAliasNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleSampleAliasesIsAliasNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleSampleAliasesIsAliasNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleSampleAliasesIsAliasNodeAggregationWhereInput>>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleSampleAliasesIsAliasRelationship = {
   __typename?: "SampleSampleAliasesIsAliasRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleAlias;
 };
 
@@ -9170,7 +9501,7 @@ export type SampleSampleAliasesIsAliasUpdateFieldInput = {
 export type SampleSampleMetadataHasMetadataSampleMetadataAggregationSelection =
   {
     __typename?: "SampleSampleMetadataHasMetadataSampleMetadataAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<SampleSampleMetadataHasMetadataSampleMetadataNodeAggregateSelection>;
   };
 
@@ -9216,7 +9547,7 @@ export type SampleSort = {
 
 export type SampleTempoHasTempoTemposAggregationSelection = {
   __typename?: "SampleTempoHasTempoTemposAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleTempoHasTempoTemposNodeAggregateSelection>;
 };
 
@@ -9235,7 +9566,7 @@ export type SampleUpdateInput = {
   cohortsHasCohortSample?: InputMaybe<
     Array<SampleCohortsHasCohortSampleUpdateFieldInput>
   >;
-  datasource?: InputMaybe<Scalars["String"]>;
+  datasource?: InputMaybe<Scalars["String"]["input"]>;
   hasDbgapDbGaps?: InputMaybe<Array<SampleHasDbgapDbGapsUpdateFieldInput>>;
   hasMetadataSampleMetadata?: InputMaybe<
     Array<SampleHasMetadataSampleMetadataUpdateFieldInput>
@@ -9247,13 +9578,13 @@ export type SampleUpdateInput = {
   requestsHasSample?: InputMaybe<
     Array<SampleRequestsHasSampleUpdateFieldInput>
   >;
-  revisable?: InputMaybe<Scalars["Boolean"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
   sampleAliasesIsAlias?: InputMaybe<
     Array<SampleSampleAliasesIsAliasUpdateFieldInput>
   >;
-  sampleCategory?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  smileSampleId?: InputMaybe<Scalars["String"]>;
+  sampleCategory?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleWhere = {
@@ -9277,12 +9608,12 @@ export type SampleWhere = {
   cohortsHasCohortSample_SINGLE?: InputMaybe<CohortWhere>;
   /** Return Samples where some of the related Cohorts match this filter */
   cohortsHasCohortSample_SOME?: InputMaybe<CohortWhere>;
-  datasource?: InputMaybe<Scalars["String"]>;
-  datasource_CONTAINS?: InputMaybe<Scalars["String"]>;
-  datasource_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  datasource_IN?: InputMaybe<Array<Scalars["String"]>>;
-  datasource_MATCHES?: InputMaybe<Scalars["String"]>;
-  datasource_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  datasource?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  datasource_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasDbgapDbGapsAggregate?: InputMaybe<SampleHasDbgapDbGapsAggregateInput>;
   /** Return Samples where all of the related SampleHasDbgapDbGapsConnections match this filter */
   hasDbgapDbGapsConnection_ALL?: InputMaybe<SampleHasDbgapDbGapsConnectionWhere>;
@@ -9368,7 +9699,7 @@ export type SampleWhere = {
   requestsHasSample_SINGLE?: InputMaybe<RequestWhere>;
   /** Return Samples where some of the related Requests match this filter */
   requestsHasSample_SOME?: InputMaybe<RequestWhere>;
-  revisable?: InputMaybe<Scalars["Boolean"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
   sampleAliasesIsAliasAggregate?: InputMaybe<SampleSampleAliasesIsAliasAggregateInput>;
   /** Return Samples where all of the related SampleSampleAliasesIsAliasConnections match this filter */
   sampleAliasesIsAliasConnection_ALL?: InputMaybe<SampleSampleAliasesIsAliasConnectionWhere>;
@@ -9386,38 +9717,38 @@ export type SampleWhere = {
   sampleAliasesIsAlias_SINGLE?: InputMaybe<SampleAliasWhere>;
   /** Return Samples where some of the related SampleAliases match this filter */
   sampleAliasesIsAlias_SOME?: InputMaybe<SampleAliasWhere>;
-  sampleCategory?: InputMaybe<Scalars["String"]>;
-  sampleCategory_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleCategory_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleCategory_IN?: InputMaybe<Array<Scalars["String"]>>;
-  sampleCategory_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleCategory_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleClass_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  smileSampleId?: InputMaybe<Scalars["String"]>;
-  smileSampleId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileSampleId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileSampleId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  sampleCategory?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  sampleCategory_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleClass_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileSampleId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SamplesConnection = {
   __typename?: "SamplesConnection";
   edges: Array<SampleEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SeqDateAccessionBySampleId = {
   __typename?: "SeqDateAccessionBySampleId";
-  DMP_SAMPLE_ID: Scalars["String"];
-  MOLECULAR_ACCESSION_NUMBER?: Maybe<Scalars["String"]>;
-  SEQUENCING_DATE: Scalars["String"];
+  DMP_SAMPLE_ID: Scalars["String"]["output"];
+  MOLECULAR_ACCESSION_NUMBER?: Maybe<Scalars["String"]["output"]>;
+  SEQUENCING_DATE: Scalars["String"]["output"];
 };
 
 /** An enum for sorting in either ascending or descending order. */
@@ -9436,51 +9767,51 @@ export type Status = {
   sampleMetadataHasStatus: Array<SampleMetadata>;
   sampleMetadataHasStatusAggregate?: Maybe<StatusSampleMetadataSampleMetadataHasStatusAggregationSelection>;
   sampleMetadataHasStatusConnection: StatusSampleMetadataHasStatusConnection;
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type StatusRequestMetadataHasStatusArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestMetadataOptions>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type StatusRequestMetadataHasStatusAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type StatusRequestMetadataHasStatusConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<StatusRequestMetadataHasStatusConnectionSort>>;
   where?: InputMaybe<StatusRequestMetadataHasStatusConnectionWhere>;
 };
 
 export type StatusSampleMetadataHasStatusArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleMetadataOptions>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type StatusSampleMetadataHasStatusAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type StatusSampleMetadataHasStatusConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<StatusSampleMetadataHasStatusConnectionSort>>;
   where?: InputMaybe<StatusSampleMetadataHasStatusConnectionWhere>;
 };
 
 export type StatusAggregateSelection = {
   __typename?: "StatusAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   validationReport: StringAggregateSelection;
 };
 
@@ -9500,8 +9831,8 @@ export type StatusConnectWhere = {
 export type StatusCreateInput = {
   requestMetadataHasStatus?: InputMaybe<StatusRequestMetadataHasStatusFieldInput>;
   sampleMetadataHasStatus?: InputMaybe<StatusSampleMetadataHasStatusFieldInput>;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type StatusDeleteInput = {
@@ -9524,13 +9855,13 @@ export type StatusDisconnectInput = {
 
 export type StatusEdge = {
   __typename?: "StatusEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Status;
 };
 
 export type StatusOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more StatusSort objects to sort Statuses by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<StatusSort>>;
 };
@@ -9548,18 +9879,18 @@ export type StatusRequestMetadataHasStatusAggregateInput = {
   AND?: InputMaybe<Array<StatusRequestMetadataHasStatusAggregateInput>>;
   NOT?: InputMaybe<StatusRequestMetadataHasStatusAggregateInput>;
   OR?: InputMaybe<Array<StatusRequestMetadataHasStatusAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<StatusRequestMetadataHasStatusNodeAggregationWhereInput>;
 };
 
 export type StatusRequestMetadataHasStatusConnectFieldInput = {
   connect?: InputMaybe<Array<RequestMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestMetadataConnectWhere>;
 };
 
@@ -9567,7 +9898,7 @@ export type StatusRequestMetadataHasStatusConnection = {
   __typename?: "StatusRequestMetadataHasStatusConnection";
   edges: Array<StatusRequestMetadataHasStatusRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type StatusRequestMetadataHasStatusConnectionSort = {
@@ -9608,61 +9939,71 @@ export type StatusRequestMetadataHasStatusNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<StatusRequestMetadataHasStatusNodeAggregationWhereInput>
   >;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type StatusRequestMetadataHasStatusRelationship = {
   __typename?: "StatusRequestMetadataHasStatusRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: RequestMetadata;
 };
 
@@ -9684,7 +10025,7 @@ export type StatusRequestMetadataHasStatusUpdateFieldInput = {
 export type StatusRequestMetadataRequestMetadataHasStatusAggregationSelection =
   {
     __typename?: "StatusRequestMetadataRequestMetadataHasStatusAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<StatusRequestMetadataRequestMetadataHasStatusNodeAggregateSelection>;
   };
 
@@ -9700,18 +10041,18 @@ export type StatusSampleMetadataHasStatusAggregateInput = {
   AND?: InputMaybe<Array<StatusSampleMetadataHasStatusAggregateInput>>;
   NOT?: InputMaybe<StatusSampleMetadataHasStatusAggregateInput>;
   OR?: InputMaybe<Array<StatusSampleMetadataHasStatusAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<StatusSampleMetadataHasStatusNodeAggregationWhereInput>;
 };
 
 export type StatusSampleMetadataHasStatusConnectFieldInput = {
   connect?: InputMaybe<Array<SampleMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleMetadataConnectWhere>;
 };
 
@@ -9719,7 +10060,7 @@ export type StatusSampleMetadataHasStatusConnection = {
   __typename?: "StatusSampleMetadataHasStatusConnection";
   edges: Array<StatusSampleMetadataHasStatusRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type StatusSampleMetadataHasStatusConnectionSort = {
@@ -9760,406 +10101,444 @@ export type StatusSampleMetadataHasStatusNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<StatusSampleMetadataHasStatusNodeAggregationWhereInput>
   >;
-  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type StatusSampleMetadataHasStatusRelationship = {
   __typename?: "StatusSampleMetadataHasStatusRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleMetadata;
 };
 
@@ -10180,7 +10559,7 @@ export type StatusSampleMetadataHasStatusUpdateFieldInput = {
 
 export type StatusSampleMetadataSampleMetadataHasStatusAggregationSelection = {
   __typename?: "StatusSampleMetadataSampleMetadataHasStatusAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<StatusSampleMetadataSampleMetadataHasStatusNodeAggregateSelection>;
 };
 
@@ -10228,8 +10607,8 @@ export type StatusUpdateInput = {
   sampleMetadataHasStatus?: InputMaybe<
     Array<StatusSampleMetadataHasStatusUpdateFieldInput>
   >;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type StatusWhere = {
@@ -10270,36 +10649,38 @@ export type StatusWhere = {
   sampleMetadataHasStatus_SINGLE?: InputMaybe<SampleMetadataWhere>;
   /** Return Statuses where some of the related SampleMetadata match this filter */
   sampleMetadataHasStatus_SOME?: InputMaybe<SampleMetadataWhere>;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationReport_CONTAINS?: InputMaybe<Scalars["String"]>;
-  validationReport_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  validationReport_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  validationReport_MATCHES?: InputMaybe<Scalars["String"]>;
-  validationReport_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  validationReport_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type StatusesConnection = {
   __typename?: "StatusesConnection";
   edges: Array<StatusEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type StringAggregateSelection = {
   __typename?: "StringAggregateSelection";
-  longest?: Maybe<Scalars["String"]>;
-  shortest?: Maybe<Scalars["String"]>;
+  longest?: Maybe<Scalars["String"]["output"]>;
+  shortest?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type Tempo = {
   __typename?: "Tempo";
-  accessLevel?: Maybe<Scalars["String"]>;
-  billed?: Maybe<Scalars["Boolean"]>;
-  billedBy?: Maybe<Scalars["String"]>;
-  costCenter?: Maybe<Scalars["String"]>;
-  custodianInformation?: Maybe<Scalars["String"]>;
-  embargoDate?: Maybe<Scalars["String"]>;
+  accessLevel?: Maybe<Scalars["String"]["output"]>;
+  billed?: Maybe<Scalars["Boolean"]["output"]>;
+  billedBy?: Maybe<Scalars["String"]["output"]>;
+  costCenter?: Maybe<Scalars["String"]["output"]>;
+  custodianInformation?: Maybe<Scalars["String"]["output"]>;
+  embargoDate?: Maybe<Scalars["String"]["output"]>;
   hasEventBamCompletes: Array<BamComplete>;
   hasEventBamCompletesAggregate?: Maybe<TempoBamCompleteHasEventBamCompletesAggregationSelection>;
   hasEventBamCompletesConnection: TempoHasEventBamCompletesConnection;
@@ -10309,85 +10690,85 @@ export type Tempo = {
   hasEventQcCompletes: Array<QcComplete>;
   hasEventQcCompletesAggregate?: Maybe<TempoQcCompleteHasEventQcCompletesAggregationSelection>;
   hasEventQcCompletesConnection: TempoHasEventQcCompletesConnection;
-  initialPipelineRunDate?: Maybe<Scalars["String"]>;
+  initialPipelineRunDate?: Maybe<Scalars["String"]["output"]>;
   samplesHasTempo: Array<Sample>;
   samplesHasTempoAggregate?: Maybe<TempoSampleSamplesHasTempoAggregationSelection>;
   samplesHasTempoConnection: TempoSamplesHasTempoConnection;
-  smileTempoId: Scalars["String"];
+  smileTempoId: Scalars["String"]["output"];
 };
 
 export type TempoHasEventBamCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<BamCompleteOptions>;
   where?: InputMaybe<BamCompleteWhere>;
 };
 
 export type TempoHasEventBamCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<BamCompleteWhere>;
 };
 
 export type TempoHasEventBamCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoHasEventBamCompletesConnectionSort>>;
   where?: InputMaybe<TempoHasEventBamCompletesConnectionWhere>;
 };
 
 export type TempoHasEventMafCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<MafCompleteOptions>;
   where?: InputMaybe<MafCompleteWhere>;
 };
 
 export type TempoHasEventMafCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<MafCompleteWhere>;
 };
 
 export type TempoHasEventMafCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoHasEventMafCompletesConnectionSort>>;
   where?: InputMaybe<TempoHasEventMafCompletesConnectionWhere>;
 };
 
 export type TempoHasEventQcCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<QcCompleteOptions>;
   where?: InputMaybe<QcCompleteWhere>;
 };
 
 export type TempoHasEventQcCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<QcCompleteWhere>;
 };
 
 export type TempoHasEventQcCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoHasEventQcCompletesConnectionSort>>;
   where?: InputMaybe<TempoHasEventQcCompletesConnectionWhere>;
 };
 
 export type TempoSamplesHasTempoArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type TempoSamplesHasTempoAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type TempoSamplesHasTempoConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoSamplesHasTempoConnectionSort>>;
   where?: InputMaybe<TempoSamplesHasTempoConnectionWhere>;
 };
@@ -10397,7 +10778,7 @@ export type TempoAggregateSelection = {
   accessLevel: StringAggregateSelection;
   billedBy: StringAggregateSelection;
   costCenter: StringAggregateSelection;
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   custodianInformation: StringAggregateSelection;
   embargoDate: StringAggregateSelection;
   initialPipelineRunDate: StringAggregateSelection;
@@ -10406,7 +10787,7 @@ export type TempoAggregateSelection = {
 
 export type TempoBamCompleteHasEventBamCompletesAggregationSelection = {
   __typename?: "TempoBamCompleteHasEventBamCompletesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoBamCompleteHasEventBamCompletesNodeAggregateSelection>;
 };
 
@@ -10418,36 +10799,36 @@ export type TempoBamCompleteHasEventBamCompletesNodeAggregateSelection = {
 
 export type TempoCohortRequest = {
   __typename?: "TempoCohortRequest";
-  cohortId: Scalars["String"];
-  endUsers: Scalars["String"];
-  pmUsers: Scalars["String"];
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
+  cohortId: Scalars["String"]["output"];
+  endUsers: Scalars["String"]["output"];
+  pmUsers: Scalars["String"]["output"];
+  projectSubtitle: Scalars["String"]["output"];
+  projectTitle: Scalars["String"]["output"];
   samples: Array<TempoCohortSample>;
-  type: Scalars["String"];
+  type: Scalars["String"]["output"];
 };
 
 export type TempoCohortRequestInput = {
-  cohortId: Scalars["String"];
-  endUsers: Array<Scalars["String"]>;
-  pmUsers: Array<Scalars["String"]>;
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
+  cohortId: Scalars["String"]["input"];
+  endUsers: Array<Scalars["String"]["input"]>;
+  pmUsers: Array<Scalars["String"]["input"]>;
+  projectSubtitle: Scalars["String"]["input"];
+  projectTitle: Scalars["String"]["input"];
   samples: Array<TempoCohortSampleInput>;
-  type: Scalars["String"];
+  type: Scalars["String"]["input"];
 };
 
 export type TempoCohortSample = {
   __typename?: "TempoCohortSample";
-  cmoId?: Maybe<Scalars["String"]>;
-  embargoDate?: Maybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
+  cmoId?: Maybe<Scalars["String"]["output"]>;
+  embargoDate?: Maybe<Scalars["String"]["output"]>;
+  primaryId: Scalars["String"]["output"];
 };
 
 export type TempoCohortSampleInput = {
-  cmoId?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
+  cmoId?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId: Scalars["String"]["input"];
 };
 
 export type TempoConnectInput = {
@@ -10468,18 +10849,18 @@ export type TempoConnectWhere = {
 };
 
 export type TempoCreateInput = {
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
   hasEventBamCompletes?: InputMaybe<TempoHasEventBamCompletesFieldInput>;
   hasEventMafCompletes?: InputMaybe<TempoHasEventMafCompletesFieldInput>;
   hasEventQcCompletes?: InputMaybe<TempoHasEventQcCompletesFieldInput>;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasTempo?: InputMaybe<TempoSamplesHasTempoFieldInput>;
-  smileTempoId: Scalars["String"];
+  smileTempoId: Scalars["String"]["input"];
 };
 
 export type TempoDeleteInput = {
@@ -10510,7 +10891,7 @@ export type TempoDisconnectInput = {
 
 export type TempoEdge = {
   __typename?: "TempoEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -10518,18 +10899,18 @@ export type TempoHasEventBamCompletesAggregateInput = {
   AND?: InputMaybe<Array<TempoHasEventBamCompletesAggregateInput>>;
   NOT?: InputMaybe<TempoHasEventBamCompletesAggregateInput>;
   OR?: InputMaybe<Array<TempoHasEventBamCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoHasEventBamCompletesNodeAggregationWhereInput>;
 };
 
 export type TempoHasEventBamCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<BamCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<BamCompleteConnectWhere>;
 };
 
@@ -10537,7 +10918,7 @@ export type TempoHasEventBamCompletesConnection = {
   __typename?: "TempoHasEventBamCompletesConnection";
   edges: Array<TempoHasEventBamCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoHasEventBamCompletesConnectionSort = {
@@ -10574,41 +10955,41 @@ export type TempoHasEventBamCompletesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoHasEventBamCompletesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoHasEventBamCompletesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoHasEventBamCompletesNodeAggregationWhereInput>>;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoHasEventBamCompletesRelationship = {
   __typename?: "TempoHasEventBamCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: BamComplete;
 };
 
@@ -10629,18 +11010,18 @@ export type TempoHasEventMafCompletesAggregateInput = {
   AND?: InputMaybe<Array<TempoHasEventMafCompletesAggregateInput>>;
   NOT?: InputMaybe<TempoHasEventMafCompletesAggregateInput>;
   OR?: InputMaybe<Array<TempoHasEventMafCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoHasEventMafCompletesNodeAggregationWhereInput>;
 };
 
 export type TempoHasEventMafCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<MafCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<MafCompleteConnectWhere>;
 };
 
@@ -10648,7 +11029,7 @@ export type TempoHasEventMafCompletesConnection = {
   __typename?: "TempoHasEventMafCompletesConnection";
   edges: Array<TempoHasEventMafCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoHasEventMafCompletesConnectionSort = {
@@ -10685,56 +11066,56 @@ export type TempoHasEventMafCompletesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoHasEventMafCompletesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoHasEventMafCompletesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoHasEventMafCompletesNodeAggregationWhereInput>>;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoHasEventMafCompletesRelationship = {
   __typename?: "TempoHasEventMafCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: MafComplete;
 };
 
@@ -10755,18 +11136,18 @@ export type TempoHasEventQcCompletesAggregateInput = {
   AND?: InputMaybe<Array<TempoHasEventQcCompletesAggregateInput>>;
   NOT?: InputMaybe<TempoHasEventQcCompletesAggregateInput>;
   OR?: InputMaybe<Array<TempoHasEventQcCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoHasEventQcCompletesNodeAggregationWhereInput>;
 };
 
 export type TempoHasEventQcCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<QcCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<QcCompleteConnectWhere>;
 };
 
@@ -10774,7 +11155,7 @@ export type TempoHasEventQcCompletesConnection = {
   __typename?: "TempoHasEventQcCompletesConnection";
   edges: Array<TempoHasEventQcCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoHasEventQcCompletesConnectionSort = {
@@ -10811,71 +11192,71 @@ export type TempoHasEventQcCompletesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoHasEventQcCompletesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoHasEventQcCompletesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoHasEventQcCompletesNodeAggregationWhereInput>>;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  reason_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  reason_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  result_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  result_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  result_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoHasEventQcCompletesRelationship = {
   __typename?: "TempoHasEventQcCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: QcComplete;
 };
 
@@ -10894,7 +11275,7 @@ export type TempoHasEventQcCompletesUpdateFieldInput = {
 
 export type TempoMafCompleteHasEventMafCompletesAggregationSelection = {
   __typename?: "TempoMafCompleteHasEventMafCompletesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoMafCompleteHasEventMafCompletesNodeAggregateSelection>;
 };
 
@@ -10906,15 +11287,15 @@ export type TempoMafCompleteHasEventMafCompletesNodeAggregateSelection = {
 };
 
 export type TempoOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more TempoSort objects to sort Tempos by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<TempoSort>>;
 };
 
 export type TempoQcCompleteHasEventQcCompletesAggregationSelection = {
   __typename?: "TempoQcCompleteHasEventQcCompletesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoQcCompleteHasEventQcCompletesNodeAggregateSelection>;
 };
 
@@ -10941,7 +11322,7 @@ export type TempoRelationInput = {
 
 export type TempoSampleSamplesHasTempoAggregationSelection = {
   __typename?: "TempoSampleSamplesHasTempoAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoSampleSamplesHasTempoNodeAggregateSelection>;
 };
 
@@ -10957,18 +11338,18 @@ export type TempoSamplesHasTempoAggregateInput = {
   AND?: InputMaybe<Array<TempoSamplesHasTempoAggregateInput>>;
   NOT?: InputMaybe<TempoSamplesHasTempoAggregateInput>;
   OR?: InputMaybe<Array<TempoSamplesHasTempoAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoSamplesHasTempoNodeAggregationWhereInput>;
 };
 
 export type TempoSamplesHasTempoConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -10976,7 +11357,7 @@ export type TempoSamplesHasTempoConnection = {
   __typename?: "TempoSamplesHasTempoConnection";
   edges: Array<TempoSamplesHasTempoRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoSamplesHasTempoConnectionSort = {
@@ -11013,71 +11394,71 @@ export type TempoSamplesHasTempoNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoSamplesHasTempoNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoSamplesHasTempoNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoSamplesHasTempoNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoSamplesHasTempoRelationship = {
   __typename?: "TempoSamplesHasTempoRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -11107,12 +11488,12 @@ export type TempoSort = {
 };
 
 export type TempoUpdateInput = {
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
   hasEventBamCompletes?: InputMaybe<
     Array<TempoHasEventBamCompletesUpdateFieldInput>
   >;
@@ -11122,46 +11503,48 @@ export type TempoUpdateInput = {
   hasEventQcCompletes?: InputMaybe<
     Array<TempoHasEventQcCompletesUpdateFieldInput>
   >;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasTempo?: InputMaybe<Array<TempoSamplesHasTempoUpdateFieldInput>>;
-  smileTempoId?: InputMaybe<Scalars["String"]>;
+  smileTempoId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type TempoWhere = {
   AND?: InputMaybe<Array<TempoWhere>>;
   NOT?: InputMaybe<TempoWhere>;
   OR?: InputMaybe<Array<TempoWhere>>;
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  accessLevel_CONTAINS?: InputMaybe<Scalars["String"]>;
-  accessLevel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  accessLevel_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  accessLevel_MATCHES?: InputMaybe<Scalars["String"]>;
-  accessLevel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  billedBy_CONTAINS?: InputMaybe<Scalars["String"]>;
-  billedBy_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  billedBy_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  billedBy_MATCHES?: InputMaybe<Scalars["String"]>;
-  billedBy_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  costCenter_CONTAINS?: InputMaybe<Scalars["String"]>;
-  costCenter_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  costCenter_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  costCenter_MATCHES?: InputMaybe<Scalars["String"]>;
-  costCenter_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  custodianInformation_CONTAINS?: InputMaybe<Scalars["String"]>;
-  custodianInformation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  custodianInformation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  custodianInformation_MATCHES?: InputMaybe<Scalars["String"]>;
-  custodianInformation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
-  embargoDate_CONTAINS?: InputMaybe<Scalars["String"]>;
-  embargoDate_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  embargoDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  embargoDate_MATCHES?: InputMaybe<Scalars["String"]>;
-  embargoDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  accessLevel_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  billedBy_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  costCenter_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  custodianInformation_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  embargoDate_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasEventBamCompletesAggregate?: InputMaybe<TempoHasEventBamCompletesAggregateInput>;
   /** Return Tempos where all of the related TempoHasEventBamCompletesConnections match this filter */
   hasEventBamCompletesConnection_ALL?: InputMaybe<TempoHasEventBamCompletesConnectionWhere>;
@@ -11213,12 +11596,14 @@ export type TempoWhere = {
   hasEventQcCompletes_SINGLE?: InputMaybe<QcCompleteWhere>;
   /** Return Tempos where some of the related QcCompletes match this filter */
   hasEventQcCompletes_SOME?: InputMaybe<QcCompleteWhere>;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_CONTAINS?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  initialPipelineRunDate_MATCHES?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  initialPipelineRunDate_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasTempoAggregate?: InputMaybe<TempoSamplesHasTempoAggregateInput>;
   /** Return Tempos where all of the related TempoSamplesHasTempoConnections match this filter */
   samplesHasTempoConnection_ALL?: InputMaybe<TempoSamplesHasTempoConnectionWhere>;
@@ -11236,26 +11621,26 @@ export type TempoWhere = {
   samplesHasTempo_SINGLE?: InputMaybe<SampleWhere>;
   /** Return Tempos where some of the related Samples match this filter */
   samplesHasTempo_SOME?: InputMaybe<SampleWhere>;
-  smileTempoId?: InputMaybe<Scalars["String"]>;
-  smileTempoId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileTempoId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileTempoId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileTempoId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileTempoId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smileTempoId?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileTempoId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type TemposConnection = {
   __typename?: "TemposConnection";
   edges: Array<TempoEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type ToleratedSampleValidationError = {
   __typename?: "ToleratedSampleValidationError";
-  primaryId: Scalars["String"];
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  primaryId: Scalars["String"]["output"];
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type UpdateBamCompletesMutationResponse = {
@@ -11286,11 +11671,11 @@ export type UpdateDbGapsMutationResponse = {
 export type UpdateInfo = {
   __typename?: "UpdateInfo";
   /** @deprecated This field has been deprecated because bookmarks are now handled by the driver. */
-  bookmark?: Maybe<Scalars["String"]>;
-  nodesCreated: Scalars["Int"];
-  nodesDeleted: Scalars["Int"];
-  relationshipsCreated: Scalars["Int"];
-  relationshipsDeleted: Scalars["Int"];
+  bookmark?: Maybe<Scalars["String"]["output"]>;
+  nodesCreated: Scalars["Int"]["output"];
+  nodesDeleted: Scalars["Int"]["output"];
+  relationshipsCreated: Scalars["Int"]["output"];
+  relationshipsDeleted: Scalars["Int"]["output"];
 };
 
 export type UpdateMafCompletesMutationResponse = {
@@ -11367,18 +11752,20 @@ export type UpdateTemposMutationResponse = {
 
 export type ValidationAdvice = {
   __typename?: "ValidationAdvice";
-  advice: Scalars["String"];
-  suggestedSteps: Array<Scalars["String"]>;
+  advice: Scalars["String"]["output"];
+  suggestedSteps: Array<Scalars["String"]["output"]>;
 };
 
 export type DashboardRequestsQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
 }>;
 
 export type DashboardRequestsQuery = {
@@ -11418,14 +11805,16 @@ export type DashboardRequestsQuery = {
 };
 
 export type DashboardPatientsQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
 export type DashboardPatientsQuery = {
@@ -11449,13 +11838,15 @@ export type DashboardPatientsQuery = {
 };
 
 export type DashboardCohortsQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
 }>;
 
 export type DashboardCohortsQuery = {
@@ -11481,7 +11872,9 @@ export type DashboardCohortsQuery = {
 };
 
 export type DashboardSamplesQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   recordContexts?: InputMaybe<
     | Array<InputMaybe<DashboardRecordContext>>
     | InputMaybe<DashboardRecordContext>
@@ -11490,10 +11883,10 @@ export type DashboardSamplesQueryVariables = Exact<{
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
-  includeDemographics?: InputMaybe<Scalars["Boolean"]>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  includeDemographics?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
 export type DashboardSamplesQuery = {
@@ -11572,10 +11965,10 @@ export type DashboardSamplesQuery = {
 };
 
 export type DashboardSampleHistoryQueryVariables = Exact<{
-  searchVals: Array<Scalars["String"]> | Scalars["String"];
+  searchVals: Array<Scalars["String"]["input"]> | Scalars["String"]["input"];
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
 }>;
 
 export type DashboardSampleHistoryQuery = {
@@ -11837,9 +12230,10 @@ export type AllBlockedCohortIdsQuery = {
 };
 
 export type GetValidationAdviceQueryVariables = Exact<{
-  validationReport: Scalars["String"];
-  recordType: Scalars["String"];
-  recordId?: InputMaybe<Scalars["String"]>;
+  validationReport: Scalars["String"]["input"];
+  recordType: Scalars["String"]["input"];
+  recordId?: InputMaybe<Scalars["String"]["input"]>;
+  igoQcReports?: InputMaybe<Scalars["String"]["input"]>;
 }>;
 
 export type GetValidationAdviceQuery = {
@@ -11852,7 +12246,7 @@ export type GetValidationAdviceQuery = {
 };
 
 export type AllAnchorSeqDateDataQueryVariables = Exact<{
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
 export type AllAnchorSeqDateDataQuery = {
@@ -12267,11 +12661,13 @@ export const GetValidationAdviceDocument = gql`
     $validationReport: String!
     $recordType: String!
     $recordId: String
+    $igoQcReports: String
   ) {
     getValidationAdvice(
       validationReport: $validationReport
       recordType: $recordType
       recordId: $recordId
+      igoQcReports: $igoQcReports
     ) {
       advice
       suggestedSteps

--- a/graphql-server/src/index.ts
+++ b/graphql-server/src/index.ts
@@ -8,6 +8,15 @@ import { configureRoutes } from "./routes";
 import { queryDatabricks } from "./utils/databricks";
 require("log-timestamp"); // adds a timestamp to every log statement
 
+const [major] = process.versions.node.split(".").map(Number);
+if (major < 18) {
+  console.error(
+    `[startup] Node.js 18+ is required (running ${process.version}). ` +
+      "Run: nvm use 18"
+  );
+  process.exit(1);
+}
+
 async function main() {
   const app: Express = express();
 

--- a/graphql-server/src/mcp/providers/anthropic.ts
+++ b/graphql-server/src/mcp/providers/anthropic.ts
@@ -1,0 +1,88 @@
+import Anthropic from "@anthropic-ai/sdk";
+import {
+  ProviderLoopArgs,
+  ValidationAdvice,
+  extractValidationAdvice,
+  normalizeSchema,
+  RETURN_ADVICE_TOOL,
+  FALLBACK_ADVICE,
+} from "./types";
+
+const MAX_ITERATIONS = 5;
+
+export async function runLoop(
+  config: { apiKey: string; model: string },
+  { tools, systemPrompt, userMessage, callTool }: ProviderLoopArgs
+): Promise<ValidationAdvice> {
+  const anthropic = new Anthropic({ apiKey: config.apiKey });
+
+  const anthropicTools: Anthropic.Tool[] = tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    input_schema: normalizeSchema(t.inputSchema) as Anthropic.Tool.InputSchema,
+  }));
+
+  const messages: Anthropic.MessageParam[] = [
+    { role: "user", content: userMessage },
+  ];
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    const response = await anthropic.messages.create({
+      model: config.model,
+      system: systemPrompt,
+      messages,
+      tools: anthropicTools,
+      max_tokens: 1024,
+    });
+
+    if (response.stop_reason === "end_turn") {
+      const textBlock = response.content.find((b) => b.type === "text");
+      return {
+        advice:
+          textBlock && "text" in textBlock
+            ? textBlock.text
+            : "Unable to generate advice.",
+        suggestedSteps: [],
+      };
+    }
+
+    if (response.stop_reason === "tool_use") {
+      messages.push({ role: "assistant", content: response.content });
+
+      const toolResults: Anthropic.ToolResultBlockParam[] = [];
+
+      for (const block of response.content) {
+        if (block.type !== "tool_use") continue;
+
+        if (block.name === RETURN_ADVICE_TOOL) {
+          const advice = extractValidationAdvice(block.input);
+          return advice ?? FALLBACK_ADVICE;
+        }
+
+        let toolOutput: string;
+        try {
+          toolOutput = await callTool(
+            block.name,
+            block.input as Record<string, unknown>
+          );
+        } catch (err) {
+          toolOutput = `Tool error: ${
+            err instanceof Error ? err.message : String(err)
+          }`;
+        }
+
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: block.id,
+          content: toolOutput,
+        });
+      }
+
+      if (toolResults.length > 0) {
+        messages.push({ role: "user", content: toolResults });
+      }
+    }
+  }
+
+  return FALLBACK_ADVICE;
+}

--- a/graphql-server/src/mcp/providers/gemini.ts
+++ b/graphql-server/src/mcp/providers/gemini.ts
@@ -1,0 +1,105 @@
+import {
+  GoogleGenAI,
+  createPartFromFunctionResponse,
+  Content,
+} from "@google/genai";
+import {
+  ProviderLoopArgs,
+  ValidationAdvice,
+  extractValidationAdvice,
+  normalizeSchema,
+  RETURN_ADVICE_TOOL,
+  FALLBACK_ADVICE,
+} from "./types";
+
+const MAX_ITERATIONS = 5;
+
+export async function runLoop(
+  config: { apiKey: string; model: string },
+  { tools, systemPrompt, userMessage, callTool }: ProviderLoopArgs
+): Promise<ValidationAdvice> {
+  const ai = new GoogleGenAI({ apiKey: config.apiKey });
+
+  const functionDeclarations = tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    parametersJsonSchema: normalizeSchema(t.inputSchema),
+  }));
+
+  const contents: Content[] = [
+    { role: "user", parts: [{ text: userMessage }] },
+  ];
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    const requestBody = {
+      contents,
+      generationConfig: { maxOutputTokens: 1024 },
+      systemInstruction: { parts: [{ text: systemPrompt }] },
+      tools: [{ functionDeclarations }],
+    };
+
+    if (i === 0) {
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${config.model}:generateContent?key=REDACTED`;
+      console.log(
+        "[gemini] equivalent cURL:\n" +
+          `curl -s -X POST '${url}' \\\n` +
+          `  -H 'Content-Type: application/json' \\\n` +
+          `  -d '${JSON.stringify(requestBody)}'`
+      );
+    }
+
+    const response = await ai.models.generateContent({
+      model: config.model,
+      contents,
+      config: {
+        systemInstruction: systemPrompt,
+        tools: [{ functionDeclarations }],
+        maxOutputTokens: 1024,
+      },
+    });
+
+    const functionCalls = response.functionCalls;
+
+    if (!functionCalls || functionCalls.length === 0) {
+      return {
+        advice: response.text ?? "Unable to generate advice.",
+        suggestedSteps: [],
+      };
+    }
+
+    // Append model turn to history before processing tools
+    const modelParts = response.candidates?.[0]?.content?.parts ?? [];
+    contents.push({ role: "model", parts: modelParts });
+
+    // Check for return_validation_advice before executing any tools
+    for (const call of functionCalls) {
+      if (call.name === RETURN_ADVICE_TOOL) {
+        const advice = extractValidationAdvice(call.args ?? {});
+        return advice ?? FALLBACK_ADVICE;
+      }
+    }
+
+    // Execute all other tool calls and collect responses
+    const responseParts = await Promise.all(
+      functionCalls.map(async (call) => {
+        const callId = call.id ?? call.name ?? "";
+        const callName = call.name ?? "";
+        let output: string;
+        try {
+          output = await callTool(callName, call.args ?? {});
+        } catch (err) {
+          output = `Tool error: ${
+            err instanceof Error ? err.message : String(err)
+          }`;
+        }
+        return createPartFromFunctionResponse(callId, callName, {
+          output,
+        });
+      })
+    );
+
+    contents.push({ role: "user", parts: responseParts });
+  }
+
+  return FALLBACK_ADVICE;
+}

--- a/graphql-server/src/mcp/providers/openai.ts
+++ b/graphql-server/src/mcp/providers/openai.ts
@@ -1,0 +1,94 @@
+import OpenAI from "openai";
+import {
+  ProviderLoopArgs,
+  ValidationAdvice,
+  extractValidationAdvice,
+  normalizeSchema,
+  RETURN_ADVICE_TOOL,
+  FALLBACK_ADVICE,
+} from "./types";
+
+const MAX_ITERATIONS = 5;
+
+export async function runLoop(
+  config: { apiKey: string; model: string },
+  { tools, systemPrompt, userMessage, callTool }: ProviderLoopArgs
+): Promise<ValidationAdvice> {
+  const openai = new OpenAI({ apiKey: config.apiKey });
+
+  const openaiTools: OpenAI.Chat.Completions.ChatCompletionTool[] = tools.map(
+    (t) => ({
+      type: "function" as const,
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: normalizeSchema(t.inputSchema),
+      },
+    })
+  );
+
+  const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
+    { role: "system", content: systemPrompt },
+    { role: "user", content: userMessage },
+  ];
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    const response = await openai.chat.completions.create({
+      model: config.model,
+      messages,
+      tools: openaiTools,
+      max_tokens: 1024,
+    });
+
+    const choice = response.choices[0];
+    if (!choice) return FALLBACK_ADVICE;
+
+    if (
+      choice.finish_reason !== "tool_calls" ||
+      !choice.message.tool_calls?.length
+    ) {
+      return {
+        advice: choice.message.content ?? "Unable to generate advice.",
+        suggestedSteps: [],
+      };
+    }
+
+    // Append assistant message (contains tool_calls) before processing
+    messages.push(choice.message);
+
+    // Check for return_validation_advice before executing any tools
+    for (const call of choice.message.tool_calls) {
+      if (call.type !== "function") continue;
+      if (call.function.name === RETURN_ADVICE_TOOL) {
+        // OpenAI function.arguments is a JSON string
+        const advice = extractValidationAdvice(call.function.arguments);
+        return advice ?? FALLBACK_ADVICE;
+      }
+    }
+
+    // Execute all other tool calls — one "tool" message per call
+    for (const call of choice.message.tool_calls) {
+      if (call.type !== "function") continue;
+      let output: string;
+      try {
+        const args = JSON.parse(call.function.arguments) as Record<
+          string,
+          unknown
+        >;
+        output = await callTool(call.function.name, args);
+      } catch (err) {
+        output = `Tool error: ${
+          err instanceof Error ? err.message : String(err)
+        }`;
+      }
+
+      messages.push({
+        role: "tool",
+        tool_call_id: call.id,
+        content: output,
+      });
+    }
+  }
+
+  return FALLBACK_ADVICE;
+}

--- a/graphql-server/src/mcp/providers/types.ts
+++ b/graphql-server/src/mcp/providers/types.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared types and utilities for LLM provider loops.
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Shared interfaces
+// ---------------------------------------------------------------------------
+
+export interface McpToolDef {
+  name: string;
+  description: string;
+  /** JSON Schema object (already stripped of non-standard fields) */
+  inputSchema: Record<string, unknown>;
+}
+
+export interface ProviderLoopArgs {
+  tools: McpToolDef[];
+  systemPrompt: string;
+  userMessage: string;
+  /**
+   * Execute an MCP tool by name. Returns the tool's text output.
+   * Should NOT be called with "return_validation_advice" — providers
+   * intercept that tool themselves and return immediately.
+   */
+  callTool: (name: string, args: Record<string, unknown>) => Promise<string>;
+}
+
+export interface ValidationAdvice {
+  advice: string;
+  suggestedSteps: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union for provider config
+// ---------------------------------------------------------------------------
+
+export type ProviderConfig =
+  | { provider: "anthropic"; apiKey: string; model: string }
+  | { provider: "gemini"; apiKey: string; model: string }
+  | { provider: "openai"; apiKey: string; model: string };
+
+// ---------------------------------------------------------------------------
+// Shared utilities
+// ---------------------------------------------------------------------------
+
+const ValidationAdviceSchema = z.object({
+  advice: z.string(),
+  suggestedSteps: z.array(z.string()),
+});
+
+/**
+ * Parse and validate the args passed to the `return_validation_advice` tool.
+ * Handles both object args (Anthropic/Gemini) and JSON-string args (OpenAI).
+ */
+export function extractValidationAdvice(
+  rawArgs: unknown
+): ValidationAdvice | null {
+  try {
+    const parsed = typeof rawArgs === "string" ? JSON.parse(rawArgs) : rawArgs;
+    const result = ValidationAdviceSchema.safeParse(parsed);
+    if (result.success) return result.data;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove JSON-Schema meta-fields that some LLM APIs reject.
+ */
+export function normalizeSchema(
+  schema: Record<string, unknown>
+): Record<string, unknown> {
+  const { $schema: _s, execution: _e, ...clean } = schema;
+  return clean;
+}
+
+export const RETURN_ADVICE_TOOL = "return_validation_advice";
+
+export const FALLBACK_ADVICE: ValidationAdvice = {
+  advice:
+    "Unable to generate advice after maximum iterations. Please contact the SMILE team.",
+  suggestedSteps: ["Contact the SMILE team for manual assistance."],
+};

--- a/graphql-server/src/mcp/server.ts
+++ b/graphql-server/src/mcp/server.ts
@@ -1,0 +1,241 @@
+/**
+ * In-process MCP server that powers the getValidationAdvice GraphQL resolver.
+ *
+ * Architecture:
+ *   GraphQL resolver
+ *     → runValidationAdviceQuery()
+ *         → McpServer (smile-validation) — registers two tools:
+ *             • get_current_record_context  (no params; fetches Neo4j metadata for the bound record)
+ *             • return_validation_advice    (structured output tool)
+ *         → InMemoryTransport pair  (server ↔ client, no network hop)
+ *         → LLM provider tool-use loop (Anthropic | Gemini | OpenAI), max 5 iterations
+ *         → returns ValidationAdvice
+ */
+
+import { createRequire } from "module";
+import type { McpServer as McpServerType } from "./shims/mcp-server";
+import type { Client as ClientType } from "./shims/mcp-client";
+import type { InMemoryTransport as InMemoryTransportType } from "./shims/mcp-inmemory";
+
+// The MCP SDK's package.json uses "./*" wildcard exports without .js extensions,
+// which Node.js CJS refuses to resolve. We load the real classes via createRequire
+// from the one explicit export ("./server") that works, using relative .js paths.
+const _sdkRequire = createRequire(
+  require.resolve("@modelcontextprotocol/sdk/server")
+);
+const { McpServer } = _sdkRequire("./mcp.js") as {
+  McpServer: typeof McpServerType;
+};
+const { Client } = _sdkRequire("../client/index.js") as {
+  Client: typeof ClientType;
+};
+const { InMemoryTransport } = _sdkRequire("../inMemory.js") as {
+  InMemoryTransport: typeof InMemoryTransportType;
+};
+import { z } from "zod";
+import { Driver } from "neo4j-driver";
+import {
+  SMILE_SYSTEM_PROMPT,
+  formatValidationReportForPrompt,
+} from "./validationCatalog";
+import {
+  ProviderConfig,
+  ValidationAdvice,
+  normalizeSchema,
+  RETURN_ADVICE_TOOL,
+} from "./providers/types";
+import { runLoop as anthropicLoop } from "./providers/anthropic";
+import { runLoop as geminiLoop } from "./providers/gemini";
+import { runLoop as openaiLoop } from "./providers/openai";
+
+export type { ValidationAdvice };
+
+export interface RunValidationAdviceArgs {
+  validationReport: string;
+  /** "SAMPLE" | "REQUEST" */
+  recordType: string;
+  /** primaryId (sample) or igoRequestId (request) — optional but improves advice quality */
+  recordId?: string | null;
+  providerConfig: ProviderConfig;
+  neo4jDriver: Driver;
+}
+
+// ---------------------------------------------------------------------------
+// Neo4j context helpers
+// ---------------------------------------------------------------------------
+
+async function fetchSampleContext(
+  primaryId: string,
+  driver: Driver
+): Promise<string> {
+  const session = driver.session();
+  try {
+    const result = await session.run(
+      `
+      MATCH (s:Sample)-[:HAS_METADATA]->(sm:SampleMetadata)
+      WHERE sm.primaryId = $primaryId
+      RETURN sm {
+        .primaryId, .cmoSampleName, .sampleClass, .sampleType, .sampleOrigin,
+        .tumorOrNormal, .genePanel, .baitSet, .recipe, .oncotreeCode,
+        .igoComplete, .investigatorSampleId, .cmoPatientId, .preservation
+      } AS metadata
+      LIMIT 1
+      `,
+      { primaryId }
+    );
+    if (result.records.length === 0) {
+      return `No metadata found for sample primaryId="${primaryId}".`;
+    }
+    return JSON.stringify(result.records[0].get("metadata"), null, 2);
+  } catch (err) {
+    return `Error fetching sample context: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+  } finally {
+    await session.close();
+  }
+}
+
+async function fetchRequestContext(
+  requestId: string,
+  driver: Driver
+): Promise<string> {
+  const session = driver.session();
+  try {
+    const result = await session.run(
+      `
+      MATCH (r:Request)
+      WHERE r.igoRequestId = $requestId
+      RETURN r {
+        .igoRequestId, .igoProjectId, .genePanel, .isCmoRequest,
+        .totalSampleCount, .dataAnalystName, .projectManagerName,
+        .investigatorName, .labHeadName, .importDate
+      } AS metadata
+      LIMIT 1
+      `,
+      { requestId }
+    );
+    if (result.records.length === 0) {
+      return `No metadata found for request igoRequestId="${requestId}".`;
+    }
+    return JSON.stringify(result.records[0].get("metadata"), null, 2);
+  } catch (err) {
+    return `Error fetching request context: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+  } finally {
+    await session.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export async function runValidationAdviceQuery({
+  validationReport,
+  recordType,
+  recordId,
+  providerConfig,
+  neo4jDriver: driver,
+}: RunValidationAdviceArgs): Promise<ValidationAdvice> {
+  // Build MCP server with tools scoped to this request
+  const server = new McpServer({ name: "smile-validation", version: "1.0.0" });
+
+  // Tool 1: context lookup — only registered when a record ID is available
+  if (recordId) {
+    server.tool(
+      "get_current_record_context",
+      `Fetch current ${recordType.toLowerCase()} metadata from the SMILE Neo4j database for record "${recordId}"`,
+      {}, // no input params — handler is already bound to recordId
+      async () => {
+        const context =
+          recordType === "SAMPLE"
+            ? await fetchSampleContext(recordId, driver)
+            : await fetchRequestContext(recordId, driver);
+        return { content: [{ type: "text" as const, text: context }] };
+      }
+    );
+  }
+
+  // Tool 2: structured output — LLM MUST call this to return its advice
+  server.tool(
+    RETURN_ADVICE_TOOL,
+    "Return the final structured advice for resolving the validation errors",
+    {
+      advice: z
+        .string()
+        .describe(
+          "A concise paragraph explaining the root cause(s) and the overall resolution approach"
+        ),
+      suggestedSteps: z
+        .array(z.string())
+        .describe("Ordered list of concrete remediation steps"),
+    },
+    async (args: Record<string, unknown>) => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            advice: args.advice,
+            suggestedSteps: args.suggestedSteps,
+          }),
+        },
+      ],
+    })
+  );
+
+  // Connect server and client in-process via InMemoryTransport
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const mcpClient = new Client(
+    { name: "smile-resolver", version: "1.0.0" },
+    { capabilities: {} }
+  );
+  await server.connect(serverTransport);
+  await mcpClient.connect(clientTransport);
+
+  try {
+    // Convert MCP tools to provider-agnostic format
+    const { tools: mcpTools } = await mcpClient.listTools();
+    const tools = mcpTools.map((t) => ({
+      name: t.name,
+      description: t.description ?? "",
+      inputSchema: normalizeSchema(t.inputSchema as Record<string, unknown>),
+    }));
+
+    // callTool closure — executes an MCP tool and returns its text output
+    const callTool = async (
+      name: string,
+      args: Record<string, unknown>
+    ): Promise<string> => {
+      const result = await mcpClient.callTool({ name, arguments: args });
+      const first = result.content[0];
+      return first && "text" in first && first.text != null
+        ? first.text
+        : JSON.stringify(result.content);
+    };
+
+    const loopArgs = {
+      tools,
+      systemPrompt: SMILE_SYSTEM_PROMPT,
+      userMessage: formatValidationReportForPrompt({
+        validationReport,
+        recordType,
+        recordId,
+      }),
+      callTool,
+    };
+
+    switch (providerConfig.provider) {
+      case "anthropic":
+        return anthropicLoop(providerConfig, loopArgs);
+      case "gemini":
+        return geminiLoop(providerConfig, loopArgs);
+      case "openai":
+        return openaiLoop(providerConfig, loopArgs);
+    }
+  } finally {
+    await mcpClient.close();
+  }
+}

--- a/graphql-server/src/mcp/server.ts
+++ b/graphql-server/src/mcp/server.ts
@@ -72,13 +72,14 @@ async function fetchSampleContext(
   try {
     const result = await session.run(
       `
-      MATCH (s:Sample)-[:HAS_METADATA]->(sm:SampleMetadata)
-      WHERE sm.primaryId = $primaryId
+      MATCH (s:Sample)[:HAS_METADATA]->(sm:SampleMetadata{primaryId: $primaryId})
+      WITH s, sm, sm.qcReports as igoQcReports
       RETURN sm {
         .primaryId, .cmoSampleName, .sampleClass, .sampleType, .sampleOrigin,
         .tumorOrNormal, .genePanel, .baitSet, .recipe, .oncotreeCode,
-        .igoComplete, .investigatorSampleId, .cmoPatientId, .preservation
+        .igoComplete, .investigatorSampleId, .cmoPatientId, .preservation, igoQcReports
       } AS metadata
+      ORDER BY sm.importDate DESC
       LIMIT 1
       `,
       { primaryId }

--- a/graphql-server/src/mcp/server.ts
+++ b/graphql-server/src/mcp/server.ts
@@ -56,6 +56,8 @@ export interface RunValidationAdviceArgs {
   recordType: string;
   /** primaryId (sample) or igoRequestId (request) — optional but improves advice quality */
   recordId?: string | null;
+  /** JSON-serialized IgoQcReport[] — sample-level only, passed from the frontend row data */
+  igoQcReports?: string | null;
   providerConfig: ProviderConfig;
   neo4jDriver: Driver;
 }
@@ -137,6 +139,7 @@ export async function runValidationAdviceQuery({
   validationReport,
   recordType,
   recordId,
+  igoQcReports,
   providerConfig,
   neo4jDriver: driver,
 }: RunValidationAdviceArgs): Promise<ValidationAdvice> {
@@ -224,6 +227,7 @@ export async function runValidationAdviceQuery({
         validationReport,
         recordType,
         recordId,
+        igoQcReports,
       }),
       callTool,
     };

--- a/graphql-server/src/mcp/server.ts
+++ b/graphql-server/src/mcp/server.ts
@@ -109,10 +109,24 @@ async function fetchRequestContext(
       `
       MATCH (r:Request)
       WHERE r.igoRequestId = $requestId
+      WITH
+        r,
+        COLLECT {
+          MATCH (r)-[:HAS_METADATA]->(rm:RequestMetadata)
+          RETURN rm ORDER BY rm.importDate DESC LIMIT 1
+        } AS latestRm
+      OPTIONAL MATCH (r)-[:HAS_SAMPLE]->(s:Sample)-[:HAS_METADATA]->(sm:SampleMetadata)
+      WITH 
+        r, 
+        COUNT(DISTINCT s.smileSampleId) AS totalSampleCount,
+        apoc.coll.max(
+          COLLECT(latestRm[0].rm.importDate) +
+          COLLECT(DISTINCT sm.importDate)
+        ) AS importDate
       RETURN r {
         .igoRequestId, .igoProjectId, .genePanel, .isCmoRequest,
-        .totalSampleCount, .dataAnalystName, .projectManagerName,
-        .investigatorName, .labHeadName, .importDate
+        totalSampleCount, .dataAnalystName, .projectManagerName,
+        .investigatorName, .labHeadName, importDate
       } AS metadata
       LIMIT 1
       `,

--- a/graphql-server/src/mcp/shims/mcp-catchall.ts
+++ b/graphql-server/src/mcp/shims/mcp-catchall.ts
@@ -1,0 +1,12 @@
+/**
+ * Catch-all shim for any @modelcontextprotocol/sdk/* subpath not explicitly
+ * covered by the specific shims. Used to prevent @google/genai's type
+ * declarations (which import from the MCP SDK) from triggering the transitive
+ * load of zod@4 `.d.cts` files, which use TS5-only `const` type parameters
+ * that TypeScript 4.x cannot parse.
+ */
+
+// Re-export the types that @google/genai needs from the MCP SDK
+export { Client } from "./mcp-client";
+export { McpServer } from "./mcp-server";
+export { InMemoryTransport } from "./mcp-inmemory";

--- a/graphql-server/src/mcp/shims/mcp-client.ts
+++ b/graphql-server/src/mcp/shims/mcp-client.ts
@@ -1,0 +1,53 @@
+/**
+ * TypeScript shim for @modelcontextprotocol/sdk/client
+ *
+ * Provides minimal types without importing the SDK's actual declaration files.
+ */
+
+import type { InMemoryTransport } from "./mcp-inmemory";
+
+export interface McpToolInputSchema {
+  type: string;
+  properties?: Record<string, unknown>;
+  required?: string[];
+  [key: string]: unknown;
+}
+
+export interface McpTool {
+  name: string;
+  description?: string;
+  inputSchema: McpToolInputSchema;
+}
+
+export interface CallToolResult {
+  content: Array<{ type: string; text?: string; [key: string]: unknown }>;
+  isError?: boolean;
+}
+
+export class Client {
+  constructor(
+    info: { name: string; version: string },
+    options: { capabilities?: Record<string, unknown> }
+  ) {
+    void info;
+    void options;
+  }
+
+  async connect(transport: InMemoryTransport): Promise<void> {
+    void transport;
+  }
+
+  async listTools(): Promise<{ tools: McpTool[] }> {
+    return { tools: [] };
+  }
+
+  async callTool(params: {
+    name: string;
+    arguments?: Record<string, unknown>;
+  }): Promise<CallToolResult> {
+    void params;
+    return { content: [] };
+  }
+
+  async close(): Promise<void> {}
+}

--- a/graphql-server/src/mcp/shims/mcp-inmemory.ts
+++ b/graphql-server/src/mcp/shims/mcp-inmemory.ts
@@ -1,0 +1,14 @@
+/**
+ * TypeScript shim for @modelcontextprotocol/sdk/inMemory
+ *
+ * Provides minimal types without importing the SDK's actual declaration files.
+ */
+
+export class InMemoryTransport {
+  static createLinkedPair(): [InMemoryTransport, InMemoryTransport] {
+    return [new InMemoryTransport(), new InMemoryTransport()];
+  }
+
+  async start(): Promise<void> {}
+  async close(): Promise<void> {}
+}

--- a/graphql-server/src/mcp/shims/mcp-server.ts
+++ b/graphql-server/src/mcp/shims/mcp-server.ts
@@ -1,0 +1,36 @@
+/**
+ * TypeScript shim for @modelcontextprotocol/sdk/server/mcp
+ *
+ * Provides minimal types without importing the SDK's actual declaration files,
+ * which transitively require zod@4 types that use TS5-only `const` type params.
+ * At runtime Node.js uses the real SDK; these types only exist during compilation.
+ */
+
+import type { z } from "zod";
+import type { InMemoryTransport } from "./mcp-inmemory";
+
+export type ToolContent = Array<{ type: "text"; text: string }>;
+
+export class McpServer {
+  constructor(info: { name: string; version: string }) {
+    void info;
+  }
+
+  tool(
+    name: string,
+    description: string,
+    schema: Record<string, z.ZodTypeAny> | Record<string, never>,
+    handler: (
+      args: Record<string, unknown>
+    ) => Promise<{ content: ToolContent }>
+  ): void {
+    void name;
+    void description;
+    void schema;
+    void handler;
+  }
+
+  async connect(transport: InMemoryTransport): Promise<void> {
+    void transport;
+  }
+}

--- a/graphql-server/src/mcp/validationCatalog.ts
+++ b/graphql-server/src/mcp/validationCatalog.ts
@@ -36,7 +36,7 @@ concise, actionable advice tailored to the specific combination of errors report
 
 --- RESPONSIBLE PARTIES ---
 - IGO errors: contact IGO to fix and redeliver; then notify SMILE via email or the "Mark delivery"
-  button in the dashboard.
+  button in the IGO LIMS app.
 - PM errors: PMs can directly update editable metadata fields in the SMILE PM dashboard.
 
 For sample-level errors where the responsible party is IGO, additional information can be gleaned from a sample's QC reports located in the "igoQcReports" field in the sample metadata.
@@ -45,9 +45,18 @@ checking the QC reports may reveal that IGO failed the sample due to low quantit
 
 --- INSTRUCTIONS ---
 1. You will receive a list of validation errors for a specific record.
-2. Optionally call get_current_record_context() to retrieve the record's current metadata from the
+2. Always call get_current_record_context() to retrieve the record's current metadata from the
    SMILE database — useful for providing more specific advice (e.g., knowing the genePanel or
    sampleClass when advising on sampleType errors).
+   - For sample-level errors where the responsible party is IGO, pay close attention to the
+     "igoQcReports" field in the returned metadata. Each QC report contains:
+       • qcReportType       — the type of QC check performed
+       • IGORecommendation  — IGO's pass/fail/warning recommendation
+       • comments           — free-text notes from IGO explaining the outcome
+       • investigatorDecision — the investigator's response (e.g. proceed, failed)
+     These reports can reveal the root cause of IGO-owned errors. For example, a missing baitSet
+     may be explained by an IGO QC report showing the sample was failed due to low input quantity.
+     Always incorporate relevant QC report findings into your advice and suggested steps.
 3. Once you have enough context, call return_validation_advice() with your final assessment.
    - "advice": a single concise paragraph explaining the root cause(s) and overall approach.
    - "suggestedSteps": an ordered list of concrete, actionable steps the user should take.

--- a/graphql-server/src/mcp/validationCatalog.ts
+++ b/graphql-server/src/mcp/validationCatalog.ts
@@ -1,0 +1,112 @@
+/**
+ * SMILE domain knowledge baked into the system prompt for the validation advice LLM.
+ * Mirrors the static error catalog in frontend/src/configs/recordValidationMaps.ts so
+ * the AI has the same vocabulary as the UI.
+ */
+export const SMILE_SYSTEM_PROMPT = `
+You are an expert assistant helping Project Managers (PMs) and IGO (Integrated Genomics Operations)
+staff resolve sample and request validation errors in the
+SMILE (Sample Meta Information Link Exchange) system.
+
+SMILE is a distributed system of microservices that tracks sample metadata across patients, requests, cohorts, etc.. When CMO samples 
+fail validation they will not be assigned a CMO label and may not be processed through bioinformatics pipelines. Your job is to give
+concise, actionable advice tailored to the specific combination of errors reported.
+
+--- SAMPLE-LEVEL ERRORS ---
+| Error key                                 | Meaning                                                            | Responsible party |
+|-------------------------------------------|--------------------------------------------------------------------|-------------------|
+| baitSet missing                           | Baitset field empty in IGO LIMS                                    | IGO               |
+| fastQs missing                            | FASTQs not sent from IGO to SMILE                                  | IGO               |
+| igoComplete false                         | IGOComplete checkbox not ticked in LIMS                            | IGO               |
+| sample type abbreviation could not resolve| Metadata for CMO Sample Name generation missing/incomplete/invalid | PMs               |
+| recipe missing                            | Recipe field empty in IGO LIMS                                     | IGO               |
+| normalizedPatientId missing               | normalizedPatientId missing from cmoSampleIdFields in IGO LIMS     | IGO               |
+| specimenType (sampleClass) invalid        | IGO Specimen Type value not recognized                             | PMs               |
+| sampleType missing from cmoSampleIdFields | Auto-generated IGO fallback field missing                          | PMs               |
+| sampleType invalid                        | Invalid sampleType in cmoSampleIdFields                            | PMs               |
+| investigatorSampleId missing              | Investigator sample ID not set                                     | PMs               |
+| cmoPatientId missing                      | CMO patient ID not set in IGO LIMS                                 | IGO               |
+| igoId missing                             | IGO ID not set in IGO LIMS                                         | IGO               |
+
+--- REQUEST-LEVEL ERRORS ---
+| Error key             | Meaning                                                                   | Responsible party |
+|-----------------------|---------------------------------------------------------------------------|-------------------|
+| isCmo false           | cmoRequest=false but SMILE CMO filter requires true                       | IGO               |
+| samples missing/empty | Request JSON missing samples — often an IGO HTTP 500 on getSampleManifests| IGO               |
+
+--- RESPONSIBLE PARTIES ---
+- IGO errors: contact IGO to fix and redeliver; then notify SMILE via email or the "Mark delivery"
+  button in the dashboard.
+- PM errors: PMs can directly update editable metadata fields in the SMILE PM dashboard.
+
+For sample-level errors where the responsible party is IGO, additional information can be gleaned from a sample's QC reports located in the "igoQcReports" field in the sample metadata.
+These reports have qcReportType, IGORecommendation, comments, and investigatorDecision - all of which may provide clues about the root cause of validation errors and next steps. For example, if a sample is missing baitSet then 
+checking the QC reports may reveal that IGO failed the sample due to low quantity.
+
+--- INSTRUCTIONS ---
+1. You will receive a list of validation errors for a specific record.
+2. Optionally call get_current_record_context() to retrieve the record's current metadata from the
+   SMILE database — useful for providing more specific advice (e.g., knowing the genePanel or
+   sampleClass when advising on sampleType errors).
+3. Once you have enough context, call return_validation_advice() with your final assessment.
+   - "advice": a single concise paragraph explaining the root cause(s) and overall approach.
+   - "suggestedSteps": an ordered list of concrete, actionable steps the user should take.
+   Prioritise the most impactful fix first. Where multiple errors share a root cause, group them.
+`.trim();
+
+/**
+ * Converts the raw validationReport string (JSON or legacy {k=v} format) into a
+ * normalised Map and then renders it as a readable list for the LLM prompt.
+ */
+export function formatValidationReportForPrompt({
+  validationReport,
+  recordType,
+  recordId,
+}: {
+  validationReport: string;
+  recordType: string;
+  recordId?: string | null;
+}): string {
+  const errors = parseValidationReport(validationReport);
+  const errorList = Array.from(errors.entries())
+    .map(([k, v]) => `  - ${k}: ${v}`)
+    .join("\n");
+
+  const lines = [
+    `Please analyse the following ${recordType.toLowerCase()} validation errors${
+      recordId ? ` for record "${recordId}"` : ""
+    }:`,
+    "",
+    errorList || `  (raw) ${validationReport}`,
+    "",
+  ];
+
+  if (recordId) {
+    lines.push(
+      "You may call get_current_record_context() to get this record's current metadata before " +
+        "providing advice."
+    );
+  }
+
+  lines.push(
+    "When you are ready, call return_validation_advice() with your assessment."
+  );
+
+  return lines.join("\n");
+}
+
+function parseValidationReport(validationReport: string): Map<string, string> {
+  try {
+    return new Map<string, string>(
+      Object.entries(JSON.parse(validationReport)) as [string, string][]
+    );
+  } catch {
+    const map = new Map<string, string>();
+    const cleaned = validationReport.replace(/[{}]/g, "");
+    for (const pair of cleaned.split(",")) {
+      const [k, v] = pair.split("=").map((s) => s.trim());
+      if (k && v) map.set(k, v);
+    }
+    return map;
+  }
+}

--- a/graphql-server/src/mcp/validationCatalog.ts
+++ b/graphql-server/src/mcp/validationCatalog.ts
@@ -71,10 +71,12 @@ export function formatValidationReportForPrompt({
   validationReport,
   recordType,
   recordId,
+  igoQcReports,
 }: {
   validationReport: string;
   recordType: string;
   recordId?: string | null;
+  igoQcReports?: string | null;
 }): string {
   const errors = parseValidationReport(validationReport);
   const errorList = Array.from(errors.entries())
@@ -89,6 +91,29 @@ export function formatValidationReportForPrompt({
     errorList || `  (raw) ${validationReport}`,
     "",
   ];
+
+  // Inline QC reports when provided so the model has them immediately
+  if (igoQcReports) {
+    try {
+      const reports = JSON.parse(igoQcReports);
+      if (Array.isArray(reports) && reports.length > 0) {
+        lines.push("IGO QC reports for this sample:");
+        reports.forEach((r: Record<string, unknown>, i: number) => {
+          lines.push(
+            `  [${i + 1}] qcReportType: ${r.qcReportType ?? "N/A"} | ` +
+              `IGORecommendation: ${r.IGORecommendation ?? "N/A"} | ` +
+              `comments: ${r.comments ?? "N/A"} | ` +
+              `investigatorDecision: ${r.investigatorDecision ?? "N/A"}`
+          );
+        });
+      } else {
+        lines.push("IGO QC reports for this sample: none on record.");
+      }
+    } catch {
+      // malformed JSON — skip silently
+    }
+    lines.push("");
+  }
 
   if (recordId) {
     lines.push(

--- a/graphql-server/src/mcp/validationCatalog.ts
+++ b/graphql-server/src/mcp/validationCatalog.ts
@@ -39,10 +39,6 @@ concise, actionable advice tailored to the specific combination of errors report
   button in the IGO LIMS app.
 - PM errors: PMs can directly update editable metadata fields in the SMILE PM dashboard.
 
-For sample-level errors where the responsible party is IGO, additional information can be gleaned from a sample's QC reports located in the "igoQcReports" field in the sample metadata.
-These reports have qcReportType, IGORecommendation, comments, and investigatorDecision - all of which may provide clues about the root cause of validation errors and next steps. For example, if a sample is missing baitSet then 
-checking the QC reports may reveal that IGO failed the sample due to low quantity.
-
 --- INSTRUCTIONS ---
 1. You will receive a list of validation errors for a specific record.
 2. Always call get_current_record_context() to retrieve the record's current metadata from the

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -60,6 +60,7 @@ import {
   queryDashboardRequests,
 } from "./queries/requests";
 import { typeDefs } from "../utils/typeDefs";
+import { runValidationAdviceQuery, ValidationAdvice } from "../mcp/server";
 const request = require("request-promise-native");
 import { AuthenticationError, ForbiddenError } from "apollo-server-express";
 import { applyMiddleware } from "graphql-middleware";
@@ -76,6 +77,7 @@ type AuthMiddleware = {
     allAnchorSeqDateData: IMiddlewareResolver;
     allBlockedCohortIds: IMiddlewareResolver;
     dashboardCohorts: IMiddlewareResolver;
+    getValidationAdvice: IMiddlewareResolver;
   };
 };
 
@@ -193,6 +195,21 @@ export async function buildCustomSchema(ogm: OGM) {
         }
         return await resolve(parent, args, context, info);
       },
+
+      async getValidationAdvice(
+        resolve,
+        parent,
+        args,
+        context: ApolloServerContext,
+        info
+      ) {
+        if (!context.req.isAuthenticated()) {
+          throw new AuthenticationError(
+            "You must be logged in to access this resource."
+          );
+        }
+        return await resolve(parent, args, context, info);
+      },
     },
   };
 
@@ -266,6 +283,10 @@ export async function buildCustomSchema(ogm: OGM) {
       },
 
       async dashboardCohorts(resolve, parent, args, context, info) {
+        return await resolve(parent, args, context, info);
+      },
+
+      async getValidationAdvice(resolve, parent, args, context, info) {
         return await resolve(parent, args, context, info);
       },
     },
@@ -382,6 +403,64 @@ export async function buildCustomSchema(ogm: OGM) {
 
       async allBlockedCohortIds() {
         return await queryAllBlockedCohortIds();
+      },
+
+      async getValidationAdvice(
+        _source: undefined,
+        {
+          validationReport,
+          recordType,
+          recordId,
+        }: { validationReport: string; recordType: string; recordId?: string }
+      ): Promise<ValidationAdvice> {
+        const provider = props.llm_provider as string;
+        let providerConfig:
+          | { provider: "anthropic"; apiKey: string; model: string }
+          | { provider: "gemini"; apiKey: string; model: string }
+          | { provider: "openai"; apiKey: string; model: string };
+
+        if (provider === "gemini") {
+          providerConfig = {
+            provider: "gemini",
+            apiKey: props.gemini_api_key as string,
+            model: props.gemini_model as string,
+          };
+        } else if (provider === "openai") {
+          providerConfig = {
+            provider: "openai",
+            apiKey: props.openai_api_key as string,
+            model: props.openai_model as string,
+          };
+        } else {
+          providerConfig = {
+            provider: "anthropic",
+            apiKey: props.anthropic_api_key as string,
+            model: props.anthropic_model as string,
+          };
+        }
+        console.log("[getValidationAdvice] request:", {
+          recordType,
+          recordId,
+          validationReportLength: validationReport?.length,
+          provider: providerConfig.provider,
+          model: providerConfig.model,
+        });
+
+        let result: ValidationAdvice;
+        try {
+          result = await runValidationAdviceQuery({
+            validationReport,
+            recordType,
+            recordId,
+            providerConfig,
+            neo4jDriver,
+          });
+          console.log("[getValidationAdvice] response:", result);
+        } catch (err) {
+          console.error("[getValidationAdvice] error:", err);
+          throw err;
+        }
+        return result;
       },
 
       async dashboardCohorts(

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -411,7 +411,13 @@ export async function buildCustomSchema(ogm: OGM) {
           validationReport,
           recordType,
           recordId,
-        }: { validationReport: string; recordType: string; recordId?: string }
+          igoQcReports,
+        }: {
+          validationReport: string;
+          recordType: string;
+          recordId?: string;
+          igoQcReports?: string;
+        }
       ): Promise<ValidationAdvice> {
         const provider = props.llm_provider as string;
         let providerConfig:
@@ -442,6 +448,7 @@ export async function buildCustomSchema(ogm: OGM) {
           recordType,
           recordId,
           validationReportLength: validationReport?.length,
+          igoQcReportsLength: igoQcReports?.length,
           provider: providerConfig.provider,
           model: providerConfig.model,
         });
@@ -452,6 +459,7 @@ export async function buildCustomSchema(ogm: OGM) {
             validationReport,
             recordType,
             recordId,
+            igoQcReports,
             providerConfig,
             neo4jDriver,
           });

--- a/graphql-server/src/utils/constants.ts
+++ b/graphql-server/src/utils/constants.ts
@@ -62,6 +62,18 @@ export const props = {
   ),
 
   ccs_blocked_cohort_ids: properties.get("ccs.blocked_cohort_ids"),
+
+  llm_provider: properties.get("llm.provider") ?? "gemini",
+
+  anthropic_api_key: properties.get("anthropic.anthropic_api_key"),
+  anthropic_model:
+    properties.get("anthropic.anthropic_model") ?? "claude-3-5-haiku-20241022",
+
+  gemini_api_key: properties.get("gemini.gemini_api_key"),
+  gemini_model: properties.get("gemini.gemini_model") ?? "gemini-2.5-flash",
+
+  openai_api_key: properties.get("openai.openai_api_key"),
+  openai_model: properties.get("openai.openai_model") ?? "gpt-4o-mini",
 };
 
 export const REACT_APP_EXPRESS_SERVER_ORIGIN =

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -235,6 +235,11 @@ const QUERY_RESULT_TYPEDEFS = gql`
     type: String!
     samples: [TempoCohortSample!]!
   }
+
+  type ValidationAdvice {
+    advice: String!
+    suggestedSteps: [String!]!
+  }
 `;
 
 const QUERY_TYPEDEFS = gql`
@@ -285,6 +290,12 @@ const QUERY_TYPEDEFS = gql`
     allAnchorSeqDateData(phiEnabled: Boolean): [AnchorSeqDateData!]!
 
     allBlockedCohortIds: [String!]!
+
+    getValidationAdvice(
+      validationReport: String!
+      recordType: String!
+      recordId: String
+    ): ValidationAdvice
   }
 `;
 

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -295,6 +295,7 @@ const QUERY_TYPEDEFS = gql`
       validationReport: String!
       recordType: String!
       recordId: String
+      igoQcReports: String
     ): ValidationAdvice
   }
 `;

--- a/graphql-server/tsconfig.json
+++ b/graphql-server/tsconfig.json
@@ -29,8 +29,18 @@
     "module": "commonjs" /* Specify what module code is generated. */,
     //"rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "moduleResolution": "node16",                        /* Respect package.json exports field for packages like @modelcontextprotocol/sdk */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // Redirect MCP SDK imports to local shims so TS 4.x never loads the SDK's
+    // nested zod@4 types (which use `const` type params — a TS5-only feature).
+    "baseUrl": ".",
+    "paths": {
+      "@modelcontextprotocol/sdk/server/mcp": ["src/mcp/shims/mcp-server"],
+      "@modelcontextprotocol/sdk/client": ["src/mcp/shims/mcp-client"],
+      "@modelcontextprotocol/sdk/inMemory": ["src/mcp/shims/mcp-inmemory"],
+      "@modelcontextprotocol/sdk/*": ["src/mcp/shims/mcp-catchall"]
+    },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -41023,6 +41023,63 @@
             "deprecationReason": null
           },
           {
+            "name": "getValidationAdvice",
+            "description": null,
+            "args": [
+              {
+                "name": "recordId",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "recordType",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "validationReport",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ValidationAdvice",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "mafCompletes",
             "description": null,
             "args": [
@@ -110209,6 +110266,57 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "Tempo",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ValidationAdvice",
+        "description": null,
+        "fields": [
+          {
+            "name": "advice",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "suggestedSteps",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
                     "ofType": null
                   }
                 }

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1,10 +1,12 @@
 {
   "__schema": {
     "queryType": {
-      "name": "Query"
+      "name": "Query",
+      "kind": "OBJECT"
     },
     "mutationType": {
-      "name": "Mutation"
+      "name": "Mutation",
+      "kind": "OBJECT"
     },
     "subscriptionType": null,
     "types": [
@@ -12,6 +14,7 @@
         "kind": "ENUM",
         "name": "AgGridSortDirection",
         "description": null,
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -35,6 +38,7 @@
         "kind": "OBJECT",
         "name": "AnchorSeqDateData",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "ANCHOR_ONCOTREE_CODE",
@@ -110,6 +114,7 @@
         "kind": "OBJECT",
         "name": "BamComplete",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -336,6 +341,7 @@
         "kind": "OBJECT",
         "name": "BamCompleteAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -395,6 +401,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -426,6 +433,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -453,6 +461,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -508,6 +517,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -539,6 +549,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -570,6 +581,7 @@
         "kind": "OBJECT",
         "name": "BamCompleteEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -613,6 +625,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -668,6 +681,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -699,6 +713,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteSort",
         "description": "Fields to sort BamCompletes by. The order in which sorts are applied is not guaranteed when specifying many fields in one BamCompleteSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -734,6 +749,7 @@
         "kind": "OBJECT",
         "name": "BamCompleteTempoTemposHasEventAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -773,6 +789,7 @@
         "kind": "OBJECT",
         "name": "BamCompleteTempoTemposHasEventNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "accessLevel",
@@ -896,6 +913,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1031,6 +1049,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1090,6 +1109,7 @@
         "kind": "OBJECT",
         "name": "BamCompleteTemposHasEventConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -1157,6 +1177,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1180,6 +1201,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1255,6 +1277,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1282,6 +1305,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1317,6 +1341,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1352,6 +1377,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1403,6 +1429,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -2726,6 +2753,7 @@
         "kind": "OBJECT",
         "name": "BamCompleteTemposHasEventRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -2769,6 +2797,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -2792,6 +2821,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -2907,6 +2937,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -2962,6 +2993,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -3293,6 +3325,7 @@
         "kind": "OBJECT",
         "name": "BamCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -3360,6 +3393,7 @@
         "kind": "SCALAR",
         "name": "BigInt",
         "description": "A BigInt value up to 64 bits in size, which can be a number or a string if used inline, or a string only if used as a variable. Always returned as a string.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -3370,6 +3404,7 @@
         "kind": "OBJECT",
         "name": "BigIntAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "average",
@@ -3429,6 +3464,7 @@
         "kind": "SCALAR",
         "name": "Boolean",
         "description": "The `Boolean` scalar type represents `true` or `false`.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -3439,9 +3475,26 @@
         "kind": "OBJECT",
         "name": "Cohort",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
             "description": null,
             "args": [],
             "type": {
@@ -3832,9 +3885,26 @@
         "kind": "OBJECT",
         "name": "CohortAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
             "description": null,
             "args": [],
             "type": {
@@ -3875,6 +3945,7 @@
         "kind": "OBJECT",
         "name": "CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -3914,6 +3985,7 @@
         "kind": "OBJECT",
         "name": "CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -4069,6 +4141,7 @@
         "kind": "OBJECT",
         "name": "CohortComplete",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortsHasCohortComplete",
@@ -4403,6 +4476,7 @@
         "kind": "OBJECT",
         "name": "CohortCompleteAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -4574,6 +4648,7 @@
         "kind": "OBJECT",
         "name": "CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -4613,9 +4688,26 @@
         "kind": "OBJECT",
         "name": "CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
             "description": null,
             "args": [],
             "type": {
@@ -4640,6 +4732,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -4775,6 +4868,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -4834,6 +4928,7 @@
         "kind": "OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -4901,6 +4996,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -4924,6 +5020,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -4999,6 +5096,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5026,6 +5124,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5061,6 +5160,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5096,6 +5196,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5147,6 +5248,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5380,6 +5482,186 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -5390,6 +5672,7 @@
         "kind": "OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -5433,6 +5716,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5456,6 +5740,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5571,6 +5856,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5602,6 +5888,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5629,6 +5916,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5792,6 +6080,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5823,6 +6112,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5854,6 +6144,7 @@
         "kind": "OBJECT",
         "name": "CohortCompleteEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -5897,6 +6188,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5952,6 +6244,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5983,6 +6276,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteSort",
         "description": "Fields to sort CohortCompletes by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortCompleteSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -6102,6 +6396,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -6265,6 +6560,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7152,6 +7448,7 @@
         "kind": "OBJECT",
         "name": "CohortCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -7219,6 +7516,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7270,6 +7568,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7297,10 +7596,27 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
             "name": "cohortId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
             "description": null,
             "type": {
               "kind": "NON_NULL",
@@ -7348,6 +7664,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7399,6 +7716,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7450,6 +7768,7 @@
         "kind": "OBJECT",
         "name": "CohortEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -7493,6 +7812,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7628,6 +7948,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7687,6 +8008,7 @@
         "kind": "OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -7754,6 +8076,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7777,6 +8100,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7852,6 +8176,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7879,6 +8204,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7914,6 +8240,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7949,6 +8276,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -8000,6 +8328,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -9743,6 +10072,7 @@
         "kind": "OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -9786,6 +10116,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -9809,6 +10140,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -9924,6 +10256,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10059,6 +10392,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10118,6 +10452,7 @@
         "kind": "OBJECT",
         "name": "CohortHasCohortSampleSamplesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -10185,6 +10520,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10208,6 +10544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10283,6 +10620,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10310,6 +10648,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10345,6 +10684,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10380,6 +10720,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10431,6 +10772,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -11214,6 +11556,7 @@
         "kind": "OBJECT",
         "name": "CohortHasCohortSampleSamplesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -11257,6 +11600,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -11280,6 +11624,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -11395,6 +11740,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -11450,6 +11796,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -11501,6 +11848,7 @@
         "kind": "OBJECT",
         "name": "CohortSampleHasCohortSampleSamplesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -11540,6 +11888,7 @@
         "kind": "OBJECT",
         "name": "CohortSampleHasCohortSampleSamplesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -11615,10 +11964,23 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortSort",
         "description": "Fields to sort Cohorts by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
             "name": "cohortId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -11638,10 +12000,23 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
             "name": "cohortId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -11701,6 +12076,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -11825,6 +12201,86 @@
           },
           {
             "name": "cohortId_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_MATCHES",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_STARTS_WITH",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -12060,6 +12516,7 @@
         "kind": "OBJECT",
         "name": "CohortsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -12127,6 +12584,7 @@
         "kind": "OBJECT",
         "name": "CreateBamCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "bamCompletes",
@@ -12178,6 +12636,7 @@
         "kind": "OBJECT",
         "name": "CreateCohortCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortCompletes",
@@ -12229,6 +12688,7 @@
         "kind": "OBJECT",
         "name": "CreateCohortsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohorts",
@@ -12280,6 +12740,7 @@
         "kind": "OBJECT",
         "name": "CreateDbGapsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dbGaps",
@@ -12331,6 +12792,7 @@
         "kind": "OBJECT",
         "name": "CreateInfo",
         "description": "Information about the number of nodes and relationships created during a create mutation",
+        "isOneOf": null,
         "fields": [
           {
             "name": "bookmark",
@@ -12386,6 +12848,7 @@
         "kind": "OBJECT",
         "name": "CreateMafCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12437,6 +12900,7 @@
         "kind": "OBJECT",
         "name": "CreatePatientAliasesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12488,6 +12952,7 @@
         "kind": "OBJECT",
         "name": "CreatePatientsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12539,6 +13004,7 @@
         "kind": "OBJECT",
         "name": "CreateProjectsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12590,6 +13056,7 @@
         "kind": "OBJECT",
         "name": "CreateQcCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12641,6 +13108,7 @@
         "kind": "OBJECT",
         "name": "CreateRequestMetadataMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12692,6 +13160,7 @@
         "kind": "OBJECT",
         "name": "CreateRequestsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12743,6 +13212,7 @@
         "kind": "OBJECT",
         "name": "CreateSampleAliasesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12794,6 +13264,7 @@
         "kind": "OBJECT",
         "name": "CreateSampleMetadataMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12845,6 +13316,7 @@
         "kind": "OBJECT",
         "name": "CreateSamplesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12896,6 +13368,7 @@
         "kind": "OBJECT",
         "name": "CreateStatusesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12947,6 +13420,7 @@
         "kind": "OBJECT",
         "name": "CreateTemposMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12998,6 +13472,7 @@
         "kind": "OBJECT",
         "name": "DashboardCohort",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "_total",
@@ -13193,6 +13668,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DashboardCohortInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -13424,6 +13900,7 @@
         "kind": "OBJECT",
         "name": "DashboardPatient",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "_total",
@@ -13595,6 +14072,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DashboardRecordColumnFilter",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -13638,6 +14116,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DashboardRecordContext",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -13685,6 +14164,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DashboardRecordSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -13728,6 +14208,7 @@
         "kind": "OBJECT",
         "name": "DashboardRequest",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "_total",
@@ -14035,6 +14516,7 @@
         "kind": "OBJECT",
         "name": "DashboardSample",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "_total",
@@ -14806,6 +15288,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DashboardSampleInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -15585,6 +16068,7 @@
         "kind": "OBJECT",
         "name": "DbGap",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dbGapStudy",
@@ -15811,6 +16295,7 @@
         "kind": "OBJECT",
         "name": "DbGapAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -15870,6 +16355,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -15901,6 +16387,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -15928,6 +16415,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -15983,6 +16471,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16014,6 +16503,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16045,6 +16535,7 @@
         "kind": "OBJECT",
         "name": "DbGapEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -16088,6 +16579,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16143,6 +16635,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16174,6 +16667,7 @@
         "kind": "OBJECT",
         "name": "DbGapSampleSamplesHasDbgapAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -16213,6 +16707,7 @@
         "kind": "OBJECT",
         "name": "DbGapSampleSamplesHasDbgapNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -16288,6 +16783,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16423,6 +16919,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16482,6 +16979,7 @@
         "kind": "OBJECT",
         "name": "DbGapSamplesHasDbgapConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -16549,6 +17047,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16572,6 +17071,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16647,6 +17147,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16674,6 +17175,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16709,6 +17211,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16744,6 +17247,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16795,6 +17299,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -17578,6 +18083,7 @@
         "kind": "OBJECT",
         "name": "DbGapSamplesHasDbgapRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -17621,6 +18127,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -17644,6 +18151,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -17759,6 +18267,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSort",
         "description": "Fields to sort DbGaps by. The order in which sorts are applied is not guaranteed when specifying many fields in one DbGapSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -17794,6 +18303,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -17849,6 +18359,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18180,6 +18691,7 @@
         "kind": "OBJECT",
         "name": "DbGapsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -18247,6 +18759,7 @@
         "kind": "OBJECT",
         "name": "DeleteInfo",
         "description": "Information about the number of nodes and relationships deleted during a delete mutation",
+        "isOneOf": null,
         "fields": [
           {
             "name": "bookmark",
@@ -18302,6 +18815,7 @@
         "kind": "SCALAR",
         "name": "Float",
         "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -18312,6 +18826,7 @@
         "kind": "OBJECT",
         "name": "IgoQcReport",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "IGORecommendation",
@@ -18371,6 +18886,7 @@
         "kind": "SCALAR",
         "name": "Int",
         "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -18381,6 +18897,7 @@
         "kind": "OBJECT",
         "name": "MafComplete",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -18623,6 +19140,7 @@
         "kind": "OBJECT",
         "name": "MafCompleteAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -18698,6 +19216,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18729,6 +19248,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18756,6 +19276,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18827,6 +19348,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18858,6 +19380,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18889,6 +19412,7 @@
         "kind": "OBJECT",
         "name": "MafCompleteEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -18932,6 +19456,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18987,6 +19512,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19018,6 +19544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteSort",
         "description": "Fields to sort MafCompletes by. The order in which sorts are applied is not guaranteed when specifying many fields in one MafCompleteSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19065,6 +19592,7 @@
         "kind": "OBJECT",
         "name": "MafCompleteTempoTemposHasEventAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -19104,6 +19632,7 @@
         "kind": "OBJECT",
         "name": "MafCompleteTempoTemposHasEventNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "accessLevel",
@@ -19227,6 +19756,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19362,6 +19892,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19421,6 +19952,7 @@
         "kind": "OBJECT",
         "name": "MafCompleteTemposHasEventConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -19488,6 +20020,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19511,6 +20044,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19586,6 +20120,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19613,6 +20148,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19648,6 +20184,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19683,6 +20220,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19734,6 +20272,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -21057,6 +21596,7 @@
         "kind": "OBJECT",
         "name": "MafCompleteTemposHasEventRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -21100,6 +21640,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -21123,6 +21664,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -21238,6 +21780,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -21305,6 +21848,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -21716,6 +22260,7 @@
         "kind": "OBJECT",
         "name": "MafCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -21783,6 +22328,7 @@
         "kind": "OBJECT",
         "name": "Mutation",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "createBamCompletes",
@@ -23845,6 +24391,7 @@
         "kind": "OBJECT",
         "name": "PageInfo",
         "description": "Pagination information (Relay)",
+        "isOneOf": null,
         "fields": [
           {
             "name": "endCursor",
@@ -23912,6 +24459,7 @@
         "kind": "OBJECT",
         "name": "Patient",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "hasSampleSamples",
@@ -24305,6 +24853,7 @@
         "kind": "OBJECT",
         "name": "PatientAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -24348,6 +24897,7 @@
         "kind": "OBJECT",
         "name": "PatientAlias",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "isAliasPatients",
@@ -24574,6 +25124,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -24633,6 +25184,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24664,6 +25216,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24691,6 +25244,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24746,6 +25300,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24777,6 +25332,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24808,6 +25364,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -24851,6 +25408,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24986,6 +25544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25045,6 +25604,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasIsAliasPatientsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -25112,6 +25672,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25135,6 +25696,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25210,6 +25772,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25237,6 +25800,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25272,6 +25836,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25307,6 +25872,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25358,6 +25924,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25601,6 +26168,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasIsAliasPatientsRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -25644,6 +26212,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25667,6 +26236,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25782,6 +26352,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25837,6 +26408,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasPatientIsAliasPatientsAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -25876,6 +26448,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasPatientIsAliasPatientsNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "smilePatientId",
@@ -25903,6 +26476,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25934,6 +26508,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasSort",
         "description": "Fields to sort PatientAliases by. The order in which sorts are applied is not guaranteed when specifying many fields in one PatientAliasSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25969,6 +26544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26024,6 +26600,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26355,6 +26932,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -26422,6 +27000,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26473,6 +27052,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26500,6 +27080,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26551,6 +27132,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26602,6 +27184,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26653,6 +27236,7 @@
         "kind": "OBJECT",
         "name": "PatientEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -26696,6 +27280,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26831,6 +27416,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26890,6 +27476,7 @@
         "kind": "OBJECT",
         "name": "PatientHasSampleSamplesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -26957,6 +27544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26980,6 +27568,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -27055,6 +27644,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -27082,6 +27672,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -27117,6 +27708,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -27152,6 +27744,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -27203,6 +27796,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -27986,6 +28580,7 @@
         "kind": "OBJECT",
         "name": "PatientHasSampleSamplesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -28029,6 +28624,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28052,6 +28648,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28167,6 +28764,7 @@
         "kind": "OBJECT",
         "name": "PatientIdsTriplet",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "CMO_PATIENT_ID",
@@ -28234,6 +28832,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28289,6 +28888,7 @@
         "kind": "OBJECT",
         "name": "PatientPatientAliasPatientAliasesIsAliasAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -28328,6 +28928,7 @@
         "kind": "OBJECT",
         "name": "PatientPatientAliasPatientAliasesIsAliasNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "namespace",
@@ -28371,6 +28972,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28506,6 +29108,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28565,6 +29168,7 @@
         "kind": "OBJECT",
         "name": "PatientPatientAliasesIsAliasConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -28632,6 +29236,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28655,6 +29260,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28730,6 +29336,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28757,6 +29364,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28792,6 +29400,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28827,6 +29436,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28878,6 +29488,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -29301,6 +29912,7 @@
         "kind": "OBJECT",
         "name": "PatientPatientAliasesIsAliasRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -29344,6 +29956,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -29367,6 +29980,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -29482,6 +30096,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -29533,6 +30148,7 @@
         "kind": "OBJECT",
         "name": "PatientSampleHasSampleSamplesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -29572,6 +30188,7 @@
         "kind": "OBJECT",
         "name": "PatientSampleHasSampleSamplesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -29647,6 +30264,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientSort",
         "description": "Fields to sort Patients by. The order in which sorts are applied is not guaranteed when specifying many fields in one PatientSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -29670,6 +30288,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -29733,6 +30352,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30092,6 +30712,7 @@
         "kind": "OBJECT",
         "name": "PatientsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -30159,6 +30780,7 @@
         "kind": "OBJECT",
         "name": "Project",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "hasRequestRequests",
@@ -30385,6 +31007,7 @@
         "kind": "OBJECT",
         "name": "ProjectAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -30444,6 +31067,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30475,6 +31099,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30502,6 +31127,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30557,6 +31183,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30588,6 +31215,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30619,6 +31247,7 @@
         "kind": "OBJECT",
         "name": "ProjectEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -30662,6 +31291,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30797,6 +31427,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30856,6 +31487,7 @@
         "kind": "OBJECT",
         "name": "ProjectHasRequestRequestsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -30923,6 +31555,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30946,6 +31579,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -31021,6 +31655,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -31048,6 +31683,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -31083,6 +31719,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -31118,6 +31755,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -31169,6 +31807,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35072,6 +35711,7 @@
         "kind": "OBJECT",
         "name": "ProjectHasRequestRequestsRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -35115,6 +35755,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35138,6 +35779,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35253,6 +35895,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35308,6 +35951,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35339,6 +35983,7 @@
         "kind": "OBJECT",
         "name": "ProjectRequestHasRequestRequestsAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -35378,6 +36023,7 @@
         "kind": "OBJECT",
         "name": "ProjectRequestHasRequestRequestsNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dataAccessEmails",
@@ -35725,6 +36371,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectSort",
         "description": "Fields to sort Projects by. The order in which sorts are applied is not guaranteed when specifying many fields in one ProjectSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35760,6 +36407,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35815,6 +36463,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36146,6 +36795,7 @@
         "kind": "OBJECT",
         "name": "ProjectsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -36213,6 +36863,7 @@
         "kind": "OBJECT",
         "name": "QcComplete",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -36471,6 +37122,7 @@
         "kind": "OBJECT",
         "name": "QcCompleteAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -36562,6 +37214,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36593,6 +37246,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36620,6 +37274,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36707,6 +37362,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36738,6 +37394,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36769,6 +37426,7 @@
         "kind": "OBJECT",
         "name": "QcCompleteEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -36812,6 +37470,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36867,6 +37526,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36898,6 +37558,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteSort",
         "description": "Fields to sort QcCompletes by. The order in which sorts are applied is not guaranteed when specifying many fields in one QcCompleteSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36957,6 +37618,7 @@
         "kind": "OBJECT",
         "name": "QcCompleteTempoTemposHasEventAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -36996,6 +37658,7 @@
         "kind": "OBJECT",
         "name": "QcCompleteTempoTemposHasEventNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "accessLevel",
@@ -37119,6 +37782,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37254,6 +37918,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37313,6 +37978,7 @@
         "kind": "OBJECT",
         "name": "QcCompleteTemposHasEventConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -37380,6 +38046,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37403,6 +38070,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37478,6 +38146,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37505,6 +38174,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37540,6 +38210,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37575,6 +38246,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37626,6 +38298,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -38949,6 +39622,7 @@
         "kind": "OBJECT",
         "name": "QcCompleteTemposHasEventRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -38992,6 +39666,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -39015,6 +39690,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -39130,6 +39806,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -39209,6 +39886,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -39700,6 +40378,7 @@
         "kind": "OBJECT",
         "name": "QcCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -39767,6 +40446,7 @@
         "kind": "OBJECT",
         "name": "Query",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "allAnchorSeqDateData",
@@ -41026,6 +41706,18 @@
             "name": "getValidationAdvice",
             "description": null,
             "args": [
+              {
+                "name": "igoQcReports",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
               {
                 "name": "recordId",
                 "description": null,
@@ -42853,6 +43545,7 @@
         "kind": "OBJECT",
         "name": "Request",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "bicAnalysis",
@@ -43781,6 +44474,7 @@
         "kind": "OBJECT",
         "name": "RequestAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -44144,6 +44838,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44215,6 +44910,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44242,6 +44938,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44657,6 +45354,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44728,6 +45426,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44799,6 +45498,7 @@
         "kind": "OBJECT",
         "name": "RequestEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -44842,6 +45542,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44977,6 +45678,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45036,6 +45738,7 @@
         "kind": "OBJECT",
         "name": "RequestHasMetadataRequestMetadataConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -45103,6 +45806,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45126,6 +45830,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45201,6 +45906,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45228,6 +45934,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45263,6 +45970,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45298,6 +46006,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45349,6 +46058,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46012,6 +46722,7 @@
         "kind": "OBJECT",
         "name": "RequestHasMetadataRequestMetadataRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -46055,6 +46766,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46078,6 +46790,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46193,6 +46906,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46328,6 +47042,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46387,6 +47102,7 @@
         "kind": "OBJECT",
         "name": "RequestHasSampleSamplesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -46454,6 +47170,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46477,6 +47194,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46552,6 +47270,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46579,6 +47298,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46614,6 +47334,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46649,6 +47370,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46700,6 +47422,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -47483,6 +48206,7 @@
         "kind": "OBJECT",
         "name": "RequestHasSampleSamplesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -47526,6 +48250,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -47549,6 +48274,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -47664,6 +48390,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadata",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "hasStatusStatuses",
@@ -48089,6 +48816,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -48164,6 +48892,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48215,6 +48944,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48242,6 +48972,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -48309,6 +49040,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48392,6 +49124,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48443,6 +49176,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48494,6 +49228,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -48537,6 +49272,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48672,6 +49408,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48731,6 +49468,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataHasStatusStatusesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -48798,6 +49536,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48821,6 +49560,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48896,6 +49636,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48923,6 +49664,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48958,6 +49700,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48993,6 +49736,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -49044,6 +49788,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -49287,6 +50032,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataHasStatusStatusesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -49330,6 +50076,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -49353,6 +50100,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -49468,6 +50216,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -49523,6 +50272,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -49574,6 +50324,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataRequestRequestsHasMetadataAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -49613,6 +50364,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dataAccessEmails",
@@ -49960,6 +50712,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50095,6 +50848,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50154,6 +50908,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataRequestsHasMetadataConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -50221,6 +50976,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50244,6 +51000,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50319,6 +51076,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50346,6 +51104,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50381,6 +51140,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50416,6 +51176,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50467,6 +51228,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -54370,6 +55132,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataRequestsHasMetadataRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -54413,6 +55176,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -54436,6 +55200,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -54551,6 +55316,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataSort",
         "description": "Fields to sort RequestMetadata by. The order in which sorts are applied is not guaranteed when specifying many fields in one RequestMetadataSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -54598,6 +55364,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataStatusHasStatusStatusesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -54637,6 +55404,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataStatusHasStatusStatusesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "validationReport",
@@ -54664,6 +55432,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -54775,6 +55544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55294,6 +56064,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55349,6 +56120,7 @@
         "kind": "OBJECT",
         "name": "RequestProjectProjectsHasRequestAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -55388,6 +56160,7 @@
         "kind": "OBJECT",
         "name": "RequestProjectProjectsHasRequestNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "igoProjectId",
@@ -55431,6 +56204,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55566,6 +56340,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55625,6 +56400,7 @@
         "kind": "OBJECT",
         "name": "RequestProjectsHasRequestConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -55692,6 +56468,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55715,6 +56492,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55790,6 +56568,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55817,6 +56596,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55852,6 +56632,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55887,6 +56668,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55938,6 +56720,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -56361,6 +57144,7 @@
         "kind": "OBJECT",
         "name": "RequestProjectsHasRequestRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -56404,6 +57188,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -56427,6 +57212,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -56542,6 +57328,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -56613,6 +57400,7 @@
         "kind": "OBJECT",
         "name": "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -56652,6 +57440,7 @@
         "kind": "OBJECT",
         "name": "RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "igoRequestId",
@@ -56711,6 +57500,7 @@
         "kind": "OBJECT",
         "name": "RequestSampleHasSampleSamplesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -56750,6 +57540,7 @@
         "kind": "OBJECT",
         "name": "RequestSampleHasSampleSamplesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -56825,6 +57616,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestSort",
         "description": "Fields to sort Requests by. The order in which sorts are applied is not guaranteed when specifying many fields in one RequestSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -57112,6 +57904,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -57527,6 +58320,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -59630,6 +60424,7 @@
         "kind": "OBJECT",
         "name": "RequestsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -59697,6 +60492,7 @@
         "kind": "OBJECT",
         "name": "Sample",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortsHasCohortSample",
@@ -61061,6 +61857,7 @@
         "kind": "OBJECT",
         "name": "SampleAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -61152,6 +61949,7 @@
         "kind": "OBJECT",
         "name": "SampleAlias",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "isAliasSamples",
@@ -61378,6 +62176,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -61437,6 +62236,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61468,6 +62268,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61495,6 +62296,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61550,6 +62352,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61581,6 +62384,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61612,6 +62416,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -61655,6 +62460,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61790,6 +62596,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61849,6 +62656,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasIsAliasSamplesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -61916,6 +62724,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61939,6 +62748,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -62014,6 +62824,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -62041,6 +62852,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -62076,6 +62888,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -62111,6 +62924,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -62162,6 +62976,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -62945,6 +63760,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasIsAliasSamplesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -62988,6 +63804,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63011,6 +63828,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63126,6 +63944,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63181,6 +64000,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63212,6 +64032,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasSampleIsAliasSamplesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -63251,6 +64072,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasSampleIsAliasSamplesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -63326,6 +64148,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasSort",
         "description": "Fields to sort SampleAliases by. The order in which sorts are applied is not guaranteed when specifying many fields in one SampleAliasSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63361,6 +64184,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63416,6 +64240,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63747,6 +64572,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -63814,6 +64640,7 @@
         "kind": "OBJECT",
         "name": "SampleCohortCohortsHasCohortSampleAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -63853,9 +64680,26 @@
         "kind": "OBJECT",
         "name": "SampleCohortCohortsHasCohortSampleNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StringAggregateSelection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
             "description": null,
             "args": [],
             "type": {
@@ -63880,6 +64724,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64015,6 +64860,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64074,6 +64920,7 @@
         "kind": "OBJECT",
         "name": "SampleCohortsHasCohortSampleConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -64141,6 +64988,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64164,6 +65012,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64239,6 +65088,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64266,6 +65116,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64301,6 +65152,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64336,6 +65188,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64387,6 +65240,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64620,6 +65474,186 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -64630,6 +65664,7 @@
         "kind": "OBJECT",
         "name": "SampleCohortsHasCohortSampleRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -64673,6 +65708,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64696,6 +65732,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64811,6 +65848,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64962,6 +66000,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64989,6 +66028,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65156,6 +66196,7 @@
         "kind": "OBJECT",
         "name": "SampleDbGapHasDbgapDbGapsAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -65195,6 +66236,7 @@
         "kind": "OBJECT",
         "name": "SampleDbGapHasDbgapDbGapsNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dbGapStudy",
@@ -65238,6 +66280,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65389,6 +66432,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65540,6 +66584,7 @@
         "kind": "OBJECT",
         "name": "SampleEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -65583,6 +66628,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65718,6 +66764,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65777,6 +66824,7 @@
         "kind": "OBJECT",
         "name": "SampleHasDbgapDbGapsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -65844,6 +66892,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65867,6 +66916,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65942,6 +66992,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65969,6 +67020,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66004,6 +67056,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66039,6 +67092,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66090,6 +67144,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66513,6 +67568,7 @@
         "kind": "OBJECT",
         "name": "SampleHasDbgapDbGapsRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -66556,6 +67612,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66579,6 +67636,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66694,6 +67752,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66829,6 +67888,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66888,6 +67948,7 @@
         "kind": "OBJECT",
         "name": "SampleHasMetadataSampleMetadataConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -66955,6 +68016,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66978,6 +68040,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -67053,6 +68116,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -67080,6 +68144,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -67115,6 +68180,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -67150,6 +68216,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -67201,6 +68268,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72004,6 +73072,7 @@
         "kind": "OBJECT",
         "name": "SampleHasMetadataSampleMetadataRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -72047,6 +73116,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72070,6 +73140,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72185,6 +73256,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72320,6 +73392,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72379,6 +73452,7 @@
         "kind": "OBJECT",
         "name": "SampleHasTempoTemposConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -72446,6 +73520,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72469,6 +73544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72544,6 +73620,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72571,6 +73648,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72606,6 +73684,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72641,6 +73720,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72692,6 +73772,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -74015,6 +75096,7 @@
         "kind": "OBJECT",
         "name": "SampleHasTempoTemposRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -74058,6 +75140,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -74081,6 +75164,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -74196,6 +75280,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadata",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "additionalProperties",
@@ -74925,6 +76010,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "additionalProperties",
@@ -75368,6 +76454,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -75419,6 +76506,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -75446,6 +76534,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -75513,6 +76602,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -75900,6 +76990,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -75951,6 +77042,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76002,6 +77094,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -76045,6 +77138,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76180,6 +77274,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76239,6 +77334,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataHasStatusStatusesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -76306,6 +77402,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76329,6 +77426,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76404,6 +77502,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76431,6 +77530,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76466,6 +77566,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76501,6 +77602,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76552,6 +77654,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76795,6 +77898,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataHasStatusStatusesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -76838,6 +77942,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76861,6 +77966,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76976,6 +78082,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77031,6 +78138,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77082,6 +78190,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataSampleSamplesHasMetadataAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -77121,6 +78230,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataSampleSamplesHasMetadataNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -77196,6 +78306,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77331,6 +78442,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77390,6 +78502,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataSamplesHasMetadataConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -77457,6 +78570,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77480,6 +78594,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77555,6 +78670,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77582,6 +78698,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77617,6 +78734,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77652,6 +78770,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77703,6 +78822,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -78486,6 +79606,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataSamplesHasMetadataRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -78529,6 +79650,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -78552,6 +79674,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -78667,6 +79790,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSort",
         "description": "Fields to sort SampleMetadata by. The order in which sorts are applied is not guaranteed when specifying many fields in one SampleMetadataSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -79002,6 +80126,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataStatusHasStatusStatusesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -79041,6 +80166,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataStatusHasStatusStatusesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "validationReport",
@@ -79068,6 +80194,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -79467,6 +80594,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -81762,6 +82890,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -81817,6 +82946,7 @@
         "kind": "OBJECT",
         "name": "SamplePatientPatientsHasSampleAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -81856,6 +82986,7 @@
         "kind": "OBJECT",
         "name": "SamplePatientPatientsHasSampleNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "smilePatientId",
@@ -81883,6 +83014,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82018,6 +83150,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82077,6 +83210,7 @@
         "kind": "OBJECT",
         "name": "SamplePatientsHasSampleConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -82144,6 +83278,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82167,6 +83302,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82242,6 +83378,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82269,6 +83406,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82304,6 +83442,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82339,6 +83478,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82390,6 +83530,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82633,6 +83774,7 @@
         "kind": "OBJECT",
         "name": "SamplePatientsHasSampleRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -82676,6 +83818,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82699,6 +83842,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82814,6 +83958,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82965,6 +84110,7 @@
         "kind": "OBJECT",
         "name": "SampleRequestRequestsHasSampleAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -83004,6 +84150,7 @@
         "kind": "OBJECT",
         "name": "SampleRequestRequestsHasSampleNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dataAccessEmails",
@@ -83351,6 +84498,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83486,6 +84634,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83545,6 +84694,7 @@
         "kind": "OBJECT",
         "name": "SampleRequestsHasSampleConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -83612,6 +84762,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83635,6 +84786,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83710,6 +84862,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83737,6 +84890,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83772,6 +84926,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83807,6 +84962,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83858,6 +85014,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -87761,6 +88918,7 @@
         "kind": "OBJECT",
         "name": "SampleRequestsHasSampleRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -87804,6 +88962,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -87827,6 +88986,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -87942,6 +89102,7 @@
         "kind": "OBJECT",
         "name": "SampleSampleAliasSampleAliasesIsAliasAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -87981,6 +89142,7 @@
         "kind": "OBJECT",
         "name": "SampleSampleAliasSampleAliasesIsAliasNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "namespace",
@@ -88024,6 +89186,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88159,6 +89322,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88218,6 +89382,7 @@
         "kind": "OBJECT",
         "name": "SampleSampleAliasesIsAliasConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -88285,6 +89450,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88308,6 +89474,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88383,6 +89550,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88410,6 +89578,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88445,6 +89614,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88480,6 +89650,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88531,6 +89702,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88954,6 +90126,7 @@
         "kind": "OBJECT",
         "name": "SampleSampleAliasesIsAliasRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -88997,6 +90170,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -89020,6 +90194,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -89135,6 +90310,7 @@
         "kind": "OBJECT",
         "name": "SampleSampleMetadataHasMetadataSampleMetadataAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -89174,6 +90350,7 @@
         "kind": "OBJECT",
         "name": "SampleSampleMetadataHasMetadataSampleMetadataNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "additionalProperties",
@@ -89601,6 +90778,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSort",
         "description": "Fields to sort Samples by. The order in which sorts are applied is not guaranteed when specifying many fields in one SampleSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -89672,6 +90850,7 @@
         "kind": "OBJECT",
         "name": "SampleTempoHasTempoTemposAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -89711,6 +90890,7 @@
         "kind": "OBJECT",
         "name": "SampleTempoHasTempoTemposNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "accessLevel",
@@ -89834,6 +91014,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -90045,6 +91226,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -91192,6 +92374,7 @@
         "kind": "OBJECT",
         "name": "SamplesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -91259,6 +92442,7 @@
         "kind": "OBJECT",
         "name": "SeqDateAccessionBySampleId",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "DMP_SAMPLE_ID",
@@ -91314,6 +92498,7 @@
         "kind": "ENUM",
         "name": "SortDirection",
         "description": "An enum for sorting in either ascending or descending order.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -91337,6 +92522,7 @@
         "kind": "OBJECT",
         "name": "Status",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "requestMetadataHasStatus",
@@ -91738,6 +92924,7 @@
         "kind": "OBJECT",
         "name": "StatusAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -91781,6 +92968,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -91832,6 +93020,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -91859,6 +93048,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -91918,6 +93108,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -91969,6 +93160,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92020,6 +93212,7 @@
         "kind": "OBJECT",
         "name": "StatusEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -92063,6 +93256,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92118,6 +93312,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92169,6 +93364,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92304,6 +93500,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92363,6 +93560,7 @@
         "kind": "OBJECT",
         "name": "StatusRequestMetadataHasStatusConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -92430,6 +93628,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92453,6 +93652,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92528,6 +93728,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92555,6 +93756,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92590,6 +93792,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92625,6 +93828,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92676,6 +93880,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93339,6 +94544,7 @@
         "kind": "OBJECT",
         "name": "StatusRequestMetadataHasStatusRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -93382,6 +94588,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93405,6 +94612,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93520,6 +94728,7 @@
         "kind": "OBJECT",
         "name": "StatusRequestMetadataRequestMetadataHasStatusAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -93559,6 +94768,7 @@
         "kind": "OBJECT",
         "name": "StatusRequestMetadataRequestMetadataHasStatusNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "igoRequestId",
@@ -93618,6 +94828,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93753,6 +94964,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93812,6 +95024,7 @@
         "kind": "OBJECT",
         "name": "StatusSampleMetadataHasStatusConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -93879,6 +95092,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93902,6 +95116,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93977,6 +95192,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -94004,6 +95220,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -94039,6 +95256,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -94074,6 +95292,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -94125,6 +95344,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -98928,6 +100148,7 @@
         "kind": "OBJECT",
         "name": "StatusSampleMetadataHasStatusRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -98971,6 +100192,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -98994,6 +100216,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -99109,6 +100332,7 @@
         "kind": "OBJECT",
         "name": "StatusSampleMetadataSampleMetadataHasStatusAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -99148,6 +100372,7 @@
         "kind": "OBJECT",
         "name": "StatusSampleMetadataSampleMetadataHasStatusNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "additionalProperties",
@@ -99575,6 +100800,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSort",
         "description": "Fields to sort Statuses by. The order in which sorts are applied is not guaranteed when specifying many fields in one StatusSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -99610,6 +100836,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -99685,6 +100912,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -100052,6 +101280,7 @@
         "kind": "OBJECT",
         "name": "StatusesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -100119,6 +101348,7 @@
         "kind": "SCALAR",
         "name": "String",
         "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -100129,6 +101359,7 @@
         "kind": "OBJECT",
         "name": "StringAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "longest",
@@ -100164,6 +101395,7 @@
         "kind": "OBJECT",
         "name": "Tempo",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "accessLevel",
@@ -101007,6 +102239,7 @@
         "kind": "OBJECT",
         "name": "TempoAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "accessLevel",
@@ -101146,6 +102379,7 @@
         "kind": "OBJECT",
         "name": "TempoBamCompleteHasEventBamCompletesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -101185,6 +102419,7 @@
         "kind": "OBJECT",
         "name": "TempoBamCompleteHasEventBamCompletesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -101228,6 +102463,7 @@
         "kind": "OBJECT",
         "name": "TempoCohortRequest",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortId",
@@ -101359,6 +102595,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoCohortRequestInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101506,6 +102743,7 @@
         "kind": "OBJECT",
         "name": "TempoCohortSample",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cmoId",
@@ -101557,6 +102795,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoCohortSampleInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101608,6 +102847,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101699,6 +102939,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101726,6 +102967,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101885,6 +103127,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101976,6 +103219,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102067,6 +103311,7 @@
         "kind": "OBJECT",
         "name": "TempoEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -102110,6 +103355,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102245,6 +103491,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102304,6 +103551,7 @@
         "kind": "OBJECT",
         "name": "TempoHasEventBamCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -102371,6 +103619,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102394,6 +103643,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102469,6 +103719,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102496,6 +103747,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102531,6 +103783,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102566,6 +103819,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102617,6 +103871,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103040,6 +104295,7 @@
         "kind": "OBJECT",
         "name": "TempoHasEventBamCompletesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -103083,6 +104339,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103106,6 +104363,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103221,6 +104479,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103356,6 +104615,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103415,6 +104675,7 @@
         "kind": "OBJECT",
         "name": "TempoHasEventMafCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -103482,6 +104743,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103505,6 +104767,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103580,6 +104843,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103607,6 +104871,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103642,6 +104907,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103677,6 +104943,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103728,6 +104995,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104331,6 +105599,7 @@
         "kind": "OBJECT",
         "name": "TempoHasEventMafCompletesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -104374,6 +105643,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104397,6 +105667,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104512,6 +105783,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104647,6 +105919,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104706,6 +105979,7 @@
         "kind": "OBJECT",
         "name": "TempoHasEventQcCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -104773,6 +106047,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104796,6 +106071,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104871,6 +106147,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104898,6 +106175,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104933,6 +106211,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104968,6 +106247,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -105019,6 +106299,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -105802,6 +107083,7 @@
         "kind": "OBJECT",
         "name": "TempoHasEventQcCompletesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -105845,6 +107127,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -105868,6 +107151,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -105983,6 +107267,7 @@
         "kind": "OBJECT",
         "name": "TempoMafCompleteHasEventMafCompletesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -106022,6 +107307,7 @@
         "kind": "OBJECT",
         "name": "TempoMafCompleteHasEventMafCompletesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -106081,6 +107367,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106136,6 +107423,7 @@
         "kind": "OBJECT",
         "name": "TempoQcCompleteHasEventQcCompletesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -106175,6 +107463,7 @@
         "kind": "OBJECT",
         "name": "TempoQcCompleteHasEventQcCompletesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -106250,6 +107539,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106341,6 +107631,7 @@
         "kind": "OBJECT",
         "name": "TempoSampleSamplesHasTempoAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -106380,6 +107671,7 @@
         "kind": "OBJECT",
         "name": "TempoSampleSamplesHasTempoNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -106455,6 +107747,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106590,6 +107883,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106649,6 +107943,7 @@
         "kind": "OBJECT",
         "name": "TempoSamplesHasTempoConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -106716,6 +108011,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106739,6 +108035,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106814,6 +108111,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106841,6 +108139,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106876,6 +108175,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106911,6 +108211,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106962,6 +108263,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -107745,6 +109047,7 @@
         "kind": "OBJECT",
         "name": "TempoSamplesHasTempoRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -107788,6 +109091,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -107811,6 +109115,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -107926,6 +109231,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSort",
         "description": "Fields to sort Tempos by. The order in which sorts are applied is not guaranteed when specifying many fields in one TempoSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -108033,6 +109339,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -108220,6 +109527,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -109263,6 +110571,7 @@
         "kind": "OBJECT",
         "name": "TemposConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -109330,6 +110639,7 @@
         "kind": "OBJECT",
         "name": "ToleratedSampleValidationError",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "primaryId",
@@ -109381,6 +110691,7 @@
         "kind": "OBJECT",
         "name": "UpdateBamCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "bamCompletes",
@@ -109432,6 +110743,7 @@
         "kind": "OBJECT",
         "name": "UpdateCohortCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortCompletes",
@@ -109483,6 +110795,7 @@
         "kind": "OBJECT",
         "name": "UpdateCohortsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohorts",
@@ -109534,6 +110847,7 @@
         "kind": "OBJECT",
         "name": "UpdateDbGapsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dbGaps",
@@ -109585,6 +110899,7 @@
         "kind": "OBJECT",
         "name": "UpdateInfo",
         "description": "Information about the number of nodes and relationships created and deleted during an update mutation",
+        "isOneOf": null,
         "fields": [
           {
             "name": "bookmark",
@@ -109672,6 +110987,7 @@
         "kind": "OBJECT",
         "name": "UpdateMafCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109723,6 +111039,7 @@
         "kind": "OBJECT",
         "name": "UpdatePatientAliasesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109774,6 +111091,7 @@
         "kind": "OBJECT",
         "name": "UpdatePatientsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109825,6 +111143,7 @@
         "kind": "OBJECT",
         "name": "UpdateProjectsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109876,6 +111195,7 @@
         "kind": "OBJECT",
         "name": "UpdateQcCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109927,6 +111247,7 @@
         "kind": "OBJECT",
         "name": "UpdateRequestMetadataMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109978,6 +111299,7 @@
         "kind": "OBJECT",
         "name": "UpdateRequestsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -110029,6 +111351,7 @@
         "kind": "OBJECT",
         "name": "UpdateSampleAliasesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -110080,6 +111403,7 @@
         "kind": "OBJECT",
         "name": "UpdateSampleMetadataMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -110131,6 +111455,7 @@
         "kind": "OBJECT",
         "name": "UpdateSamplesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -110182,6 +111507,7 @@
         "kind": "OBJECT",
         "name": "UpdateStatusesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -110233,6 +111559,7 @@
         "kind": "OBJECT",
         "name": "UpdateTemposMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -110284,6 +111611,7 @@
         "kind": "OBJECT",
         "name": "ValidationAdvice",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "advice",
@@ -110335,6 +111663,7 @@
         "kind": "OBJECT",
         "name": "__Directive",
         "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+        "isOneOf": null,
         "fields": [
           {
             "name": "name",
@@ -110451,6 +111780,7 @@
         "kind": "ENUM",
         "name": "__DirectiveLocation",
         "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -110576,6 +111906,7 @@
         "kind": "OBJECT",
         "name": "__EnumValue",
         "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+        "isOneOf": null,
         "fields": [
           {
             "name": "name",
@@ -110643,6 +111974,7 @@
         "kind": "OBJECT",
         "name": "__Field",
         "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+        "isOneOf": null,
         "fields": [
           {
             "name": "name",
@@ -110763,6 +112095,7 @@
         "kind": "OBJECT",
         "name": "__InputValue",
         "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+        "isOneOf": null,
         "fields": [
           {
             "name": "name",
@@ -110858,6 +112191,7 @@
         "kind": "OBJECT",
         "name": "__Schema",
         "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+        "isOneOf": null,
         "fields": [
           {
             "name": "description",
@@ -110969,6 +112303,7 @@
         "kind": "OBJECT",
         "name": "__Type",
         "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByURL`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+        "isOneOf": null,
         "fields": [
           {
             "name": "kind",
@@ -111172,6 +112507,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "isOneOf",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -111183,6 +112530,7 @@
         "kind": "ENUM",
         "name": "__TypeKind",
         "description": "An enum describing what kind of type a given `__Type` is.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -111292,6 +112640,15 @@
             "deprecationReason": null
           }
         ]
+      },
+      {
+        "name": "oneOf",
+        "description": "Indicates exactly one field must be supplied and this field must not be `null`.",
+        "isRepeatable": false,
+        "locations": [
+          "INPUT_OBJECT"
+        ],
+        "args": []
       },
       {
         "name": "skip",

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -300,6 +300,21 @@ query AllBlockedCohortIds {
   allBlockedCohortIds
 }
 
+query GetValidationAdvice(
+  $validationReport: String!
+  $recordType: String!
+  $recordId: String
+) {
+  getValidationAdvice(
+    validationReport: $validationReport
+    recordType: $recordType
+    recordId: $recordId
+  ) {
+    advice
+    suggestedSteps
+  }
+}
+
 query AllAnchorSeqDateData($phiEnabled: Boolean = false) {
   allAnchorSeqDateData(phiEnabled: $phiEnabled) {
     MRN

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -304,11 +304,13 @@ query GetValidationAdvice(
   $validationReport: String!
   $recordType: String!
   $recordId: String
+  $igoQcReports: String
 ) {
   getValidationAdvice(
     validationReport: $validationReport
     recordType: $recordType
     recordId: $recordId
+    igoQcReports: $igoQcReports
   ) {
     advice
     suggestedSteps

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "alisman <lisman.aaron@gmail.com>",
   "private": true,
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "workspaces": [
     "frontend",
     "graphql-server",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,13 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
+"@anthropic-ai/sdk@^0.91.1":
+  version "0.91.1"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.91.1.tgz#09eeee4b12b91ba6d827ca249c2ede61e521aa00"
+  integrity sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==
+  dependencies:
+    json-schema-to-ts "^3.1.1"
+
 "@apideck/better-ajv-errors@^0.3.1":
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz#89238f689d81a644139a47e0ebc2e236bca1ff2c"
@@ -209,29 +216,6 @@
   dependencies:
     xss "^1.0.8"
 
-"@ardatan/relay-compiler@12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@ardatan/relay-compiler/-/relay-compiler-12.0.0.tgz#2e4cca43088e807adc63450e8cab037020e91106"
-  integrity sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==
-  dependencies:
-    "@babel/core" "^7.14.0"
-    "@babel/generator" "^7.14.0"
-    "@babel/parser" "^7.14.0"
-    "@babel/runtime" "^7.0.0"
-    "@babel/traverse" "^7.14.0"
-    "@babel/types" "^7.0.0"
-    babel-preset-fbjs "^3.4.0"
-    chalk "^4.0.0"
-    fb-watchman "^2.0.0"
-    fbjs "^3.0.0"
-    glob "^7.1.1"
-    immutable "~3.7.6"
-    invariant "^2.2.4"
-    nullthrows "^1.1.1"
-    relay-runtime "12.0.0"
-    signedsource "^1.0.0"
-    yargs "^15.3.1"
-
 "@ardatan/relay-compiler@^13.0.1":
   version "13.0.1"
   resolved "https://registry.yarnpkg.com/@ardatan/relay-compiler/-/relay-compiler-13.0.1.tgz#b00a4c1f986156fa2472db8036e9087877d37be3"
@@ -257,12 +241,12 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
-"@babel/compat-data@^7.20.5", "@babel/compat-data@^7.28.6", "@babel/compat-data@^7.29.0":
+"@babel/compat-data@^7.28.6", "@babel/compat-data@^7.29.0":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.0.tgz#00d03e8c0ac24dd9be942c5370990cbe1f17d88d"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
-"@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.12.3", "@babel/core@^7.14.0", "@babel/core@^7.16.0", "@babel/core@^7.28.6", "@babel/core@^7.7.2", "@babel/core@^7.8.0":
+"@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.28.6", "@babel/core@^7.7.2", "@babel/core@^7.8.0":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.0.tgz#5286ad785df7f79d656e88ce86e650d16ca5f322"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
@@ -301,7 +285,7 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     jsesc "^2.5.1"
 
-"@babel/generator@^7.14.0", "@babel/generator@^7.18.13", "@babel/generator@^7.29.0", "@babel/generator@^7.7.2":
+"@babel/generator@^7.18.13", "@babel/generator@^7.29.0", "@babel/generator@^7.7.2":
   version "7.29.1"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.1.tgz#d09876290111abbb00ef962a7b83a5307fba0d50"
   integrity sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==
@@ -319,7 +303,7 @@
   dependencies:
     "@babel/types" "^7.27.3"
 
-"@babel/helper-compilation-targets@^7.20.7", "@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.28.6":
+"@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz#32c4a3f41f12ed1532179b108a4d746e105c2b25"
   integrity sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==
@@ -463,7 +447,7 @@
     "@babel/template" "^7.28.6"
     "@babel/types" "^7.29.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.1.3", "@babel/parser@^7.14.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.28.6", "@babel/parser@^7.29.0", "@babel/parser@^7.29.2":
+"@babel/parser@^7.1.0", "@babel/parser@^7.1.3", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.28.6", "@babel/parser@^7.29.0", "@babel/parser@^7.29.2":
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.2.tgz#58bd50b9a7951d134988a1ae177a35ef9a703ba1"
   integrity sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==
@@ -509,7 +493,7 @@
     "@babel/helper-plugin-utils" "^7.28.6"
     "@babel/traverse" "^7.28.6"
 
-"@babel/plugin-proposal-class-properties@^7.0.0", "@babel/plugin-proposal-class-properties@^7.16.0":
+"@babel/plugin-proposal-class-properties@^7.16.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz#b110f59741895f7ec21a6fff696ec46265c446a3"
   integrity sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==
@@ -541,17 +525,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
-
-"@babel/plugin-proposal-object-rest-spread@^7.0.0":
-  version "7.20.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz#aa662940ef425779c75534a5c41e9d936edc390a"
-  integrity sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==
-  dependencies:
-    "@babel/compat-data" "^7.20.5"
-    "@babel/helper-compilation-targets" "^7.20.7"
-    "@babel/helper-plugin-utils" "^7.20.2"
-    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
-    "@babel/plugin-transform-parameters" "^7.20.7"
 
 "@babel/plugin-proposal-optional-chaining@^7.16.0":
   version "7.21.0"
@@ -599,7 +572,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-class-properties@^7.0.0", "@babel/plugin-syntax-class-properties@^7.12.13":
+"@babel/plugin-syntax-class-properties@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz#b5c987274c4a3a82b89714796931a6b53544ae10"
   integrity sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
@@ -620,7 +593,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.28.6"
 
-"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.27.1":
+"@babel/plugin-syntax-flow@^7.27.1":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.28.6.tgz#447559a225e66c4cd477a3ffb1a74d8c1fe25a62"
   integrity sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==
@@ -655,7 +628,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.0.0", "@babel/plugin-syntax-jsx@^7.22.5", "@babel/plugin-syntax-jsx@^7.27.1", "@babel/plugin-syntax-jsx@^7.28.6":
+"@babel/plugin-syntax-jsx@^7.22.5", "@babel/plugin-syntax-jsx@^7.27.1", "@babel/plugin-syntax-jsx@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz#f8ca28bbd84883b5fea0e447c635b81ba73997ee"
   integrity sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==
@@ -683,7 +656,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
+"@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
   integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
@@ -733,7 +706,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-arrow-functions@^7.0.0", "@babel/plugin-transform-arrow-functions@^7.27.1":
+"@babel/plugin-transform-arrow-functions@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz#6e2061067ba3ab0266d834a9f94811196f2aba9a"
   integrity sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==
@@ -758,14 +731,14 @@
     "@babel/helper-plugin-utils" "^7.28.6"
     "@babel/helper-remap-async-to-generator" "^7.27.1"
 
-"@babel/plugin-transform-block-scoped-functions@^7.0.0", "@babel/plugin-transform-block-scoped-functions@^7.27.1":
+"@babel/plugin-transform-block-scoped-functions@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz#558a9d6e24cf72802dd3b62a4b51e0d62c0f57f9"
   integrity sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-block-scoping@^7.0.0", "@babel/plugin-transform-block-scoping@^7.28.6":
+"@babel/plugin-transform-block-scoping@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz#e1ef5633448c24e76346125c2534eeb359699a99"
   integrity sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==
@@ -788,7 +761,7 @@
     "@babel/helper-create-class-features-plugin" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"
 
-"@babel/plugin-transform-classes@^7.0.0", "@babel/plugin-transform-classes@^7.28.6":
+"@babel/plugin-transform-classes@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz#8f6fb79ba3703978e701ce2a97e373aae7dda4b7"
   integrity sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==
@@ -800,7 +773,7 @@
     "@babel/helper-replace-supers" "^7.28.6"
     "@babel/traverse" "^7.28.6"
 
-"@babel/plugin-transform-computed-properties@^7.0.0", "@babel/plugin-transform-computed-properties@^7.28.6":
+"@babel/plugin-transform-computed-properties@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz#936824fc71c26cb5c433485776d79c8e7b0202d2"
   integrity sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==
@@ -808,7 +781,7 @@
     "@babel/helper-plugin-utils" "^7.28.6"
     "@babel/template" "^7.28.6"
 
-"@babel/plugin-transform-destructuring@^7.0.0", "@babel/plugin-transform-destructuring@^7.28.5":
+"@babel/plugin-transform-destructuring@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz#b8402764df96179a2070bb7b501a1586cf8ad7a7"
   integrity sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==
@@ -868,7 +841,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-flow-strip-types@^7.0.0", "@babel/plugin-transform-flow-strip-types@^7.16.0":
+"@babel/plugin-transform-flow-strip-types@^7.16.0":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz#5def3e1e7730f008d683144fb79b724f92c5cdf9"
   integrity sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==
@@ -876,7 +849,7 @@
     "@babel/helper-plugin-utils" "^7.27.1"
     "@babel/plugin-syntax-flow" "^7.27.1"
 
-"@babel/plugin-transform-for-of@^7.0.0", "@babel/plugin-transform-for-of@^7.27.1":
+"@babel/plugin-transform-for-of@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz#bc24f7080e9ff721b63a70ac7b2564ca15b6c40a"
   integrity sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==
@@ -884,7 +857,7 @@
     "@babel/helper-plugin-utils" "^7.27.1"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
 
-"@babel/plugin-transform-function-name@^7.0.0", "@babel/plugin-transform-function-name@^7.27.1":
+"@babel/plugin-transform-function-name@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz#4d0bf307720e4dce6d7c30fcb1fd6ca77bdeb3a7"
   integrity sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==
@@ -900,7 +873,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.28.6"
 
-"@babel/plugin-transform-literals@^7.0.0", "@babel/plugin-transform-literals@^7.27.1":
+"@babel/plugin-transform-literals@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz#baaefa4d10a1d4206f9dcdda50d7d5827bb70b24"
   integrity sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==
@@ -914,7 +887,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.28.6"
 
-"@babel/plugin-transform-member-expression-literals@^7.0.0", "@babel/plugin-transform-member-expression-literals@^7.27.1":
+"@babel/plugin-transform-member-expression-literals@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz#37b88ba594d852418e99536f5612f795f23aeaf9"
   integrity sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==
@@ -929,7 +902,7 @@
     "@babel/helper-module-transforms" "^7.27.1"
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-modules-commonjs@^7.0.0", "@babel/plugin-transform-modules-commonjs@^7.27.1", "@babel/plugin-transform-modules-commonjs@^7.28.6":
+"@babel/plugin-transform-modules-commonjs@^7.27.1", "@babel/plugin-transform-modules-commonjs@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz#c0232e0dfe66a734cc4ad0d5e75fc3321b6fdef1"
   integrity sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==
@@ -995,7 +968,7 @@
     "@babel/plugin-transform-parameters" "^7.27.7"
     "@babel/traverse" "^7.28.6"
 
-"@babel/plugin-transform-object-super@^7.0.0", "@babel/plugin-transform-object-super@^7.27.1":
+"@babel/plugin-transform-object-super@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz#1c932cd27bf3874c43a5cac4f43ebf970c9871b5"
   integrity sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==
@@ -1018,7 +991,7 @@
     "@babel/helper-plugin-utils" "^7.28.6"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
 
-"@babel/plugin-transform-parameters@^7.0.0", "@babel/plugin-transform-parameters@^7.20.7", "@babel/plugin-transform-parameters@^7.27.7":
+"@babel/plugin-transform-parameters@^7.27.7":
   version "7.27.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz#1fd2febb7c74e7d21cf3b05f7aebc907940af53a"
   integrity sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==
@@ -1042,7 +1015,7 @@
     "@babel/helper-create-class-features-plugin" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"
 
-"@babel/plugin-transform-property-literals@^7.0.0", "@babel/plugin-transform-property-literals@^7.27.1":
+"@babel/plugin-transform-property-literals@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz#07eafd618800591e88073a0af1b940d9a42c6424"
   integrity sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==
@@ -1056,7 +1029,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-react-display-name@^7.0.0", "@babel/plugin-transform-react-display-name@^7.16.0", "@babel/plugin-transform-react-display-name@^7.28.0":
+"@babel/plugin-transform-react-display-name@^7.16.0", "@babel/plugin-transform-react-display-name@^7.28.0":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz#6f20a7295fea7df42eb42fed8f896813f5b934de"
   integrity sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==
@@ -1070,7 +1043,7 @@
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.27.1"
 
-"@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.27.1":
+"@babel/plugin-transform-react-jsx@^7.27.1":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz#f51cb70a90b9529fbb71ee1f75ea27b7078eed62"
   integrity sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==
@@ -1123,14 +1096,14 @@
     babel-plugin-polyfill-regenerator "^0.6.5"
     semver "^6.3.1"
 
-"@babel/plugin-transform-shorthand-properties@^7.0.0", "@babel/plugin-transform-shorthand-properties@^7.27.1":
+"@babel/plugin-transform-shorthand-properties@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz#532abdacdec87bfee1e0ef8e2fcdee543fe32b90"
   integrity sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-spread@^7.0.0", "@babel/plugin-transform-spread@^7.28.6":
+"@babel/plugin-transform-spread@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz#40a2b423f6db7b70f043ad027a58bcb44a9757b6"
   integrity sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==
@@ -1145,7 +1118,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-template-literals@^7.0.0", "@babel/plugin-transform-template-literals@^7.27.1":
+"@babel/plugin-transform-template-literals@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz#1a0eb35d8bb3e6efc06c9fd40eb0bcef548328b8"
   integrity sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==
@@ -1309,7 +1282,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.28.5"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.24.7", "@babel/runtime@^7.26.0", "@babel/runtime@^7.29.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.24.7", "@babel/runtime@^7.26.0", "@babel/runtime@^7.29.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
@@ -1323,7 +1296,7 @@
     "@babel/parser" "^7.28.6"
     "@babel/types" "^7.28.6"
 
-"@babel/traverse@^7.14.0", "@babel/traverse@^7.26.10", "@babel/traverse@^7.27.1", "@babel/traverse@^7.28.5", "@babel/traverse@^7.28.6", "@babel/traverse@^7.29.0", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.2":
+"@babel/traverse@^7.26.10", "@babel/traverse@^7.27.1", "@babel/traverse@^7.28.5", "@babel/traverse@^7.28.6", "@babel/traverse@^7.29.0", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.2":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.0.tgz#f323d05001440253eead3c9c858adbe00b90310a"
   integrity sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==
@@ -1591,6 +1564,16 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
+"@google/genai@^1.50.1":
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/@google/genai/-/genai-1.51.0.tgz#5830dbbef23a290d088231c7b31ecd8668cfbc13"
+  integrity sha512-vTZZF3CSimN7cn2zsLpW2p5WF0eZa5Gz69ITMPCNHpPrDlAstOfGifSfi0p/s9Z9400f7xJRkgvkQNrcM7pJ6w==
+  dependencies:
+    google-auth-library "^10.3.0"
+    p-retry "^4.6.2"
+    protobufjs "^7.5.4"
+    ws "^8.18.0"
+
 "@graphql-codegen/add@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/add/-/add-5.0.3.tgz#1ede6bac9a93661ed7fa5808b203d079e1b1d215"
@@ -1680,38 +1663,14 @@
     auto-bind "~4.0.0"
     tslib "~2.6.0"
 
-"@graphql-codegen/introspection@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/introspection/-/introspection-2.2.0.tgz#52fb1b54476f9e272be3dba736abafcf1bcb083a"
-  integrity sha512-duIRd/o3SHEEwnxc+lx6v5y/DZEeesxCOusY+u8Bjh8ZBssh3wXcWsGSGhH1amfNMRTby+xsz7HiLW6Q4x7Qwg==
+"@graphql-codegen/introspection@4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/introspection/-/introspection-4.0.3.tgz#756e39fb4529ea15d32a122f0bce9b0a66425379"
+  integrity sha512-4cHRG15Zu4MXMF4wTQmywNf4+fkDYv5lTbzraVfliDnB8rJKcaurQpRBi11KVuQUe24YTq/Cfk4uwewfNikWoA==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.5.0"
-    "@graphql-codegen/visitor-plugin-common" "^2.11.0"
-    tslib "~2.4.0"
-
-"@graphql-codegen/plugin-helpers@^2.5.0":
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.2.tgz#6544f739d725441c826a8af6a49519f588ff9bed"
-  integrity sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==
-  dependencies:
-    "@graphql-tools/utils" "^8.8.0"
-    change-case-all "1.0.14"
-    common-tags "1.8.2"
-    import-from "4.0.0"
-    lodash "~4.17.0"
-    tslib "~2.4.0"
-
-"@graphql-codegen/plugin-helpers@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz#69a2e91178f478ea6849846ade0a59a844d34389"
-  integrity sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==
-  dependencies:
-    "@graphql-tools/utils" "^9.0.0"
-    change-case-all "1.0.15"
-    common-tags "1.8.2"
-    import-from "4.0.0"
-    lodash "~4.17.0"
-    tslib "~2.4.0"
+    "@graphql-codegen/plugin-helpers" "^5.0.3"
+    "@graphql-codegen/visitor-plugin-common" "^5.0.0"
+    tslib "~2.6.0"
 
 "@graphql-codegen/plugin-helpers@^5.0.0", "@graphql-codegen/plugin-helpers@^5.0.3", "@graphql-codegen/plugin-helpers@^5.1.0", "@graphql-codegen/plugin-helpers@^5.1.1":
   version "5.1.1"
@@ -1725,14 +1684,16 @@
     lodash "~4.17.0"
     tslib "~2.6.0"
 
-"@graphql-codegen/schema-ast@^2.5.0", "@graphql-codegen/schema-ast@^2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/schema-ast/-/schema-ast-2.6.1.tgz#8ba1b38827c034b51ecd3ce88622c2ae6cd3fe1a"
-  integrity sha512-5TNW3b1IHJjCh07D2yQNGDQzUpUl2AD+GVe1Dzjqyx/d2Fn0TPMxLsHsKPS4Plg4saO8FK/QO70wLsP7fdbQ1w==
+"@graphql-codegen/plugin-helpers@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.3.0.tgz#d4ba4660c68cb703291fbc6616a6510df26dd5f3"
+  integrity sha512-Auc+/B7okDx9+pVgLVliZtZLYh6iltWXlnzzM+bRE+zh1T4r3hKbnr8xAmtT937ArfSgk5GHcQHr8LfPYnrRBg==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^3.1.2"
-    "@graphql-tools/utils" "^9.0.0"
-    tslib "~2.4.0"
+    "@graphql-tools/utils" "^11.0.0"
+    change-case-all "1.0.15"
+    common-tags "1.8.2"
+    import-from "4.0.0"
+    tslib "^2.8.0"
 
 "@graphql-codegen/schema-ast@^4.0.2":
   version "4.1.0"
@@ -1754,16 +1715,16 @@
     change-case-all "1.0.15"
     tslib "~2.6.0"
 
-"@graphql-codegen/typescript-operations@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-2.5.1.tgz#99a6f3b3086214086582d2731058ec74090da308"
-  integrity sha512-lGv+sPDXGcp/vDdIh7SoQjz8BRCZhLats4Hbqnf6gB7UtIasMvGuFDQyrKb3XAkQQYWqx/xtmEo0rBN8syV+Wg==
+"@graphql-codegen/typescript-operations@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-4.5.1.tgz#59995370aa257daf517e3419265ed587522b44df"
+  integrity sha512-KL+sYPm7GWHwVvFPVaaWSOv9WF7PDxkmOX8DEBtzqTYez5xCWqtCz7LIrwzmtDd7XoJGkRpWlyrHdpuw5VakhA==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.5.0"
-    "@graphql-codegen/typescript" "^2.7.1"
-    "@graphql-codegen/visitor-plugin-common" "2.11.1"
+    "@graphql-codegen/plugin-helpers" "^5.1.0"
+    "@graphql-codegen/typescript" "^4.1.5"
+    "@graphql-codegen/visitor-plugin-common" "5.7.1"
     auto-bind "~4.0.0"
-    tslib "~2.4.0"
+    tslib "~2.6.0"
 
 "@graphql-codegen/typescript-operations@^4.6.1":
   version "4.6.1"
@@ -1776,40 +1737,18 @@
     auto-bind "~4.0.0"
     tslib "~2.6.0"
 
-"@graphql-codegen/typescript-react-apollo@3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-react-apollo/-/typescript-react-apollo-3.3.1.tgz#fb92c1ffd4ca14c2d72fd4eb625b4a612c3a3116"
-  integrity sha512-YZaQyhPfD3yDKdUU9IBzALLxLeUC9GkTxxkR6OmaGv3acthMLgyt+TwcYAbIrb+wIjB2INk8waP1V4vklHZ2qA==
+"@graphql-codegen/typescript-react-apollo@4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-react-apollo/-/typescript-react-apollo-4.4.2.tgz#37f10af85a01ff3a752264ba16f1d3cede87e254"
+  integrity sha512-S/VQeLWMNzo/WnUpvCQELqh2qgAK4H9kkWyC8JrrrPHaV3w/BmOwzeHpcwlHKcuSYWRH6u61XPRQ5+eCjj00AQ==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.5.0"
-    "@graphql-codegen/visitor-plugin-common" "2.11.1"
+    "@graphql-codegen/plugin-helpers" "^6.3.0"
+    "@graphql-codegen/visitor-plugin-common" "^6.3.0"
     auto-bind "~4.0.0"
-    change-case-all "1.0.14"
-    tslib "~2.4.0"
+    change-case-all "1.0.15"
+    tslib "^2.8.1"
 
-"@graphql-codegen/typescript@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.7.1.tgz#e237dd8829842282245b79ce7ea024aaa3c39afb"
-  integrity sha512-qF4SBMgBnLcegba2s9+zC3NwgRhU0Kv+eS8kl9G5ldEHx9Bpu2tft+lk6fjqqhExDzJT+MEOU3Ecog3BzL2R1g==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.5.0"
-    "@graphql-codegen/schema-ast" "^2.5.0"
-    "@graphql-codegen/visitor-plugin-common" "2.11.1"
-    auto-bind "~4.0.0"
-    tslib "~2.4.0"
-
-"@graphql-codegen/typescript@^2.7.1":
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.8.8.tgz#8c3b9153e334db43c65f8f31ced69b4c60d14861"
-  integrity sha512-A0oUi3Oy6+DormOlrTC4orxT9OBZkIglhbJBcDmk34jAKKUgesukXRd4yOhmTrnbchpXz2T8IAOFB3FWIaK4Rw==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^3.1.2"
-    "@graphql-codegen/schema-ast" "^2.6.1"
-    "@graphql-codegen/visitor-plugin-common" "2.13.8"
-    auto-bind "~4.0.0"
-    tslib "~2.4.0"
-
-"@graphql-codegen/typescript@^4.0.0", "@graphql-codegen/typescript@^4.1.6":
+"@graphql-codegen/typescript@4.1.6", "@graphql-codegen/typescript@^4.0.0", "@graphql-codegen/typescript@^4.1.5", "@graphql-codegen/typescript@^4.1.6":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-4.1.6.tgz#f3481ccc1656e96892d629671fb2cff5dabc458b"
   integrity sha512-vpw3sfwf9A7S+kIUjyFxuvrywGxd4lmwmyYnnDVjVE4kSQ6Td3DpqaPTy8aNQ6O96vFoi/bxbZS2BW49PwSUUA==
@@ -1820,39 +1759,23 @@
     auto-bind "~4.0.0"
     tslib "~2.6.0"
 
-"@graphql-codegen/visitor-plugin-common@2.11.1":
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.11.1.tgz#2653e25a8888767a6422a204441083299c3a83a4"
-  integrity sha512-AlrtGWKn2o89SPna75ATEHYAu95MUMucgBqLgcRvK9n/PHhVAbkDrNCH5pL03fE0HLOup3GpjX8DcnFBMU46IA==
+"@graphql-codegen/visitor-plugin-common@5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-5.7.1.tgz#45852ff994d6fba9aa24c84bea199663b159e8a9"
+  integrity sha512-jnBjDN7IghoPy1TLqIE1E4O0XcoRc7dJOHENkHvzGhu0SnvPL6ZgJxkQiADI4Vg2hj/4UiTGqo8q/GRoZz22lQ==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.5.0"
-    "@graphql-tools/optimize" "^1.3.0"
-    "@graphql-tools/relay-operation-optimizer" "^6.5.0"
-    "@graphql-tools/utils" "^8.8.0"
-    auto-bind "~4.0.0"
-    change-case-all "1.0.14"
-    dependency-graph "^0.11.0"
-    graphql-tag "^2.11.0"
-    parse-filepath "^1.0.2"
-    tslib "~2.4.0"
-
-"@graphql-codegen/visitor-plugin-common@2.13.8", "@graphql-codegen/visitor-plugin-common@^2.11.0":
-  version "2.13.8"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.8.tgz#09bc6317b227e5a278f394f4cef0d6c2d1910597"
-  integrity sha512-IQWu99YV4wt8hGxIbBQPtqRuaWZhkQRG2IZKbMoSvh0vGeWb3dB0n0hSgKaOOxDY+tljtOf9MTcUYvJslQucMQ==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^3.1.2"
-    "@graphql-tools/optimize" "^1.3.0"
-    "@graphql-tools/relay-operation-optimizer" "^6.5.0"
-    "@graphql-tools/utils" "^9.0.0"
+    "@graphql-codegen/plugin-helpers" "^5.1.0"
+    "@graphql-tools/optimize" "^2.0.0"
+    "@graphql-tools/relay-operation-optimizer" "^7.0.0"
+    "@graphql-tools/utils" "^10.0.0"
     auto-bind "~4.0.0"
     change-case-all "1.0.15"
     dependency-graph "^0.11.0"
     graphql-tag "^2.11.0"
     parse-filepath "^1.0.2"
-    tslib "~2.4.0"
+    tslib "~2.6.0"
 
-"@graphql-codegen/visitor-plugin-common@5.8.0", "@graphql-codegen/visitor-plugin-common@^5.8.0":
+"@graphql-codegen/visitor-plugin-common@5.8.0", "@graphql-codegen/visitor-plugin-common@^5.0.0", "@graphql-codegen/visitor-plugin-common@^5.8.0":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-5.8.0.tgz#1b796453eb96d8e6ad5d4d3acff304e4672781a0"
   integrity sha512-lC1E1Kmuzi3WZUlYlqB4fP6+CvbKH9J+haU1iWmgsBx5/sO2ROeXJG4Dmt8gP03bI2BwjiwV5WxCEMlyeuzLnA==
@@ -1867,6 +1790,22 @@
     graphql-tag "^2.11.0"
     parse-filepath "^1.0.2"
     tslib "~2.6.0"
+
+"@graphql-codegen/visitor-plugin-common@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.3.0.tgz#5c3d1b6397acd27a552beab989c5d8af155e2aef"
+  integrity sha512-vGBoE+4huzZyNhyGSAhXAkdROHlwKxxuziZm4XtP1mxe7nuI+VgyOmXebafLijbmuDsptPXQN0C/htL54O8hrg==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^6.3.0"
+    "@graphql-tools/optimize" "^2.0.0"
+    "@graphql-tools/relay-operation-optimizer" "^7.1.1"
+    "@graphql-tools/utils" "^11.0.0"
+    auto-bind "~4.0.0"
+    change-case-all "1.0.15"
+    dependency-graph "^1.0.0"
+    graphql-tag "^2.11.0"
+    parse-filepath "^1.0.2"
+    tslib "^2.8.0"
 
 "@graphql-tools/apollo-engine-loader@8.0.12", "@graphql-tools/apollo-engine-loader@^8.0.0":
   version "8.0.12"
@@ -2080,13 +2019,6 @@
     fast-json-stable-stringify "^2.1.0"
     tslib "^2.4.0"
 
-"@graphql-tools/optimize@^1.3.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/optimize/-/optimize-1.4.0.tgz#20d6a9efa185ef8fc4af4fd409963e0907c6e112"
-  integrity sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==
-  dependencies:
-    tslib "^2.4.0"
-
 "@graphql-tools/optimize@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/optimize/-/optimize-2.0.0.tgz#7a9779d180824511248a50c5a241eff6e7a2d906"
@@ -2116,16 +2048,7 @@
     tslib "^2.4.0"
     yaml-ast-parser "^0.0.43"
 
-"@graphql-tools/relay-operation-optimizer@^6.5.0":
-  version "6.5.18"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.18.tgz#a1b74a8e0a5d0c795b8a4d19629b654cf66aa5ab"
-  integrity sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==
-  dependencies:
-    "@ardatan/relay-compiler" "12.0.0"
-    "@graphql-tools/utils" "^9.2.1"
-    tslib "^2.4.0"
-
-"@graphql-tools/relay-operation-optimizer@^7.0.0":
+"@graphql-tools/relay-operation-optimizer@^7.0.0", "@graphql-tools/relay-operation-optimizer@^7.1.1":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.1.4.tgz#6e25416d78d7bc8d92c64df89d39d30644c26042"
   integrity sha512-cwOD/GEo/R//1uGCP0/urIxsMFoUgzkJVyMt9BDM2HhQhU6rSgH5l6lFukAFTJyPJVdyeOdYm2i0Jj5vYWbHTw==
@@ -2219,7 +2142,7 @@
     cross-inspect "1.0.1"
     tslib "^2.4.0"
 
-"@graphql-tools/utils@^11.1.0":
+"@graphql-tools/utils@^11.0.0", "@graphql-tools/utils@^11.1.0":
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-11.1.0.tgz#03593c3ae1177e04a3620c688fd29df912aa094f"
   integrity sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag==
@@ -2229,14 +2152,7 @@
     cross-inspect "1.0.1"
     tslib "^2.4.0"
 
-"@graphql-tools/utils@^8.8.0":
-  version "8.13.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.13.1.tgz#b247607e400365c2cd87ff54654d4ad25a7ac491"
-  integrity sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==
-  dependencies:
-    tslib "^2.4.0"
-
-"@graphql-tools/utils@^9.0.0", "@graphql-tools/utils@^9.2.1":
+"@graphql-tools/utils@^9.2.1":
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-9.2.1.tgz#1b3df0ef166cfa3eae706e3518b17d5922721c57"
   integrity sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==
@@ -2259,6 +2175,11 @@
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
+
+"@hono/node-server@^1.19.9":
+  version "1.19.14"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
+  integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
@@ -2675,6 +2596,29 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
 
+"@modelcontextprotocol/sdk@^1.29.0":
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz#79786d8b525e269de850ac82b1f1f757f3915f44"
+  integrity sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==
+  dependencies:
+    "@hono/node-server" "^1.19.9"
+    ajv "^8.17.1"
+    ajv-formats "^3.0.1"
+    content-type "^1.0.5"
+    cors "^2.8.5"
+    cross-spawn "^7.0.5"
+    eventsource "^3.0.2"
+    eventsource-parser "^3.0.0"
+    express "^5.2.1"
+    express-rate-limit "^8.2.1"
+    hono "^4.11.4"
+    jose "^6.1.3"
+    json-schema-typed "^8.0.2"
+    pkce-challenge "^5.0.0"
+    raw-body "^3.0.0"
+    zod "^3.25 || ^4.0"
+    zod-to-json-schema "^3.25.1"
+
 "@neo4j/cypher-builder@^2.4.0":
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/@neo4j/cypher-builder/-/cypher-builder-2.12.0.tgz#dc4b3a83be8a29af74499bb5d8d27923fc5873da"
@@ -3080,7 +3024,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
   integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
 
-"@protobufjs/codegen@^2.0.4":
+"@protobufjs/codegen@^2.0.4", "@protobufjs/codegen@^2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
   integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
@@ -3103,7 +3047,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
   integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
 
-"@protobufjs/inquire@^1.1.0":
+"@protobufjs/inquire@^1.1.0", "@protobufjs/inquire@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.1.tgz#6cb936f4ac50965230af1e9d0bbfd57ea3675aa4"
   integrity sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==
@@ -3118,7 +3062,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
   integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
 
-"@protobufjs/utf8@^1.1.0":
+"@protobufjs/utf8@^1.1.0", "@protobufjs/utf8@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
   integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
@@ -3687,7 +3631,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=6":
+"@types/node@*", "@types/node@>=13.7.0", "@types/node@>=6":
   version "25.6.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.0.tgz#4e09bad9b469871f2d0f68140198cbd714f4edca"
   integrity sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==
@@ -4239,6 +4183,14 @@ accepts@^1.3.5, accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+accepts@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-2.0.0.tgz#bbcf4ba5075467f3f2131eab3cffc73c2f5d7895"
+  integrity sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==
+  dependencies:
+    mime-types "^3.0.0"
+    negotiator "^1.0.0"
+
 acorn-globals@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
@@ -4336,6 +4288,13 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
+ajv-formats@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
@@ -4358,7 +4317,7 @@ ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.0.1, ajv@^8.6.0, ajv@^8.9.0:
+ajv@^8.0.0, ajv@^8.0.1, ajv@^8.17.1, ajv@^8.6.0, ajv@^8.9.0:
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
   integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
@@ -4987,7 +4946,7 @@ arraybuffer.prototype.slice@^1.0.4:
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
 
-asap@~2.0.3, asap@~2.0.6:
+asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
@@ -5224,11 +5183,6 @@ babel-plugin-polyfill-regenerator@^0.6.5, babel-plugin-polyfill-regenerator@^0.6
     lodash "^4.17.21"
     picomatch "^2.3.1"
 
-babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
-  version "7.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
-  integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
-
 babel-plugin-transform-react-remove-prop-types@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
@@ -5254,39 +5208,6 @@ babel-preset-current-node-syntax@^1.0.0:
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
     "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
     "@babel/plugin-syntax-top-level-await" "^7.14.5"
-
-babel-preset-fbjs@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz#38a14e5a7a3b285a3f3a86552d650dca5cf6111c"
-  integrity sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "^7.0.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
-    "@babel/plugin-syntax-class-properties" "^7.0.0"
-    "@babel/plugin-syntax-flow" "^7.0.0"
-    "@babel/plugin-syntax-jsx" "^7.0.0"
-    "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
-    "@babel/plugin-transform-arrow-functions" "^7.0.0"
-    "@babel/plugin-transform-block-scoped-functions" "^7.0.0"
-    "@babel/plugin-transform-block-scoping" "^7.0.0"
-    "@babel/plugin-transform-classes" "^7.0.0"
-    "@babel/plugin-transform-computed-properties" "^7.0.0"
-    "@babel/plugin-transform-destructuring" "^7.0.0"
-    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
-    "@babel/plugin-transform-for-of" "^7.0.0"
-    "@babel/plugin-transform-function-name" "^7.0.0"
-    "@babel/plugin-transform-literals" "^7.0.0"
-    "@babel/plugin-transform-member-expression-literals" "^7.0.0"
-    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
-    "@babel/plugin-transform-object-super" "^7.0.0"
-    "@babel/plugin-transform-parameters" "^7.0.0"
-    "@babel/plugin-transform-property-literals" "^7.0.0"
-    "@babel/plugin-transform-react-display-name" "^7.0.0"
-    "@babel/plugin-transform-react-jsx" "^7.0.0"
-    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
-    "@babel/plugin-transform-spread" "^7.0.0"
-    "@babel/plugin-transform-template-literals" "^7.0.0"
-    babel-plugin-syntax-trailing-function-commas "^7.0.0-beta.0"
 
 babel-preset-jest@^27.5.1:
   version "27.5.1"
@@ -5324,7 +5245,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.3.1:
+base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -5374,6 +5295,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bignumber.js@^9.0.0:
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.1.tgz#759c5aaddf2ffdc4f154f7b493e1c8770f88c4d7"
+  integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
+
 binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
@@ -5410,6 +5336,21 @@ body-parser@^1.19.0, body-parser@~1.20.3:
     raw-body "~2.5.3"
     type-is "~1.6.18"
     unpipe "~1.0.0"
+
+body-parser@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-2.2.2.tgz#1a32cdb966beaf68de50a9dfbe5b58f83cb8890c"
+  integrity sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==
+  dependencies:
+    bytes "^3.1.2"
+    content-type "^1.0.5"
+    debug "^4.4.3"
+    http-errors "^2.0.0"
+    iconv-lite "^0.7.0"
+    on-finished "^2.4.1"
+    qs "^6.14.1"
+    raw-body "^3.0.1"
+    type-is "^2.0.1"
 
 bonjour-service@^1.0.11:
   version "1.3.0"
@@ -5479,6 +5420,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-equal-constant-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -5517,7 +5463,7 @@ byline@5.0.0:
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
   integrity sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==
 
-bytes@3.1.2, bytes@~3.1.2:
+bytes@3.1.2, bytes@^3.1.2, bytes@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
@@ -5566,7 +5512,7 @@ camelcase-css@^2.0.1:
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
-camelcase@^5.0.0, camelcase@^5.3.1:
+camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -5657,22 +5603,6 @@ chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-change-case-all@1.0.14:
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/change-case-all/-/change-case-all-1.0.14.tgz#bac04da08ad143278d0ac3dda7eccd39280bfba1"
-  integrity sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==
-  dependencies:
-    change-case "^4.1.2"
-    is-lower-case "^2.0.2"
-    is-upper-case "^2.0.2"
-    lower-case "^2.0.2"
-    lower-case-first "^2.0.2"
-    sponge-case "^1.0.1"
-    swap-case "^2.0.2"
-    title-case "^3.0.3"
-    upper-case "^2.0.2"
-    upper-case-first "^2.0.2"
 
 change-case-all@1.0.15:
   version "1.0.15"
@@ -5866,15 +5796,6 @@ cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
-
-cliui@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
-  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
-  dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
-    wrap-ansi "^6.2.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -6121,6 +6042,11 @@ constant-case@^3.0.4:
     tslib "^2.0.3"
     upper-case "^2.0.2"
 
+content-disposition@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.1.0.tgz#f3db789c752d45564cc7e9e1e0b31790d4a38e17"
+  integrity sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==
+
 content-disposition@~0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
@@ -6128,7 +6054,7 @@ content-disposition@~0.5.4:
   dependencies:
     safe-buffer "5.2.1"
 
-content-type@^1.0.4, content-type@~1.0.4, content-type@~1.0.5:
+content-type@^1.0.4, content-type@^1.0.5, content-type@~1.0.4, content-type@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
@@ -6143,12 +6069,17 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie-signature@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.2.2.tgz#57c7fc3cc293acab9fec54d73e15690ebe4a1793"
+  integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
+
 cookie-signature@~1.0.6, cookie-signature@~1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.7.tgz#ab5dd7ab757c54e60f37ef6550f481c426d10454"
   integrity sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==
 
-cookie@~0.7.1, cookie@~0.7.2:
+cookie@^0.7.1, cookie@~0.7.1, cookie@~0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
@@ -6248,7 +6179,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.5:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -6501,6 +6432,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
 data-uri-to-buffer@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz#8a58bb67384b261a38ef18bea1810cb01badd28b"
@@ -6569,7 +6505,7 @@ debug@2.6.9, debug@^2.6.0, debug@~2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.3:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -6582,11 +6518,6 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-decamelize@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-  integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
 decimal.js@^10.2.1:
   version "10.6.0"
@@ -6664,7 +6595,7 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-depd@2.0.0, depd@~2.0.0:
+depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
@@ -6678,6 +6609,11 @@ dependency-graph@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.11.0.tgz#ac0ce7ed68a54da22165a85e97a01d53f5eb2e27"
   integrity sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==
+
+dependency-graph@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-1.0.0.tgz#bb5e85aec1310bc13b22dbd76e3196c4ee4c10d2"
+  integrity sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==
 
 dequal@^2.0.3:
   version "2.0.3"
@@ -6902,6 +6838,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -6954,7 +6897,7 @@ enabled@2.0.x:
   resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
   integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
-encodeurl@~2.0.0:
+encodeurl@^2.0.0, encodeurl@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
@@ -7140,7 +7083,7 @@ escalade@^3.1.1, escalade@^3.2.0:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
@@ -7438,7 +7381,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-etag@~1.8.1:
+etag@^1.8.1, etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
@@ -7452,6 +7395,18 @@ events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
+eventsource-parser@^3.0.0, eventsource-parser@^3.0.1:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.8.tgz#1c792503e4080455d00701bb1f7a1d60734d0e58"
+  integrity sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==
+
+eventsource@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.7.tgz#1157622e2f5377bb6aef2114372728ba0c156989"
+  integrity sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==
+  dependencies:
+    eventsource-parser "^3.0.1"
 
 execa@^5.0.0:
   version "5.1.1"
@@ -7482,6 +7437,13 @@ expect@^27.5.1:
     jest-get-type "^27.5.1"
     jest-matcher-utils "^27.5.1"
     jest-message-util "^27.5.1"
+
+express-rate-limit@^8.2.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.4.1.tgz#15a769dbe7b97f94581ed0db2bcead644753574f"
+  integrity sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==
+  dependencies:
+    ip-address "10.1.0"
 
 express-session@^1.17.3:
   version "1.19.0"
@@ -7534,7 +7496,41 @@ express@^4.17.1, express@^4.17.3, express@^4.18.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-extend@~3.0.2:
+express@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
+  integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
+  dependencies:
+    accepts "^2.0.0"
+    body-parser "^2.2.1"
+    content-disposition "^1.0.0"
+    content-type "^1.0.5"
+    cookie "^0.7.1"
+    cookie-signature "^1.2.1"
+    debug "^4.4.0"
+    depd "^2.0.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    finalhandler "^2.1.0"
+    fresh "^2.0.0"
+    http-errors "^2.0.0"
+    merge-descriptors "^2.0.0"
+    mime-types "^3.0.0"
+    on-finished "^2.4.1"
+    once "^1.4.0"
+    parseurl "^1.3.3"
+    proxy-addr "^2.0.7"
+    qs "^6.14.0"
+    range-parser "^1.2.1"
+    router "^2.2.0"
+    send "^1.1.0"
+    serve-static "^2.2.0"
+    statuses "^2.0.1"
+    type-is "^2.0.1"
+    vary "^1.1.2"
+
+extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -7644,24 +7640,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fbjs-css-vars@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
-  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
-
-fbjs@^3.0.0:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-3.0.5.tgz#aa0edb7d5caa6340011790bd9249dbef8a81128d"
-  integrity sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==
-  dependencies:
-    cross-fetch "^3.1.5"
-    fbjs-css-vars "^1.0.0"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^1.0.35"
-
 fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
@@ -7671,6 +7649,14 @@ fecha@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
   integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
+
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
 
 figures@^1.7.0:
   version "1.7.0"
@@ -7732,6 +7718,18 @@ filter-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
   integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
+
+finalhandler@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-2.1.1.tgz#a2c517a6559852bcdb06d1f8bd7f51b68fad8099"
+  integrity sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==
+  dependencies:
+    debug "^4.4.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    on-finished "^2.4.1"
+    parseurl "^1.3.3"
+    statuses "^2.0.1"
 
 finalhandler@~1.3.1:
   version "1.3.2"
@@ -7876,6 +7874,13 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
+
 forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
@@ -7885,6 +7890,11 @@ fraction.js@^5.3.4:
   version "5.3.4"
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
+
+fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-2.0.0.tgz#8dd7df6a1b3a1b3a5cf186c05a5dd267622635a4"
+  integrity sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==
 
 fresh@~0.5.2:
   version "0.5.2"
@@ -7961,12 +7971,30 @@ functions-have-names@^1.2.3:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+gaxios@^7.0.0, gaxios@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.1.4.tgz#33a5b78e2c5c01cf5a5d17f58dd188839867fc9c"
+  integrity sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    node-fetch "^3.3.2"
+
 gaze@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/gaze/-/gaze-1.1.3.tgz#c441733e13b927ac8c0ff0b4c3b033f28812924a"
   integrity sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==
   dependencies:
     globule "^1.0.0"
+
+gcp-metadata@8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-8.1.2.tgz#e62e3373ddf41fc727ccc31c55c687b798bee898"
+  integrity sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==
+  dependencies:
+    gaxios "^7.0.0"
+    google-logging-utils "^1.0.0"
+    json-bigint "^1.0.0"
 
 generator-function@^2.0.0:
   version "2.0.1"
@@ -7978,7 +8006,7 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.1, get-caller-file@^2.0.5:
+get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -8208,6 +8236,23 @@ globule@^1.0.0:
     glob "~7.1.1"
     lodash "^4.17.21"
     minimatch "~3.0.2"
+
+google-auth-library@^10.3.0:
+  version "10.6.2"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.6.2.tgz#44557c536aec626b7cda48a85b5d026e2c9b74c4"
+  integrity sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==
+  dependencies:
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    gaxios "^7.1.4"
+    gcp-metadata "8.1.2"
+    google-logging-utils "1.1.3"
+    jws "^4.0.0"
+
+google-logging-utils@1.1.3, google-logging-utils@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz#17b71f1f95d266d2ddd356b8f00178433f041b17"
+  integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
 
 gopd@^1.0.1, gopd@^1.2.0:
   version "1.2.0"
@@ -8451,6 +8496,11 @@ hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.2:
   dependencies:
     react-is "^16.7.0"
 
+hono@^4.11.4:
+  version "4.12.16"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.16.tgz#90fcc63caa713199703bda08d8518f654e98b516"
+  integrity sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==
+
 hoopy@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.4.tgz#609207d661100033a9a9402ad3dea677381c1b1d"
@@ -8539,6 +8589,17 @@ http-deceiver@^1.2.7:
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
   integrity sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==
 
+http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.0, http-errors@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
+  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
+  dependencies:
+    depd "~2.0.0"
+    inherits "~2.0.4"
+    setprototypeof "~1.2.0"
+    statuses "~2.0.2"
+    toidentifier "~1.0.1"
+
 http-errors@~1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
@@ -8549,17 +8610,6 @@ http-errors@~1.8.0:
     setprototypeof "1.2.0"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.1"
-
-http-errors@~2.0.0, http-errors@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
-  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
-  dependencies:
-    depd "~2.0.0"
-    inherits "~2.0.4"
-    setprototypeof "~1.2.0"
-    statuses "~2.0.2"
-    toidentifier "~1.0.1"
 
 http-parser-js@>=0.5.1:
   version "0.5.10"
@@ -8620,7 +8670,7 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-https-proxy-agent@^7.0.0, https-proxy-agent@^7.0.6:
+https-proxy-agent@^7.0.0, https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
   integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
@@ -8662,6 +8712,13 @@ iconv-lite@^0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
+iconv-lite@^0.7.0, iconv-lite@~0.7.0:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
+  integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
@@ -8698,11 +8755,6 @@ immutable@^5.1.5:
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.1.5.tgz#93ee4db5c2a9ab42a4a783069f3c5d8847d40165"
   integrity sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==
-
-immutable@~3.7.6:
-  version "3.7.6"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
-  integrity sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==
 
 import-fresh@^3.1.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.1"
@@ -8804,6 +8856,11 @@ invariant@^2.2.4:
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
+
+ip-address@10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.1.0.tgz#d8dcffb34d0e02eb241427444a6e23f5b0595aa4"
+  integrity sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==
 
 ip-address@^10.1.1:
   version "10.1.1"
@@ -9047,6 +9104,11 @@ is-promise@^2.1.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
+
+is-promise@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
+  integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
 is-regex@^1.2.1:
   version "1.2.1"
@@ -9794,6 +9856,11 @@ jose@^5.0.0:
   resolved "https://registry.yarnpkg.com/jose/-/jose-5.10.0.tgz#c37346a099d6467c401351a9a0c2161e0f52c4be"
   integrity sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==
 
+jose@^6.1.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.3.tgz#0975197ad973251221c658a3cddc4b951a250c2d"
+  integrity sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==
+
 js-file-download@^0.4.12:
   version "0.4.12"
   resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.12.tgz#10c70ef362559a5b23cdbdc3bd6f399c3d91d821"
@@ -9872,6 +9939,13 @@ jsesc@^3.0.2, jsesc@~3.1.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
+json-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
+
 json-bignum@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/json-bignum/-/json-bignum-0.0.3.tgz#41163b50436c773d82424dbc20ed70db7604b8d7"
@@ -9899,6 +9973,14 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json-schema-to-ts@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz#81f3acaf5a34736492f6f5f51870ef9ece1ca853"
+  integrity sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    ts-algebra "^2.0.0"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -9908,6 +9990,11 @@ json-schema-traverse@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
+json-schema-typed@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz#e98ee7b1899ff4a184534d1f167c288c66bbeff4"
+  integrity sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==
 
 json-schema@0.4.0:
   version "0.4.0"
@@ -10076,6 +10163,23 @@ jss@10.10.0, jss@^10.5.1:
     array.prototype.flat "^1.3.1"
     object.assign "^4.1.4"
     object.values "^1.1.6"
+
+jwa@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.1.tgz#bf8176d1ad0cd72e0f3f58338595a13e110bc804"
+  integrity sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==
+  dependencies:
+    buffer-equal-constant-time "^1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-4.0.1.tgz#07edc1be8fac20e677b283ece261498bd38f0690"
+  integrity sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==
+  dependencies:
+    jwa "^2.0.1"
+    safe-buffer "^5.0.1"
 
 keyv@^4.5.3:
   version "4.5.4"
@@ -10400,6 +10504,11 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
+long@^5.0.0:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
+
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -10528,6 +10637,11 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
+media-typer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
+  integrity sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==
+
 memfs@^3.1.2, memfs@^3.4.3:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.6.0.tgz#d7a2110f86f79dd950a8b6df6d57bc984aa185f6"
@@ -10539,6 +10653,11 @@ merge-descriptors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.3.tgz#d80319a65f3c7935351e5cfdac8f9318504dbed5"
   integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
+
+merge-descriptors@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz#ea922f660635a2249ee565e0449f951e6b603808"
+  integrity sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -10584,6 +10703,13 @@ mime-types@^2.1.12, mime-types@^2.1.31, mime-types@^2.1.35, mime-types@~2.1.19, 
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+mime-types@^3.0.0, mime-types@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.2.tgz#39002d4182575d5af036ffa118100f2524b2e2ab"
+  integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
+  dependencies:
+    mime-db "^1.54.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -10743,6 +10869,11 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
+negotiator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
+  integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
+
 negotiator@~0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.4.tgz#777948e2452651c570b712dd01c23e262713fff7"
@@ -10823,6 +10954,11 @@ node-cache@^5.1.2:
   dependencies:
     clone "2.x"
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-exports-info@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/node-exports-info/-/node-exports-info-1.6.0.tgz#1aedafb01a966059c9a5e791a94a94d93f5c2a13"
@@ -10839,6 +10975,15 @@ node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7, node-fetch@^2.7.0:
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-forge@^1:
   version "1.4.0"
@@ -10892,11 +11037,6 @@ nth-check@^2.0.1:
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
     boolbase "^1.0.0"
-
-nullthrows@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
-  integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -11026,17 +11166,17 @@ ometajs@~3.2.4:
     q "0.8.x"
     uglify-js "1.3.x"
 
+on-finished@^2.4.1, on-finished@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
+  dependencies:
+    ee-first "1.1.1"
+
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   integrity sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==
-  dependencies:
-    ee-first "1.1.1"
-
-on-finished@~2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
-  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
   dependencies:
     ee-first "1.1.1"
 
@@ -11045,7 +11185,7 @@ on-headers@~1.1.0:
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.1.0.tgz#59da4f91c45f5f989c6e4bcedc5a3b0aed70ff65"
   integrity sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -11081,6 +11221,11 @@ open@^8.0.9, open@^8.4.0, open@^8.4.2:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+openai@^6.34.0:
+  version "6.35.0"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-6.35.0.tgz#3f3fdf2a03b9009b3c85d1b386f41ad0284d4b5d"
+  integrity sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==
 
 openid-client@^5.4.2, openid-client@^5.6.1:
   version "5.7.1"
@@ -11209,7 +11354,7 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
-p-retry@^4.5.0:
+p-retry@^4.5.0, p-retry@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
   integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
@@ -11398,6 +11543,11 @@ path-root@^0.1.1:
   dependencies:
     path-root-regex "^0.1.0"
 
+path-to-regexp@^8.0.0:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz#795c420c4f7ca45c5b887366f622ee0c9852cccd"
+  integrity sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==
+
 path-to-regexp@~0.1.12:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.13.tgz#9b22ec16bc3ab88d05a0c7e369869421401ab17d"
@@ -11452,6 +11602,11 @@ pirates@^4.0.1, pirates@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
+
+pkce-challenge@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz#3b4446865b17b1745e9ace2016a31f48ddf6230d"
+  integrity sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==
 
 pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
@@ -12103,13 +12258,6 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
 promise@^8.1.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.3.0.tgz#8cb333d1edeb61ef23869fbb8a4ea0279ab60e0a"
@@ -12149,6 +12297,24 @@ properties-reader@^2.2.0:
   dependencies:
     mkdirp "^1.0.4"
 
+protobufjs@^7.5.4:
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.6.tgz#11af832ebc4b4326f658a5b1308e6141eb57edfd"
+  integrity sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.5"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.1"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.1"
+    "@types/node" ">=13.7.0"
+    long "^5.0.0"
+
 protocols@^1.4.0:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.8.tgz#48eea2d8f58d9644a4a32caae5d5db290a075ce8"
@@ -12159,7 +12325,7 @@ protocols@^2.0.1:
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-2.0.2.tgz#822e8fcdcb3df5356538b3e91bfd890b067fd0a4"
   integrity sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==
 
-proxy-addr@~2.0.7:
+proxy-addr@^2.0.7, proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
   integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
@@ -12213,7 +12379,7 @@ q@^1.1.2, q@^1.5.0:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
 
-qs@^6.9.4, qs@~6.15.1:
+qs@^6.14.0, qs@^6.14.1, qs@^6.9.4, qs@~6.15.1:
   version "6.15.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.1.tgz#bdb55aed06bfac257a90c44a446a73fba5575c8f"
   integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
@@ -12275,6 +12441,16 @@ range-parser@^1.2.1, range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+raw-body@^3.0.0, raw-body@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-3.0.2.tgz#3e3ada5ae5568f9095d84376fd3a49b8fb000a51"
+  integrity sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==
+  dependencies:
+    bytes "~3.1.2"
+    http-errors "~2.0.1"
+    iconv-lite "~0.7.0"
+    unpipe "~1.0.0"
 
 raw-body@~2.5.3:
   version "2.5.3"
@@ -12687,15 +12863,6 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
 
-relay-runtime@12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-12.0.0.tgz#1e039282bdb5e0c1b9a7dc7f6b9a09d4f4ff8237"
-  integrity sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    fbjs "^3.0.0"
-    invariant "^2.2.4"
-
 remedial@^1.0.7:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/remedial/-/remedial-1.0.8.tgz#a5e4fd52a0e4956adbaf62da63a5a46a78c578a0"
@@ -12778,11 +12945,6 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
-
-require-main-filename@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
-  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
 requires-port@^1.0.0:
   version "1.0.0"
@@ -12917,6 +13079,17 @@ rollup@^2.43.1:
   integrity sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==
   optionalDependencies:
     fsevents "~2.3.2"
+
+router@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/router/-/router-2.2.0.tgz#019be620b711c87641167cc79b99090f00b146ef"
+  integrity sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==
+  dependencies:
+    debug "^4.4.0"
+    depd "^2.0.0"
+    is-promise "^4.0.0"
+    parseurl "^1.3.3"
+    path-to-regexp "^8.0.0"
 
 run-async@^2.4.0:
   version "2.4.1"
@@ -13111,6 +13284,23 @@ semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
+send@^1.1.0, send@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/send/-/send-1.2.1.tgz#9eab743b874f3550f40a26867bf286ad60d3f3ed"
+  integrity sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==
+  dependencies:
+    debug "^4.4.3"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    fresh "^2.0.0"
+    http-errors "^2.0.1"
+    mime-types "^3.0.2"
+    ms "^2.1.3"
+    on-finished "^2.4.1"
+    range-parser "^1.2.1"
+    statuses "^2.0.2"
+
 send@~0.19.0, send@~0.19.1:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/send/-/send-0.19.2.tgz#59bc0da1b4ea7ad42736fd642b1c4294e114ff29"
@@ -13173,6 +13363,16 @@ serve-index@^1.9.1:
     mime-types "~2.1.35"
     parseurl "~1.3.3"
 
+serve-static@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-2.2.1.tgz#7f186a4a4e5f5b663ad7a4294ff1bf37cf0e98a9"
+  integrity sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==
+  dependencies:
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    parseurl "^1.3.3"
+    send "^1.2.0"
+
 serve-static@~1.16.2:
   version "1.16.3"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.3.tgz#a97b74d955778583f3862a4f0b841eb4d5d78cf9"
@@ -13182,11 +13382,6 @@ serve-static@~1.16.2:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "~0.19.1"
-
-set-blocking@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-  integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -13218,11 +13413,6 @@ set-proto@^1.0.0:
     dunder-proto "^1.0.1"
     es-errors "^1.3.0"
     es-object-atoms "^1.0.0"
-
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 setprototypeof@1.2.0, setprototypeof@~1.2.0:
   version "1.2.0"
@@ -13325,11 +13515,6 @@ signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
-
-signedsource@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
-  integrity sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==
 
 simple-swizzle@^0.2.2:
   version "0.2.4"
@@ -13566,7 +13751,7 @@ static-eval@2.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-statuses@~2.0.1, statuses@~2.0.2:
+statuses@^2.0.1, statuses@^2.0.2, statuses@~2.0.1, statuses@~2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
   integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
@@ -14222,6 +14407,11 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
+ts-algebra@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ts-algebra/-/ts-algebra-2.0.0.tgz#4e3e0953878f26518fce7f6bb115064a65388b7a"
+  integrity sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==
+
 ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
@@ -14323,15 +14513,10 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.5.0, tslib@^2.5.3, tslib@^2.6.1, tslib@^2.6.2, tslib@^2.6.3, tslib@^2.8.0:
+tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.5.0, tslib@^2.5.3, tslib@^2.6.1, tslib@^2.6.2, tslib@^2.6.3, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
-tslib@~2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
-  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tslib@~2.6.0:
   version "2.6.3"
@@ -14403,6 +14588,15 @@ type-fest@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
   integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
+
+type-is@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-2.0.1.tgz#64f6cf03f92fce4015c2b224793f6bdd4b068c97"
+  integrity sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==
+  dependencies:
+    content-type "^1.0.5"
+    media-typer "^1.1.0"
+    mime-types "^3.0.0"
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -14488,11 +14682,6 @@ typical@^7.1.1, typical@^7.3.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/typical/-/typical-7.3.0.tgz#930376be344228709f134613911fa22aa09617a4"
   integrity sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==
-
-ua-parser-js@^1.0.35:
-  version "1.0.41"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.41.tgz#bd04dc9ec830fcf9e4fad35cf22dcedd2e3b4e9c"
-  integrity sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==
 
 uglify-js@1.3.x:
   version "1.3.5"
@@ -14740,7 +14929,7 @@ value-or-promise@^1.0.11, value-or-promise@^1.0.12:
   resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.12.tgz#0e5abfeec70148c78460a849f6b003ea7986f15c"
   integrity sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==
 
-vary@^1, vary@~1.1.2:
+vary@^1, vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
@@ -14838,6 +15027,11 @@ wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 web-vitals@^2.1.4:
   version "2.1.4"
@@ -15071,11 +15265,6 @@ which-collection@^1.0.2:
     is-set "^2.0.3"
     is-weakmap "^2.0.2"
     is-weakset "^2.0.3"
-
-which-module@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
-  integrity sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==
 
 which-typed-array@^1.1.16, which-typed-array@^1.1.19:
   version "1.1.20"
@@ -15376,7 +15565,7 @@ ws@^7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
-ws@^8.13.0, ws@^8.17.1, ws@^8.20.0:
+ws@^8.13.0, ws@^8.17.1, ws@^8.18.0, ws@^8.20.0:
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
   integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
@@ -15410,11 +15599,6 @@ xxhashjs@^0.2.2:
   integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
   dependencies:
     cuint "^0.2.2"
-
-y18n@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
-  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
 y18n@^5.0.5:
   version "5.0.8"
@@ -15451,14 +15635,6 @@ yaml@^2.3.1, yaml@^2.3.4:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"
   integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==
 
-yargs-parser@^18.1.2:
-  version "18.1.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
-  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
 yargs-parser@^20.2.2:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
@@ -15468,23 +15644,6 @@ yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
-
-yargs@^15.3.1:
-  version "15.4.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
-  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
-  dependencies:
-    cliui "^6.0.0"
-    decamelize "^1.2.0"
-    find-up "^4.1.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^4.2.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^18.1.2"
 
 yargs@^16.2.0:
   version "16.2.0"
@@ -15546,3 +15705,18 @@ zen-observable@0.8.15, zen-observable@^0.8.0:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
+
+zod-to-json-schema@^3.25.1:
+  version "3.25.2"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz#3fa799a7badd554541472fb65843fdc460b2e5aa"
+  integrity sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==
+
+zod@^3.23.8:
+  version "3.25.76"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
+
+"zod@^3.25 || ^4.0":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.1.tgz#3c9bcf62b846273c7c8056d5b698bbae19db1d8b"
+  integrity sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==


### PR DESCRIPTION
## Description

<Include a summary of the changes. Please also include relevant motivation and context. List any external dependencies that are required for this change, like new environment variables.>

## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [ ] Searching for a single term or multiple terms returns relevant results
- [ ] Searching in PHI mode returns results with PHI columns
- [ ] Filtering columns returns the results matching the filter
- [ ] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [ ] Clicking "Download as TSV"
- [ ] Searching for some terms then clicking "Download as TSV"
- [ ] Filtering a column then clicking "Download as TSV"
- [ ] Search in PHI mode then clicking "Download as TSV"
- [ ] Clicking the dropdown download option <download option name>
- [ ] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
- [ ] Viewing a sample's data diff and clicking "Download as TSV"

#### AG Grid interactions

- [ ] [Samples page] Editing a cell updates the value as expected
- [ ] [Samples page] Pasting data into the grid works as expected
- [ ] Editing a cell in a non-editable row/column is prevented
- [ ] Column sorting in ascending and descending order works as expected
- [ ] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [ ] [Samples page] Cell changes confirmation modal appears and works as expected
- [ ] [Requests page] Validation errors are displayed in the Record Validation modal
- [ ] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [ ] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [ ] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [ ] The GraphQL types that are auto-generated via `yarn run codegen`
- [ ] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
