### PR TITLE
Pin MSKWESRP cohort at the top of the cohorts table

### DIFF
--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -6,6 +6,7 @@ import {
   CellEditRequestEvent,
   ColDef,
   ITooltipParams,
+  RowClassRules,
 } from "ag-grid-community";
 import { useNavigate } from "react-router-dom";
 import { createCustomHeader, lockIcon } from "../configs/gridIcons";
@@ -84,6 +85,7 @@ interface DataGridPropsBase {
       | ((prev: CohortBuilderSample[]) => CohortBuilderSample[])
   ) => void;
   onCellDoubleClicked?: (params: CellDoubleClickedEvent) => void;
+  rowClassRules?: RowClassRules;
 }
 
 type DataGridProps = DataGridPropsBase &
@@ -100,6 +102,7 @@ export function DataGrid({
   selectedRowIds,
   onSelectionChanged,
   onCellDoubleClicked,
+  rowClassRules,
 }: DataGridProps) {
   const navigate = useNavigate();
   const { userEmail } = useUserEmail();
@@ -205,6 +208,7 @@ export function DataGrid({
         rowClassRules={{
           unlocked: (params) => params.data?.revisable === true,
           locked: (params) => params.data?.revisable === false,
+          ...rowClassRules,
         }}
         onCellEditRequest={handleCellEditRequest}
         onCellDoubleClicked={onCellDoubleClicked}

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -51,6 +51,10 @@ $standardMargin: 10px;
   background: #fffcc9 !important;
 }
 
+.pinned-cohort-separator {
+  border-bottom: 2px solid lightgrey !important;
+}
+
 .cursorNotAllowed {
   cursor: not-allowed;
 }

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useMemo } from "react";
 import { DataGrid } from "../../components/DataGrid";
 import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
 import { useFetchData } from "../../hooks/useFetchData";
@@ -31,6 +31,9 @@ import { CellChangesContainer } from "../../components/CellChangesContainer";
 const QUERY_NAME = "dashboardCohorts";
 const INITIAL_SORT_FIELD_NAME = "initialCohortDeliveryDate";
 const RECORD_NAME = "cohorts";
+
+// Must match the PINNED_COHORT_IDS constant in graphql-server/src/schemas/queries/cohorts.ts.
+const PINNED_COHORT_IDS = ["MSKWESRP"];
 
 export function CohortsPage() {
   const [userSearchVal, setUserSearchVal] = useState("");
@@ -74,6 +77,21 @@ export function CohortsPage() {
       recordCount,
       queryName: QUERY_NAME,
     });
+
+  // Adds a bold bottom border only to the last pinned cohort row to visually separate
+  // the pinned rows from the rest of the table.
+  const cohortRowClassRules = useMemo(
+    () => ({
+      "pinned-cohort-separator": (params: any) => {
+        if (!PINNED_COHORT_IDS.includes(params.data?.cohortId)) return false;
+        const nextRow = params.api.getDisplayedRowAtIndex(
+          params.node.rowIndex + 1
+        );
+        return !PINNED_COHORT_IDS.includes(nextRow?.data?.cohortId);
+      },
+    }),
+    []
+  );
 
   // remove selected samples from cohort col defs
   const filteredWesSampleColDefs = wesSampleColDefs.filter(
@@ -132,6 +150,7 @@ export function CohortsPage() {
         handlePaste={handlePaste}
         selectedRowIds={[]}
         onSelectionChanged={() => {}}
+        rowClassRules={cohortRowClassRules}
       />
 
       {hasParams && (

--- a/graphql-server/src/schemas/queries/cohorts.ts
+++ b/graphql-server/src/schemas/queries/cohorts.ts
@@ -155,6 +155,9 @@ export function buildCohortsQueryBody({
 
   return cohortsQueryBody;
 }
+// Must match the PINNED_COHORT_IDS constant in frontend/src/pages/cohorts/CohortsPage.tsx.
+const PINNED_COHORT_IDS = ["MSKWESRP"];
+
 export function buildCohortsQueryFinal({
   queryBody,
   sort,
@@ -174,7 +177,9 @@ export function buildCohortsQueryFinal({
     RETURN
       resultz{.*, _total:total, _uniqueSampleCount: uniqueSampleCount}
 
-    ORDER BY ${getCypherCustomOrderBy(sort)}
+    ORDER BY CASE WHEN resultz.cohortId IN ${JSON.stringify(
+      PINNED_COHORT_IDS
+    )} THEN 0 ELSE 1 END ASC, ${getCypherCustomOrderBy(sort)}
     SKIP ${offset}
     LIMIT ${limit}
   `;


### PR DESCRIPTION
Implements https://github.com/mskcc/smile-server/issues/1809

## Description

<Include a summary of the changes. Please also include relevant motivation and context. List any external dependencies that are required for this change, like new environment variables.>

## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [x] Searching for a single term or multiple terms returns relevant results
- [x] Searching in PHI mode returns results with PHI columns
- [x] Filtering columns returns the results matching the filter
- [x] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [x] Clicking "Download as TSV"
- [x] Searching for some terms then clicking "Download as TSV"
- [x] Filtering a column then clicking "Download as TSV"
- [x] Search in PHI mode then clicking "Download as TSV"
- [x] Clicking the dropdown download option <download option name>
- [x] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
- [x] Viewing a sample's data diff and clicking "Download as TSV"

#### AG Grid interactions

- [x] [Samples page] Editing a cell updates the value as expected
- [x] [Samples page] Pasting data into the grid works as expected
- [x] Editing a cell in a non-editable row/column is prevented
- [x] Column sorting in ascending and descending order works as expected
- [x] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [x] [Samples page] Cell changes confirmation modal appears and works as expected
- [ ] [Requests page] Validation errors are displayed in the Record Validation modal
- [x] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [x] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [ ] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [ ] The GraphQL types that are auto-generated via `yarn run codegen`
- [ ] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
