### PR TITLE
Filter out normals when in cohort builder mode

### DIFF
--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -17,6 +17,7 @@ import {
   phiModeSwitchTooltipContent,
   BILLING_FIELDS,
   PHI_FIELDS,
+  TUMOR_ONLY_CONTEXT,
 } from "./config";
 import { Button, Col } from "react-bootstrap";
 import { FilterButtons } from "../../components/FilterButtons";
@@ -105,6 +106,11 @@ export function SamplesPage() {
   const disableCohortBuildling = !isWesAndLoggedIn;
   const includeDemographics = isWesAndLoggedIn;
 
+  const effectiveRecordContexts =
+    showCohortBuilder && !disableCohortBuildling
+      ? [...(recordContexts ?? []), ...TUMOR_ONLY_CONTEXT]
+      : recordContexts;
+
   // Reset cohort builder when transitioning from enabled to disabled
   const prevIsWesAndLoggedIn = useRef(isWesAndLoggedIn);
   useEffect(() => {
@@ -131,7 +137,7 @@ export function SamplesPage() {
     initialSortFieldName: INITIAL_SORT_FIELD_NAME,
     gridRef,
     userSearchVal,
-    recordContexts,
+    recordContexts: effectiveRecordContexts,
     pollInterval: POLL_INTERVAL,
     includeDemographics,
   });
@@ -144,7 +150,11 @@ export function SamplesPage() {
         gridRef.current.columnApi.setColumnsVisible(["selected"], false);
       }
     }
-  }, [gridRef, colDefs, showCohortBuilder, disableCohortBuildling]);
+    if (gridRef.current?.api) {
+      refreshData();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showCohortBuilder, disableCohortBuildling]);
 
   const { changes, cellChangesHandlers, handleCellEditRequest, handlePaste } =
     useCellChanges({

--- a/frontend/src/pages/samples/config.tsx
+++ b/frontend/src/pages/samples/config.tsx
@@ -46,6 +46,16 @@ export const PHI_FIELDS = new Set([
 ]);
 
 /**
+ * Filters samples to Tumor-only. Used when cohort builder mode is active.
+ */
+export const TUMOR_ONLY_CONTEXT: Array<DashboardRecordContext> = [
+  {
+    fieldName: "tumorOrNormal",
+    values: ["Tumor"],
+  },
+];
+
+/**
  * Applies the context in which sample records are filtered for SamplesPage.
  */
 const WES_SAMPLE_CONTEXT: Array<DashboardRecordContext> = [

--- a/graphql-server/src/schemas/queries/samples.ts
+++ b/graphql-server/src/schemas/queries/samples.ts
@@ -104,6 +104,12 @@ export function buildSamplesQueryBody({
     contextField: "baitSet",
     predicateField: "latestSm.baitSet",
   });
+  // WES-specific and only active during cohort builder mode.
+  const tumorOrNormalContext = buildCypherPredicateFromContext({
+    recordContexts: recordContexts,
+    contextField: "tumorOrNormal",
+    predicateField: "latestSm.tumorOrNormal",
+  });
 
   // Filter for the current request in the Request Samples view
   const requestContext = buildCypherPredicateFromContext({
@@ -208,6 +214,7 @@ export function buildSamplesQueryBody({
     // Filters for either the WES Samples or Request Samples view, if applicable
     ${genePanelContext && `WHERE ${genePanelContext}`}
     ${baitSetContext && `OR ${baitSetContext}`}
+    ${tumorOrNormalContext && `AND ${tumorOrNormalContext}`}
     ${requestContext && `WHERE ${requestContext}`}
 
     WITH 


### PR DESCRIPTION
Implements https://github.com/mskcc/smile-server/issues/1827

## Description

<Include a summary of the changes. Please also include relevant motivation and context. List any external dependencies that are required for this change, like new environment variables.>

## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [x] Searching for a single term or multiple terms returns relevant results
- [x] Searching in PHI mode returns results with PHI columns
- [x] Filtering columns returns the results matching the filter
- [x] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [x] Clicking "Download as TSV"
- [x] Searching for some terms then clicking "Download as TSV"
- [x] Filtering a column then clicking "Download as TSV"
- [x] Search in PHI mode then clicking "Download as TSV"
- [x] Clicking the dropdown download option <download option name>
- [x] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
- [x] Viewing a sample's data diff and clicking "Download as TSV"

#### AG Grid interactions

- [x] [Samples page] Editing a cell updates the value as expected
- [x] [Samples page] Pasting data into the grid works as expected
- [x] Editing a cell in a non-editable row/column is prevented
- [x] Column sorting in ascending and descending order works as expected
- [x] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [x] [Samples page] Cell changes confirmation modal appears and works as expected
- [x] [Requests page] Validation errors are displayed in the Record Validation modal
- [x] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [x] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [ ] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [ ] The GraphQL types that are auto-generated via `yarn run codegen`
- [ ] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
