### PR TITLE
Display cohortStatus on Cohorts page

### DIFF
--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -11,15 +11,24 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never;
+    };
 const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  BigInt: any;
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  BigInt: { input: any; output: any };
 };
 
 export enum AgGridSortDirection {
@@ -29,43 +38,43 @@ export enum AgGridSortDirection {
 
 export type AnchorSeqDateData = {
   __typename?: "AnchorSeqDateData";
-  ANCHOR_ONCOTREE_CODE: Scalars["String"];
-  ANCHOR_SEQUENCING_DATE: Scalars["String"];
-  DMP_PATIENT_ID: Scalars["String"];
-  MRN: Scalars["String"];
+  ANCHOR_ONCOTREE_CODE: Scalars["String"]["output"];
+  ANCHOR_SEQUENCING_DATE: Scalars["String"]["output"];
+  DMP_PATIENT_ID: Scalars["String"]["output"];
+  MRN: Scalars["String"]["output"];
 };
 
 export type BamComplete = {
   __typename?: "BamComplete";
-  date: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
   temposHasEvent: Array<Tempo>;
   temposHasEventAggregate?: Maybe<BamCompleteTempoTemposHasEventAggregationSelection>;
   temposHasEventConnection: BamCompleteTemposHasEventConnection;
 };
 
 export type BamCompleteTemposHasEventArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type BamCompleteTemposHasEventAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type BamCompleteTemposHasEventConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<BamCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<BamCompleteTemposHasEventConnectionWhere>;
 };
 
 export type BamCompleteAggregateSelection = {
   __typename?: "BamCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   status: StringAggregateSelection;
 };
@@ -81,8 +90,8 @@ export type BamCompleteConnectWhere = {
 };
 
 export type BamCompleteCreateInput = {
-  date: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
   temposHasEvent?: InputMaybe<BamCompleteTemposHasEventFieldInput>;
 };
 
@@ -98,13 +107,13 @@ export type BamCompleteDisconnectInput = {
 
 export type BamCompleteEdge = {
   __typename?: "BamCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: BamComplete;
 };
 
 export type BamCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more BamCompleteSort objects to sort BamCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<BamCompleteSort>>;
 };
@@ -121,7 +130,7 @@ export type BamCompleteSort = {
 
 export type BamCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "BamCompleteTempoTemposHasEventAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<BamCompleteTempoTemposHasEventNodeAggregateSelection>;
 };
 
@@ -140,18 +149,18 @@ export type BamCompleteTemposHasEventAggregateInput = {
   AND?: InputMaybe<Array<BamCompleteTemposHasEventAggregateInput>>;
   NOT?: InputMaybe<BamCompleteTemposHasEventAggregateInput>;
   OR?: InputMaybe<Array<BamCompleteTemposHasEventAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<BamCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type BamCompleteTemposHasEventConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -159,7 +168,7 @@ export type BamCompleteTemposHasEventConnection = {
   __typename?: "BamCompleteTemposHasEventConnection";
   edges: Array<BamCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type BamCompleteTemposHasEventConnectionSort = {
@@ -196,116 +205,164 @@ export type BamCompleteTemposHasEventNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<BamCompleteTemposHasEventNodeAggregationWhereInput>>;
   NOT?: InputMaybe<BamCompleteTemposHasEventNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<BamCompleteTemposHasEventNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type BamCompleteTemposHasEventRelationship = {
   __typename?: "BamCompleteTemposHasEventRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -323,8 +380,8 @@ export type BamCompleteTemposHasEventUpdateFieldInput = {
 };
 
 export type BamCompleteUpdateInput = {
-  date?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEvent?: InputMaybe<Array<BamCompleteTemposHasEventUpdateFieldInput>>;
 };
 
@@ -332,18 +389,18 @@ export type BamCompleteWhere = {
   AND?: InputMaybe<Array<BamCompleteWhere>>;
   NOT?: InputMaybe<BamCompleteWhere>;
   OR?: InputMaybe<Array<BamCompleteWhere>>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEventAggregate?: InputMaybe<BamCompleteTemposHasEventAggregateInput>;
   /** Return BamCompletes where all of the related BamCompleteTemposHasEventConnections match this filter */
   temposHasEventConnection_ALL?: InputMaybe<BamCompleteTemposHasEventConnectionWhere>;
@@ -367,20 +424,21 @@ export type BamCompletesConnection = {
   __typename?: "BamCompletesConnection";
   edges: Array<BamCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type BigIntAggregateSelection = {
   __typename?: "BigIntAggregateSelection";
-  average?: Maybe<Scalars["BigInt"]>;
-  max?: Maybe<Scalars["BigInt"]>;
-  min?: Maybe<Scalars["BigInt"]>;
-  sum?: Maybe<Scalars["BigInt"]>;
+  average?: Maybe<Scalars["BigInt"]["output"]>;
+  max?: Maybe<Scalars["BigInt"]["output"]>;
+  min?: Maybe<Scalars["BigInt"]["output"]>;
+  sum?: Maybe<Scalars["BigInt"]["output"]>;
 };
 
 export type Cohort = {
   __typename?: "Cohort";
-  cohortId: Scalars["String"];
+  cohortId: Scalars["String"]["output"];
+  cohortStatus: Scalars["String"]["output"];
   hasCohortCompleteCohortCompletes: Array<CohortComplete>;
   hasCohortCompleteCohortCompletesAggregate?: Maybe<CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection>;
   hasCohortCompleteCohortCompletesConnection: CohortHasCohortCompleteCohortCompletesConnection;
@@ -390,20 +448,20 @@ export type Cohort = {
 };
 
 export type CohortHasCohortCompleteCohortCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<CohortCompleteOptions>;
   where?: InputMaybe<CohortCompleteWhere>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<CohortCompleteWhere>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesConnectionSort>
   >;
@@ -411,20 +469,20 @@ export type CohortHasCohortCompleteCohortCompletesConnectionArgs = {
 };
 
 export type CohortHasCohortSampleSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type CohortHasCohortSampleSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type CohortHasCohortSampleSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<CohortHasCohortSampleSamplesConnectionSort>>;
   where?: InputMaybe<CohortHasCohortSampleSamplesConnectionWhere>;
 };
@@ -432,13 +490,14 @@ export type CohortHasCohortSampleSamplesConnectionArgs = {
 export type CohortAggregateSelection = {
   __typename?: "CohortAggregateSelection";
   cohortId: StringAggregateSelection;
-  count: Scalars["Int"];
+  cohortStatus: StringAggregateSelection;
+  count: Scalars["Int"]["output"];
 };
 
 export type CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection =
   {
     __typename?: "CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSelection>;
   };
 
@@ -461,32 +520,32 @@ export type CohortComplete = {
   cohortsHasCohortComplete: Array<Cohort>;
   cohortsHasCohortCompleteAggregate?: Maybe<CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection>;
   cohortsHasCohortCompleteConnection: CohortCompleteCohortsHasCohortCompleteConnection;
-  date: Scalars["String"];
-  endUsers: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  pipelineVersion?: Maybe<Scalars["String"]>;
-  pmUsers: Scalars["String"];
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
-  status: Scalars["String"];
-  type: Scalars["String"];
+  date?: Maybe<Scalars["String"]["output"]>;
+  endUsers: Scalars["String"]["output"];
+  importDate: Scalars["BigInt"]["output"];
+  pipelineVersion?: Maybe<Scalars["String"]["output"]>;
+  pmUsers: Scalars["String"]["output"];
+  projectSubtitle: Scalars["String"]["output"];
+  projectTitle: Scalars["String"]["output"];
+  status?: Maybe<Scalars["String"]["output"]>;
+  type: Scalars["String"]["output"];
 };
 
 export type CohortCompleteCohortsHasCohortCompleteArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<CohortOptions>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteConnectionSort>
   >;
@@ -495,7 +554,7 @@ export type CohortCompleteCohortsHasCohortCompleteConnectionArgs = {
 
 export type CohortCompleteAggregateSelection = {
   __typename?: "CohortCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   endUsers: StringAggregateSelection;
   importDate: BigIntAggregateSelection;
@@ -509,7 +568,7 @@ export type CohortCompleteAggregateSelection = {
 
 export type CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection = {
   __typename?: "CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection>;
 };
 
@@ -517,24 +576,25 @@ export type CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection =
   {
     __typename?: "CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection";
     cohortId: StringAggregateSelection;
+    cohortStatus: StringAggregateSelection;
   };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateInput = {
   AND?: InputMaybe<Array<CohortCompleteCohortsHasCohortCompleteAggregateInput>>;
   NOT?: InputMaybe<CohortCompleteCohortsHasCohortCompleteAggregateInput>;
   OR?: InputMaybe<Array<CohortCompleteCohortsHasCohortCompleteAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteConnectFieldInput = {
   connect?: InputMaybe<Array<CohortConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<CohortConnectWhere>;
 };
 
@@ -542,7 +602,7 @@ export type CohortCompleteCohortsHasCohortCompleteConnection = {
   __typename?: "CohortCompleteCohortsHasCohortCompleteConnection";
   edges: Array<CohortCompleteCohortsHasCohortCompleteRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortCompleteCohortsHasCohortCompleteConnectionSort = {
@@ -589,26 +649,41 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput>
   >;
-  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteRelationship = {
   __typename?: "CohortCompleteCohortsHasCohortCompleteRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Cohort;
 };
 
@@ -645,15 +720,15 @@ export type CohortCompleteConnectWhere = {
 
 export type CohortCompleteCreateInput = {
   cohortsHasCohortComplete?: InputMaybe<CohortCompleteCohortsHasCohortCompleteFieldInput>;
-  date: Scalars["String"];
-  endUsers: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pmUsers: Scalars["String"];
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
-  status: Scalars["String"];
-  type: Scalars["String"];
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers: Scalars["String"]["input"];
+  importDate: Scalars["BigInt"]["input"];
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers: Scalars["String"]["input"];
+  projectSubtitle: Scalars["String"]["input"];
+  projectTitle: Scalars["String"]["input"];
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  type: Scalars["String"]["input"];
 };
 
 export type CohortCompleteDeleteInput = {
@@ -670,13 +745,13 @@ export type CohortCompleteDisconnectInput = {
 
 export type CohortCompleteEdge = {
   __typename?: "CohortCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: CohortComplete;
 };
 
 export type CohortCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more CohortCompleteSort objects to sort CohortCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<CohortCompleteSort>>;
 };
@@ -704,17 +779,17 @@ export type CohortCompleteUpdateInput = {
   cohortsHasCohortComplete?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteUpdateFieldInput>
   >;
-  date?: InputMaybe<Scalars["String"]>;
-  endUsers?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Scalars["String"]>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  type?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type CohortCompleteWhere = {
@@ -738,67 +813,69 @@ export type CohortCompleteWhere = {
   cohortsHasCohortComplete_SINGLE?: InputMaybe<CohortWhere>;
   /** Return CohortCompletes where some of the related Cohorts match this filter */
   cohortsHasCohortComplete_SOME?: InputMaybe<CohortWhere>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  endUsers?: InputMaybe<Scalars["String"]>;
-  endUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
-  endUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  endUsers_IN?: InputMaybe<Array<Scalars["String"]>>;
-  endUsers_MATCHES?: InputMaybe<Scalars["String"]>;
-  endUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]>>;
-  importDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_CONTAINS?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pipelineVersion_MATCHES?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Scalars["String"]>;
-  pmUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
-  pmUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  pmUsers_IN?: InputMaybe<Array<Scalars["String"]>>;
-  pmUsers_MATCHES?: InputMaybe<Scalars["String"]>;
-  pmUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_IN?: InputMaybe<Array<Scalars["String"]>>;
-  projectSubtitle_MATCHES?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
-  projectTitle_CONTAINS?: InputMaybe<Scalars["String"]>;
-  projectTitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectTitle_IN?: InputMaybe<Array<Scalars["String"]>>;
-  projectTitle_MATCHES?: InputMaybe<Scalars["String"]>;
-  projectTitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  type?: InputMaybe<Scalars["String"]>;
-  type_CONTAINS?: InputMaybe<Scalars["String"]>;
-  type_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  type_IN?: InputMaybe<Array<Scalars["String"]>>;
-  type_MATCHES?: InputMaybe<Scalars["String"]>;
-  type_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  endUsers_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  importDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  pipelineVersion_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  pmUsers_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  projectSubtitle_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  projectTitle_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
+  type_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  type_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  type_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  type_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  type_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type CohortCompletesConnection = {
   __typename?: "CohortCompletesConnection";
   edges: Array<CohortCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortConnectInput = {
@@ -815,7 +892,8 @@ export type CohortConnectWhere = {
 };
 
 export type CohortCreateInput = {
-  cohortId: Scalars["String"];
+  cohortId: Scalars["String"]["input"];
+  cohortStatus: Scalars["String"]["input"];
   hasCohortCompleteCohortCompletes?: InputMaybe<CohortHasCohortCompleteCohortCompletesFieldInput>;
   hasCohortSampleSamples?: InputMaybe<CohortHasCohortSampleSamplesFieldInput>;
 };
@@ -840,7 +918,7 @@ export type CohortDisconnectInput = {
 
 export type CohortEdge = {
   __typename?: "CohortEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Cohort;
 };
 
@@ -848,18 +926,18 @@ export type CohortHasCohortCompleteCohortCompletesAggregateInput = {
   AND?: InputMaybe<Array<CohortHasCohortCompleteCohortCompletesAggregateInput>>;
   NOT?: InputMaybe<CohortHasCohortCompleteCohortCompletesAggregateInput>;
   OR?: InputMaybe<Array<CohortHasCohortCompleteCohortCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<CohortCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<CohortCompleteConnectWhere>;
 };
 
@@ -867,7 +945,7 @@ export type CohortHasCohortCompleteCohortCompletesConnection = {
   __typename?: "CohortHasCohortCompleteCohortCompletesConnection";
   edges: Array<CohortHasCohortCompleteCohortCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortHasCohortCompleteCohortCompletesConnectionSort = {
@@ -914,151 +992,151 @@ export type CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput>
   >;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  endUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  pipelineVersion_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  pmUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectTitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  type_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  type_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  type_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesRelationship = {
   __typename?: "CohortHasCohortCompleteCohortCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: CohortComplete;
 };
 
@@ -1087,18 +1165,18 @@ export type CohortHasCohortSampleSamplesAggregateInput = {
   AND?: InputMaybe<Array<CohortHasCohortSampleSamplesAggregateInput>>;
   NOT?: InputMaybe<CohortHasCohortSampleSamplesAggregateInput>;
   OR?: InputMaybe<Array<CohortHasCohortSampleSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<CohortHasCohortSampleSamplesNodeAggregationWhereInput>;
 };
 
 export type CohortHasCohortSampleSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -1106,7 +1184,7 @@ export type CohortHasCohortSampleSamplesConnection = {
   __typename?: "CohortHasCohortSampleSamplesConnection";
   edges: Array<CohortHasCohortSampleSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortHasCohortSampleSamplesConnectionSort = {
@@ -1145,71 +1223,71 @@ export type CohortHasCohortSampleSamplesNodeAggregationWhereInput = {
   >;
   NOT?: InputMaybe<CohortHasCohortSampleSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<CohortHasCohortSampleSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type CohortHasCohortSampleSamplesRelationship = {
   __typename?: "CohortHasCohortSampleSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -1229,8 +1307,8 @@ export type CohortHasCohortSampleSamplesUpdateFieldInput = {
 };
 
 export type CohortOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more CohortSort objects to sort Cohorts by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<CohortSort>>;
 };
@@ -1246,7 +1324,7 @@ export type CohortRelationInput = {
 
 export type CohortSampleHasCohortSampleSamplesAggregationSelection = {
   __typename?: "CohortSampleHasCohortSampleSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<CohortSampleHasCohortSampleSamplesNodeAggregateSelection>;
 };
 
@@ -1261,10 +1339,12 @@ export type CohortSampleHasCohortSampleSamplesNodeAggregateSelection = {
 /** Fields to sort Cohorts by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortSort object. */
 export type CohortSort = {
   cohortId?: InputMaybe<SortDirection>;
+  cohortStatus?: InputMaybe<SortDirection>;
 };
 
 export type CohortUpdateInput = {
-  cohortId?: InputMaybe<Scalars["String"]>;
+  cohortId?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus?: InputMaybe<Scalars["String"]["input"]>;
   hasCohortCompleteCohortCompletes?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesUpdateFieldInput>
   >;
@@ -1277,12 +1357,18 @@ export type CohortWhere = {
   AND?: InputMaybe<Array<CohortWhere>>;
   NOT?: InputMaybe<CohortWhere>;
   OR?: InputMaybe<Array<CohortWhere>>;
-  cohortId?: InputMaybe<Scalars["String"]>;
-  cohortId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cohortId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cohortId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  cohortId_MATCHES?: InputMaybe<Scalars["String"]>;
-  cohortId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cohortId?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  cohortId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  cohortStatus_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasCohortCompleteCohortCompletesAggregate?: InputMaybe<CohortHasCohortCompleteCohortCompletesAggregateInput>;
   /** Return Cohorts where all of the related CohortHasCohortCompleteCohortCompletesConnections match this filter */
   hasCohortCompleteCohortCompletesConnection_ALL?: InputMaybe<CohortHasCohortCompleteCohortCompletesConnectionWhere>;
@@ -1323,7 +1409,7 @@ export type CohortsConnection = {
   __typename?: "CohortsConnection";
   edges: Array<CohortEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CreateBamCompletesMutationResponse = {
@@ -1354,9 +1440,9 @@ export type CreateDbGapsMutationResponse = {
 export type CreateInfo = {
   __typename?: "CreateInfo";
   /** @deprecated This field has been deprecated because bookmarks are now handled by the driver. */
-  bookmark?: Maybe<Scalars["String"]>;
-  nodesCreated: Scalars["Int"];
-  relationshipsCreated: Scalars["Int"];
+  bookmark?: Maybe<Scalars["String"]["output"]>;
+  nodesCreated: Scalars["Int"]["output"];
+  relationshipsCreated: Scalars["Int"]["output"];
 };
 
 export type CreateMafCompletesMutationResponse = {
@@ -1433,265 +1519,267 @@ export type CreateTemposMutationResponse = {
 
 export type DashboardCohort = {
   __typename?: "DashboardCohort";
-  _total?: Maybe<Scalars["Int"]>;
-  _uniqueSampleCount?: Maybe<Scalars["Int"]>;
-  billed?: Maybe<Scalars["String"]>;
-  cohortId: Scalars["String"];
-  endUsers?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
-  initialCohortDeliveryDate?: Maybe<Scalars["String"]>;
-  pipelineVersion?: Maybe<Scalars["String"]>;
-  pmUsers?: Maybe<Scalars["String"]>;
-  projectSubtitle?: Maybe<Scalars["String"]>;
-  projectTitle?: Maybe<Scalars["String"]>;
-  searchableSampleIds?: Maybe<Scalars["String"]>;
-  status?: Maybe<Scalars["String"]>;
-  totalSampleCount?: Maybe<Scalars["Int"]>;
-  type?: Maybe<Scalars["String"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  _uniqueSampleCount?: Maybe<Scalars["Int"]["output"]>;
+  billed?: Maybe<Scalars["String"]["output"]>;
+  cohortId: Scalars["String"]["output"];
+  cohortStatus?: Maybe<Scalars["String"]["output"]>;
+  endUsers?: Maybe<Scalars["String"]["output"]>;
+  importDate?: Maybe<Scalars["String"]["output"]>;
+  initialCohortDeliveryDate?: Maybe<Scalars["String"]["output"]>;
+  pipelineVersion?: Maybe<Scalars["String"]["output"]>;
+  pmUsers?: Maybe<Scalars["String"]["output"]>;
+  projectSubtitle?: Maybe<Scalars["String"]["output"]>;
+  projectTitle?: Maybe<Scalars["String"]["output"]>;
+  searchableSampleIds?: Maybe<Scalars["String"]["output"]>;
+  status?: Maybe<Scalars["String"]["output"]>;
+  totalSampleCount?: Maybe<Scalars["Int"]["output"]>;
+  type?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type DashboardCohortInput = {
-  _total?: InputMaybe<Scalars["Int"]>;
-  _uniqueSampleCount?: InputMaybe<Scalars["Int"]>;
-  billed?: InputMaybe<Scalars["String"]>;
-  changedFieldNames: Array<Scalars["String"]>;
-  changelog?: InputMaybe<Scalars["String"]>;
-  cohortId: Scalars["String"];
-  endUsers?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["String"]>;
-  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Scalars["String"]>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
-  searchableSampleIds?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  totalSampleCount?: InputMaybe<Scalars["Int"]>;
-  type?: InputMaybe<Scalars["String"]>;
+  _total?: InputMaybe<Scalars["Int"]["input"]>;
+  _uniqueSampleCount?: InputMaybe<Scalars["Int"]["input"]>;
+  billed?: InputMaybe<Scalars["String"]["input"]>;
+  changedFieldNames: Array<Scalars["String"]["input"]>;
+  changelog?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId: Scalars["String"]["input"];
+  cohortStatus?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["String"]["input"]>;
+  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle?: InputMaybe<Scalars["String"]["input"]>;
+  searchableSampleIds?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type DashboardPatient = {
   __typename?: "DashboardPatient";
-  _total?: Maybe<Scalars["Int"]>;
-  anchorOncotreeCode?: Maybe<Scalars["String"]>;
-  anchorSequencingDate?: Maybe<Scalars["String"]>;
-  cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleIds?: Maybe<Scalars["String"]>;
-  consentPartA?: Maybe<Scalars["String"]>;
-  consentPartC?: Maybe<Scalars["String"]>;
-  dmpPatientId?: Maybe<Scalars["String"]>;
-  inDbGap?: Maybe<Scalars["Boolean"]>;
-  mrn?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  smilePatientId: Scalars["String"];
-  totalSampleCount?: Maybe<Scalars["Int"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  anchorOncotreeCode?: Maybe<Scalars["String"]["output"]>;
+  anchorSequencingDate?: Maybe<Scalars["String"]["output"]>;
+  cmoPatientId?: Maybe<Scalars["String"]["output"]>;
+  cmoSampleIds?: Maybe<Scalars["String"]["output"]>;
+  consentPartA?: Maybe<Scalars["String"]["output"]>;
+  consentPartC?: Maybe<Scalars["String"]["output"]>;
+  dmpPatientId?: Maybe<Scalars["String"]["output"]>;
+  inDbGap?: Maybe<Scalars["Boolean"]["output"]>;
+  mrn?: Maybe<Scalars["String"]["output"]>;
+  race?: Maybe<Scalars["String"]["output"]>;
+  smilePatientId: Scalars["String"]["output"];
+  totalSampleCount?: Maybe<Scalars["Int"]["output"]>;
 };
 
 export type DashboardRecordColumnFilter = {
-  field: Scalars["String"];
-  filter: Scalars["String"];
+  field: Scalars["String"]["input"];
+  filter: Scalars["String"]["input"];
 };
 
 export type DashboardRecordContext = {
-  fieldName?: InputMaybe<Scalars["String"]>;
-  values: Array<Scalars["String"]>;
+  fieldName?: InputMaybe<Scalars["String"]["input"]>;
+  values: Array<Scalars["String"]["input"]>;
 };
 
 export type DashboardRecordSort = {
-  colId: Scalars["String"];
+  colId: Scalars["String"]["input"];
   sort: AgGridSortDirection;
 };
 
 export type DashboardRequest = {
   __typename?: "DashboardRequest";
-  _total?: Maybe<Scalars["Int"]>;
-  bicAnalysis?: Maybe<Scalars["Boolean"]>;
-  dataAccessEmails?: Maybe<Scalars["String"]>;
-  dataAnalystEmail?: Maybe<Scalars["String"]>;
-  dataAnalystName?: Maybe<Scalars["String"]>;
-  genePanel?: Maybe<Scalars["String"]>;
-  igoDeliveryDate?: Maybe<Scalars["String"]>;
-  igoProjectId?: Maybe<Scalars["String"]>;
-  igoRequestId: Scalars["String"];
-  ilabRequestId?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
-  investigatorEmail?: Maybe<Scalars["String"]>;
-  investigatorName?: Maybe<Scalars["String"]>;
-  isCmoRequest?: Maybe<Scalars["Boolean"]>;
-  labHeadEmail?: Maybe<Scalars["String"]>;
-  labHeadName?: Maybe<Scalars["String"]>;
-  otherContactEmails?: Maybe<Scalars["String"]>;
-  piEmail?: Maybe<Scalars["String"]>;
-  projectManagerName?: Maybe<Scalars["String"]>;
-  qcAccessEmails?: Maybe<Scalars["String"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  bicAnalysis?: Maybe<Scalars["Boolean"]["output"]>;
+  dataAccessEmails?: Maybe<Scalars["String"]["output"]>;
+  dataAnalystEmail?: Maybe<Scalars["String"]["output"]>;
+  dataAnalystName?: Maybe<Scalars["String"]["output"]>;
+  genePanel?: Maybe<Scalars["String"]["output"]>;
+  igoDeliveryDate?: Maybe<Scalars["String"]["output"]>;
+  igoProjectId?: Maybe<Scalars["String"]["output"]>;
+  igoRequestId: Scalars["String"]["output"];
+  ilabRequestId?: Maybe<Scalars["String"]["output"]>;
+  importDate?: Maybe<Scalars["String"]["output"]>;
+  investigatorEmail?: Maybe<Scalars["String"]["output"]>;
+  investigatorName?: Maybe<Scalars["String"]["output"]>;
+  isCmoRequest?: Maybe<Scalars["Boolean"]["output"]>;
+  labHeadEmail?: Maybe<Scalars["String"]["output"]>;
+  labHeadName?: Maybe<Scalars["String"]["output"]>;
+  otherContactEmails?: Maybe<Scalars["String"]["output"]>;
+  piEmail?: Maybe<Scalars["String"]["output"]>;
+  projectManagerName?: Maybe<Scalars["String"]["output"]>;
+  qcAccessEmails?: Maybe<Scalars["String"]["output"]>;
   toleratedSampleErrors?: Maybe<Array<Maybe<ToleratedSampleValidationError>>>;
-  totalSampleCount?: Maybe<Scalars["Int"]>;
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  totalSampleCount?: Maybe<Scalars["Int"]["output"]>;
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type DashboardSample = {
   __typename?: "DashboardSample";
-  _total?: Maybe<Scalars["Int"]>;
-  accessLevel?: Maybe<Scalars["String"]>;
-  altId?: Maybe<Scalars["String"]>;
-  analyteType?: Maybe<Scalars["String"]>;
-  baitSet?: Maybe<Scalars["String"]>;
-  bamCompleteDate?: Maybe<Scalars["String"]>;
-  bamCompleteStatus?: Maybe<Scalars["String"]>;
-  billed?: Maybe<Scalars["Boolean"]>;
-  billedBy?: Maybe<Scalars["String"]>;
-  cancerType?: Maybe<Scalars["String"]>;
-  cancerTypeDetailed?: Maybe<Scalars["String"]>;
-  cfDNA2dBarcode?: Maybe<Scalars["String"]>;
-  changelog?: Maybe<Scalars["String"]>;
-  cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleName?: Maybe<Scalars["String"]>;
-  collectionYear?: Maybe<Scalars["String"]>;
-  costCenter?: Maybe<Scalars["String"]>;
-  custodianInformation?: Maybe<Scalars["String"]>;
-  dbGapStudy?: Maybe<Scalars["String"]>;
-  dmpPatientAlias?: Maybe<Scalars["String"]>;
-  dmpRecommendedCoverage?: Maybe<Scalars["String"]>;
-  embargoDate?: Maybe<Scalars["String"]>;
-  genePanel?: Maybe<Scalars["String"]>;
-  historicalCmoSampleNames?: Maybe<Scalars["String"]>;
-  igoComplete?: Maybe<Scalars["Boolean"]>;
-  igoDeliveryDate?: Maybe<Scalars["String"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  accessLevel?: Maybe<Scalars["String"]["output"]>;
+  altId?: Maybe<Scalars["String"]["output"]>;
+  analyteType?: Maybe<Scalars["String"]["output"]>;
+  baitSet?: Maybe<Scalars["String"]["output"]>;
+  bamCompleteDate?: Maybe<Scalars["String"]["output"]>;
+  bamCompleteStatus?: Maybe<Scalars["String"]["output"]>;
+  billed?: Maybe<Scalars["Boolean"]["output"]>;
+  billedBy?: Maybe<Scalars["String"]["output"]>;
+  cancerType?: Maybe<Scalars["String"]["output"]>;
+  cancerTypeDetailed?: Maybe<Scalars["String"]["output"]>;
+  cfDNA2dBarcode?: Maybe<Scalars["String"]["output"]>;
+  changelog?: Maybe<Scalars["String"]["output"]>;
+  cmoPatientId?: Maybe<Scalars["String"]["output"]>;
+  cmoSampleName?: Maybe<Scalars["String"]["output"]>;
+  collectionYear?: Maybe<Scalars["String"]["output"]>;
+  costCenter?: Maybe<Scalars["String"]["output"]>;
+  custodianInformation?: Maybe<Scalars["String"]["output"]>;
+  dbGapStudy?: Maybe<Scalars["String"]["output"]>;
+  dmpPatientAlias?: Maybe<Scalars["String"]["output"]>;
+  dmpRecommendedCoverage?: Maybe<Scalars["String"]["output"]>;
+  embargoDate?: Maybe<Scalars["String"]["output"]>;
+  genePanel?: Maybe<Scalars["String"]["output"]>;
+  historicalCmoSampleNames?: Maybe<Scalars["String"]["output"]>;
+  igoComplete?: Maybe<Scalars["Boolean"]["output"]>;
+  igoDeliveryDate?: Maybe<Scalars["String"]["output"]>;
   igoQcReports?: Maybe<Array<Maybe<IgoQcReport>>>;
-  igoSampleStatus?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
-  initialPipelineRunDate?: Maybe<Scalars["String"]>;
-  instrumentModel?: Maybe<Scalars["String"]>;
-  investigatorSampleId?: Maybe<Scalars["String"]>;
-  irbConsentProtocol?: Maybe<Scalars["String"]>;
-  mafCompleteDate?: Maybe<Scalars["String"]>;
-  mafCompleteNormalPrimaryId?: Maybe<Scalars["String"]>;
-  mafCompleteStatus?: Maybe<Scalars["String"]>;
-  molecularAccessionNumber?: Maybe<Scalars["String"]>;
-  oncotreeCode?: Maybe<Scalars["String"]>;
-  platform?: Maybe<Scalars["String"]>;
-  preservation?: Maybe<Scalars["String"]>;
-  primaryId?: Maybe<Scalars["String"]>;
-  qcCompleteDate?: Maybe<Scalars["String"]>;
-  qcCompleteReason?: Maybe<Scalars["String"]>;
-  qcCompleteResult?: Maybe<Scalars["String"]>;
-  qcCompleteStatus?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  recipe?: Maybe<Scalars["String"]>;
-  recordId: Scalars["String"];
-  revisable?: Maybe<Scalars["Boolean"]>;
-  sampleCategory: Scalars["String"];
-  sampleClass?: Maybe<Scalars["String"]>;
-  sampleCohortIds?: Maybe<Scalars["String"]>;
-  sampleOrigin?: Maybe<Scalars["String"]>;
-  sampleType?: Maybe<Scalars["String"]>;
-  sequencingDate?: Maybe<Scalars["String"]>;
-  sex?: Maybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
-  species?: Maybe<Scalars["String"]>;
-  tissueLocation?: Maybe<Scalars["String"]>;
-  tumorOrNormal?: Maybe<Scalars["String"]>;
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  igoSampleStatus?: Maybe<Scalars["String"]["output"]>;
+  importDate?: Maybe<Scalars["String"]["output"]>;
+  initialPipelineRunDate?: Maybe<Scalars["String"]["output"]>;
+  instrumentModel?: Maybe<Scalars["String"]["output"]>;
+  investigatorSampleId?: Maybe<Scalars["String"]["output"]>;
+  irbConsentProtocol?: Maybe<Scalars["String"]["output"]>;
+  mafCompleteDate?: Maybe<Scalars["String"]["output"]>;
+  mafCompleteNormalPrimaryId?: Maybe<Scalars["String"]["output"]>;
+  mafCompleteStatus?: Maybe<Scalars["String"]["output"]>;
+  molecularAccessionNumber?: Maybe<Scalars["String"]["output"]>;
+  oncotreeCode?: Maybe<Scalars["String"]["output"]>;
+  platform?: Maybe<Scalars["String"]["output"]>;
+  preservation?: Maybe<Scalars["String"]["output"]>;
+  primaryId?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteDate?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteReason?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteResult?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteStatus?: Maybe<Scalars["String"]["output"]>;
+  race?: Maybe<Scalars["String"]["output"]>;
+  recipe?: Maybe<Scalars["String"]["output"]>;
+  recordId: Scalars["String"]["output"];
+  revisable?: Maybe<Scalars["Boolean"]["output"]>;
+  sampleCategory: Scalars["String"]["output"];
+  sampleClass?: Maybe<Scalars["String"]["output"]>;
+  sampleCohortIds?: Maybe<Scalars["String"]["output"]>;
+  sampleOrigin?: Maybe<Scalars["String"]["output"]>;
+  sampleType?: Maybe<Scalars["String"]["output"]>;
+  sequencingDate?: Maybe<Scalars["String"]["output"]>;
+  sex?: Maybe<Scalars["String"]["output"]>;
+  smileSampleId: Scalars["String"]["output"];
+  species?: Maybe<Scalars["String"]["output"]>;
+  tissueLocation?: Maybe<Scalars["String"]["output"]>;
+  tumorOrNormal?: Maybe<Scalars["String"]["output"]>;
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type DashboardSampleInput = {
-  _total?: InputMaybe<Scalars["Int"]>;
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  altId?: InputMaybe<Scalars["String"]>;
-  analyteType?: InputMaybe<Scalars["String"]>;
-  baitSet?: InputMaybe<Scalars["String"]>;
-  bamCompleteDate?: InputMaybe<Scalars["String"]>;
-  bamCompleteStatus?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  cancerType?: InputMaybe<Scalars["String"]>;
-  cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  changedFieldNames: Array<Scalars["String"]>;
-  changelog?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  dbGapStudy?: InputMaybe<Scalars["String"]>;
-  dmpPatientAlias?: InputMaybe<Scalars["String"]>;
-  dmpRecommendedCoverage?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
-  historicalCmoSampleNames?: InputMaybe<Scalars["String"]>;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoDeliveryDate?: InputMaybe<Scalars["String"]>;
-  igoSampleStatus?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
-  instrumentModel?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  irbConsentProtocol?: InputMaybe<Scalars["String"]>;
-  mafCompleteDate?: InputMaybe<Scalars["String"]>;
-  mafCompleteNormalPrimaryId?: InputMaybe<Scalars["String"]>;
-  mafCompleteStatus?: InputMaybe<Scalars["String"]>;
-  molecularAccessionNumber?: InputMaybe<Scalars["String"]>;
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  platform?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
-  qcCompleteDate?: InputMaybe<Scalars["String"]>;
-  qcCompleteReason?: InputMaybe<Scalars["String"]>;
-  qcCompleteResult?: InputMaybe<Scalars["String"]>;
-  qcCompleteStatus?: InputMaybe<Scalars["String"]>;
-  race?: InputMaybe<Scalars["String"]>;
-  recipe?: InputMaybe<Scalars["String"]>;
-  recordId: Scalars["String"];
-  revisable?: InputMaybe<Scalars["Boolean"]>;
-  sampleCategory: Scalars["String"];
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleCohortIds?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
-  sequencingDate?: InputMaybe<Scalars["String"]>;
-  sex?: InputMaybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
-  species?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  _total?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  altId?: InputMaybe<Scalars["String"]["input"]>;
+  analyteType?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  bamCompleteDate?: InputMaybe<Scalars["String"]["input"]>;
+  bamCompleteStatus?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  cancerType?: InputMaybe<Scalars["String"]["input"]>;
+  cancerTypeDetailed?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  changedFieldNames: Array<Scalars["String"]["input"]>;
+  changelog?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy?: InputMaybe<Scalars["String"]["input"]>;
+  dmpPatientAlias?: InputMaybe<Scalars["String"]["input"]>;
+  dmpRecommendedCoverage?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
+  historicalCmoSampleNames?: InputMaybe<Scalars["String"]["input"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoDeliveryDate?: InputMaybe<Scalars["String"]["input"]>;
+  igoSampleStatus?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
+  instrumentModel?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  irbConsentProtocol?: InputMaybe<Scalars["String"]["input"]>;
+  mafCompleteDate?: InputMaybe<Scalars["String"]["input"]>;
+  mafCompleteNormalPrimaryId?: InputMaybe<Scalars["String"]["input"]>;
+  mafCompleteStatus?: InputMaybe<Scalars["String"]["input"]>;
+  molecularAccessionNumber?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  platform?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteDate?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteReason?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteResult?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteStatus?: InputMaybe<Scalars["String"]["input"]>;
+  race?: InputMaybe<Scalars["String"]["input"]>;
+  recipe?: InputMaybe<Scalars["String"]["input"]>;
+  recordId: Scalars["String"]["input"];
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
+  sampleCategory: Scalars["String"]["input"];
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCohortIds?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
+  sequencingDate?: InputMaybe<Scalars["String"]["input"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId: Scalars["String"]["input"];
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type DbGap = {
   __typename?: "DbGap";
-  dbGapStudy: Scalars["String"];
+  dbGapStudy: Scalars["String"]["output"];
   samplesHasDbgap: Array<Sample>;
   samplesHasDbgapAggregate?: Maybe<DbGapSampleSamplesHasDbgapAggregationSelection>;
   samplesHasDbgapConnection: DbGapSamplesHasDbgapConnection;
-  smileDbGapId: Scalars["String"];
+  smileDbGapId: Scalars["String"]["output"];
 };
 
 export type DbGapSamplesHasDbgapArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type DbGapSamplesHasDbgapAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type DbGapSamplesHasDbgapConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<DbGapSamplesHasDbgapConnectionSort>>;
   where?: InputMaybe<DbGapSamplesHasDbgapConnectionWhere>;
 };
 
 export type DbGapAggregateSelection = {
   __typename?: "DbGapAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   dbGapStudy: StringAggregateSelection;
   smileDbGapId: StringAggregateSelection;
 };
@@ -1705,9 +1793,9 @@ export type DbGapConnectWhere = {
 };
 
 export type DbGapCreateInput = {
-  dbGapStudy: Scalars["String"];
+  dbGapStudy: Scalars["String"]["input"];
   samplesHasDbgap?: InputMaybe<DbGapSamplesHasDbgapFieldInput>;
-  smileDbGapId: Scalars["String"];
+  smileDbGapId: Scalars["String"]["input"];
 };
 
 export type DbGapDeleteInput = {
@@ -1720,13 +1808,13 @@ export type DbGapDisconnectInput = {
 
 export type DbGapEdge = {
   __typename?: "DbGapEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: DbGap;
 };
 
 export type DbGapOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more DbGapSort objects to sort DbGaps by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<DbGapSort>>;
 };
@@ -1737,7 +1825,7 @@ export type DbGapRelationInput = {
 
 export type DbGapSampleSamplesHasDbgapAggregationSelection = {
   __typename?: "DbGapSampleSamplesHasDbgapAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<DbGapSampleSamplesHasDbgapNodeAggregateSelection>;
 };
 
@@ -1753,18 +1841,18 @@ export type DbGapSamplesHasDbgapAggregateInput = {
   AND?: InputMaybe<Array<DbGapSamplesHasDbgapAggregateInput>>;
   NOT?: InputMaybe<DbGapSamplesHasDbgapAggregateInput>;
   OR?: InputMaybe<Array<DbGapSamplesHasDbgapAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<DbGapSamplesHasDbgapNodeAggregationWhereInput>;
 };
 
 export type DbGapSamplesHasDbgapConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -1772,7 +1860,7 @@ export type DbGapSamplesHasDbgapConnection = {
   __typename?: "DbGapSamplesHasDbgapConnection";
   edges: Array<DbGapSamplesHasDbgapRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type DbGapSamplesHasDbgapConnectionSort = {
@@ -1809,71 +1897,71 @@ export type DbGapSamplesHasDbgapNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<DbGapSamplesHasDbgapNodeAggregationWhereInput>>;
   NOT?: InputMaybe<DbGapSamplesHasDbgapNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<DbGapSamplesHasDbgapNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type DbGapSamplesHasDbgapRelationship = {
   __typename?: "DbGapSamplesHasDbgapRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -1897,21 +1985,21 @@ export type DbGapSort = {
 };
 
 export type DbGapUpdateInput = {
-  dbGapStudy?: InputMaybe<Scalars["String"]>;
+  dbGapStudy?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasDbgap?: InputMaybe<Array<DbGapSamplesHasDbgapUpdateFieldInput>>;
-  smileDbGapId?: InputMaybe<Scalars["String"]>;
+  smileDbGapId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type DbGapWhere = {
   AND?: InputMaybe<Array<DbGapWhere>>;
   NOT?: InputMaybe<DbGapWhere>;
   OR?: InputMaybe<Array<DbGapWhere>>;
-  dbGapStudy?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dbGapStudy_MATCHES?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  dbGapStudy?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dbGapStudy_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasDbgapAggregate?: InputMaybe<DbGapSamplesHasDbgapAggregateInput>;
   /** Return DbGaps where all of the related DbGapSamplesHasDbgapConnections match this filter */
   samplesHasDbgapConnection_ALL?: InputMaybe<DbGapSamplesHasDbgapConnectionWhere>;
@@ -1929,70 +2017,70 @@ export type DbGapWhere = {
   samplesHasDbgap_SINGLE?: InputMaybe<SampleWhere>;
   /** Return DbGaps where some of the related Samples match this filter */
   samplesHasDbgap_SOME?: InputMaybe<SampleWhere>;
-  smileDbGapId?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileDbGapId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smileDbGapId?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileDbGapId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type DbGapsConnection = {
   __typename?: "DbGapsConnection";
   edges: Array<DbGapEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 /** Information about the number of nodes and relationships deleted during a delete mutation */
 export type DeleteInfo = {
   __typename?: "DeleteInfo";
   /** @deprecated This field has been deprecated because bookmarks are now handled by the driver. */
-  bookmark?: Maybe<Scalars["String"]>;
-  nodesDeleted: Scalars["Int"];
-  relationshipsDeleted: Scalars["Int"];
+  bookmark?: Maybe<Scalars["String"]["output"]>;
+  nodesDeleted: Scalars["Int"]["output"];
+  relationshipsDeleted: Scalars["Int"]["output"];
 };
 
 export type IgoQcReport = {
   __typename?: "IgoQcReport";
-  IGORecommendation?: Maybe<Scalars["String"]>;
-  comments?: Maybe<Scalars["String"]>;
-  investigatorDecision?: Maybe<Scalars["String"]>;
-  qcReportType?: Maybe<Scalars["String"]>;
+  IGORecommendation?: Maybe<Scalars["String"]["output"]>;
+  comments?: Maybe<Scalars["String"]["output"]>;
+  investigatorDecision?: Maybe<Scalars["String"]["output"]>;
+  qcReportType?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type MafComplete = {
   __typename?: "MafComplete";
-  date: Scalars["String"];
-  normalPrimaryId: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["output"];
+  normalPrimaryId: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
   temposHasEvent: Array<Tempo>;
   temposHasEventAggregate?: Maybe<MafCompleteTempoTemposHasEventAggregationSelection>;
   temposHasEventConnection: MafCompleteTemposHasEventConnection;
 };
 
 export type MafCompleteTemposHasEventArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type MafCompleteTemposHasEventAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type MafCompleteTemposHasEventConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<MafCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<MafCompleteTemposHasEventConnectionWhere>;
 };
 
 export type MafCompleteAggregateSelection = {
   __typename?: "MafCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   normalPrimaryId: StringAggregateSelection;
   status: StringAggregateSelection;
@@ -2009,9 +2097,9 @@ export type MafCompleteConnectWhere = {
 };
 
 export type MafCompleteCreateInput = {
-  date: Scalars["String"];
-  normalPrimaryId: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["input"];
+  normalPrimaryId: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
   temposHasEvent?: InputMaybe<MafCompleteTemposHasEventFieldInput>;
 };
 
@@ -2027,13 +2115,13 @@ export type MafCompleteDisconnectInput = {
 
 export type MafCompleteEdge = {
   __typename?: "MafCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: MafComplete;
 };
 
 export type MafCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more MafCompleteSort objects to sort MafCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<MafCompleteSort>>;
 };
@@ -2051,7 +2139,7 @@ export type MafCompleteSort = {
 
 export type MafCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "MafCompleteTempoTemposHasEventAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<MafCompleteTempoTemposHasEventNodeAggregateSelection>;
 };
 
@@ -2070,18 +2158,18 @@ export type MafCompleteTemposHasEventAggregateInput = {
   AND?: InputMaybe<Array<MafCompleteTemposHasEventAggregateInput>>;
   NOT?: InputMaybe<MafCompleteTemposHasEventAggregateInput>;
   OR?: InputMaybe<Array<MafCompleteTemposHasEventAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<MafCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type MafCompleteTemposHasEventConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -2089,7 +2177,7 @@ export type MafCompleteTemposHasEventConnection = {
   __typename?: "MafCompleteTemposHasEventConnection";
   edges: Array<MafCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type MafCompleteTemposHasEventConnectionSort = {
@@ -2126,116 +2214,164 @@ export type MafCompleteTemposHasEventNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<MafCompleteTemposHasEventNodeAggregationWhereInput>>;
   NOT?: InputMaybe<MafCompleteTemposHasEventNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<MafCompleteTemposHasEventNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type MafCompleteTemposHasEventRelationship = {
   __typename?: "MafCompleteTemposHasEventRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -2253,9 +2389,9 @@ export type MafCompleteTemposHasEventUpdateFieldInput = {
 };
 
 export type MafCompleteUpdateInput = {
-  date?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEvent?: InputMaybe<Array<MafCompleteTemposHasEventUpdateFieldInput>>;
 };
 
@@ -2263,24 +2399,24 @@ export type MafCompleteWhere = {
   AND?: InputMaybe<Array<MafCompleteWhere>>;
   NOT?: InputMaybe<MafCompleteWhere>;
   OR?: InputMaybe<Array<MafCompleteWhere>>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  normalPrimaryId_MATCHES?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  normalPrimaryId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEventAggregate?: InputMaybe<MafCompleteTemposHasEventAggregateInput>;
   /** Return MafCompletes where all of the related MafCompleteTemposHasEventConnections match this filter */
   temposHasEventConnection_ALL?: InputMaybe<MafCompleteTemposHasEventConnectionWhere>;
@@ -2304,7 +2440,7 @@ export type MafCompletesConnection = {
   __typename?: "MafCompletesConnection";
   edges: Array<MafCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Mutation = {
@@ -2601,10 +2737,10 @@ export type MutationUpdateTemposArgs = {
 /** Pagination information (Relay) */
 export type PageInfo = {
   __typename?: "PageInfo";
-  endCursor?: Maybe<Scalars["String"]>;
-  hasNextPage: Scalars["Boolean"];
-  hasPreviousPage: Scalars["Boolean"];
-  startCursor?: Maybe<Scalars["String"]>;
+  endCursor?: Maybe<Scalars["String"]["output"]>;
+  hasNextPage: Scalars["Boolean"]["output"];
+  hasPreviousPage: Scalars["Boolean"]["output"];
+  startCursor?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type Patient = {
@@ -2615,50 +2751,50 @@ export type Patient = {
   patientAliasesIsAlias: Array<PatientAlias>;
   patientAliasesIsAliasAggregate?: Maybe<PatientPatientAliasPatientAliasesIsAliasAggregationSelection>;
   patientAliasesIsAliasConnection: PatientPatientAliasesIsAliasConnection;
-  smilePatientId: Scalars["String"];
+  smilePatientId: Scalars["String"]["output"];
 };
 
 export type PatientHasSampleSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type PatientHasSampleSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type PatientHasSampleSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<PatientHasSampleSamplesConnectionSort>>;
   where?: InputMaybe<PatientHasSampleSamplesConnectionWhere>;
 };
 
 export type PatientPatientAliasesIsAliasArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<PatientAliasOptions>;
   where?: InputMaybe<PatientAliasWhere>;
 };
 
 export type PatientPatientAliasesIsAliasAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PatientAliasWhere>;
 };
 
 export type PatientPatientAliasesIsAliasConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<PatientPatientAliasesIsAliasConnectionSort>>;
   where?: InputMaybe<PatientPatientAliasesIsAliasConnectionWhere>;
 };
 
 export type PatientAggregateSelection = {
   __typename?: "PatientAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   smilePatientId: StringAggregateSelection;
 };
 
@@ -2667,32 +2803,32 @@ export type PatientAlias = {
   isAliasPatients: Array<Patient>;
   isAliasPatientsAggregate?: Maybe<PatientAliasPatientIsAliasPatientsAggregationSelection>;
   isAliasPatientsConnection: PatientAliasIsAliasPatientsConnection;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["output"];
+  value: Scalars["String"]["output"];
 };
 
 export type PatientAliasIsAliasPatientsArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<PatientOptions>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type PatientAliasIsAliasPatientsAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type PatientAliasIsAliasPatientsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<PatientAliasIsAliasPatientsConnectionSort>>;
   where?: InputMaybe<PatientAliasIsAliasPatientsConnectionWhere>;
 };
 
 export type PatientAliasAggregateSelection = {
   __typename?: "PatientAliasAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   namespace: StringAggregateSelection;
   value: StringAggregateSelection;
 };
@@ -2709,8 +2845,8 @@ export type PatientAliasConnectWhere = {
 
 export type PatientAliasCreateInput = {
   isAliasPatients?: InputMaybe<PatientAliasIsAliasPatientsFieldInput>;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["input"];
+  value: Scalars["String"]["input"];
 };
 
 export type PatientAliasDeleteInput = {
@@ -2727,7 +2863,7 @@ export type PatientAliasDisconnectInput = {
 
 export type PatientAliasEdge = {
   __typename?: "PatientAliasEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: PatientAlias;
 };
 
@@ -2735,18 +2871,18 @@ export type PatientAliasIsAliasPatientsAggregateInput = {
   AND?: InputMaybe<Array<PatientAliasIsAliasPatientsAggregateInput>>;
   NOT?: InputMaybe<PatientAliasIsAliasPatientsAggregateInput>;
   OR?: InputMaybe<Array<PatientAliasIsAliasPatientsAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<PatientAliasIsAliasPatientsNodeAggregationWhereInput>;
 };
 
 export type PatientAliasIsAliasPatientsConnectFieldInput = {
   connect?: InputMaybe<Array<PatientConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<PatientConnectWhere>;
 };
 
@@ -2754,7 +2890,7 @@ export type PatientAliasIsAliasPatientsConnection = {
   __typename?: "PatientAliasIsAliasPatientsConnection";
   edges: Array<PatientAliasIsAliasPatientsRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientAliasIsAliasPatientsConnectionSort = {
@@ -2791,26 +2927,26 @@ export type PatientAliasIsAliasPatientsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<PatientAliasIsAliasPatientsNodeAggregationWhereInput>>;
   NOT?: InputMaybe<PatientAliasIsAliasPatientsNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<PatientAliasIsAliasPatientsNodeAggregationWhereInput>>;
-  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PatientAliasIsAliasPatientsRelationship = {
   __typename?: "PatientAliasIsAliasPatientsRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Patient;
 };
 
@@ -2830,15 +2966,15 @@ export type PatientAliasIsAliasPatientsUpdateFieldInput = {
 };
 
 export type PatientAliasOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more PatientAliasSort objects to sort PatientAliases by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<PatientAliasSort>>;
 };
 
 export type PatientAliasPatientIsAliasPatientsAggregationSelection = {
   __typename?: "PatientAliasPatientIsAliasPatientsAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<PatientAliasPatientIsAliasPatientsNodeAggregateSelection>;
 };
 
@@ -2863,8 +2999,8 @@ export type PatientAliasUpdateInput = {
   isAliasPatients?: InputMaybe<
     Array<PatientAliasIsAliasPatientsUpdateFieldInput>
   >;
-  namespace?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientAliasWhere = {
@@ -2888,25 +3024,25 @@ export type PatientAliasWhere = {
   isAliasPatients_SINGLE?: InputMaybe<PatientWhere>;
   /** Return PatientAliases where some of the related Patients match this filter */
   isAliasPatients_SOME?: InputMaybe<PatientWhere>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
-  value_CONTAINS?: InputMaybe<Scalars["String"]>;
-  value_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  value_IN?: InputMaybe<Array<Scalars["String"]>>;
-  value_MATCHES?: InputMaybe<Scalars["String"]>;
-  value_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
+  value_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  value_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  value_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  value_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientAliasesConnection = {
   __typename?: "PatientAliasesConnection";
   edges: Array<PatientAliasEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientConnectInput = {
@@ -2925,7 +3061,7 @@ export type PatientConnectWhere = {
 export type PatientCreateInput = {
   hasSampleSamples?: InputMaybe<PatientHasSampleSamplesFieldInput>;
   patientAliasesIsAlias?: InputMaybe<PatientPatientAliasesIsAliasFieldInput>;
-  smilePatientId: Scalars["String"];
+  smilePatientId: Scalars["String"]["input"];
 };
 
 export type PatientDeleteInput = {
@@ -2946,7 +3082,7 @@ export type PatientDisconnectInput = {
 
 export type PatientEdge = {
   __typename?: "PatientEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Patient;
 };
 
@@ -2954,18 +3090,18 @@ export type PatientHasSampleSamplesAggregateInput = {
   AND?: InputMaybe<Array<PatientHasSampleSamplesAggregateInput>>;
   NOT?: InputMaybe<PatientHasSampleSamplesAggregateInput>;
   OR?: InputMaybe<Array<PatientHasSampleSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<PatientHasSampleSamplesNodeAggregationWhereInput>;
 };
 
 export type PatientHasSampleSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -2973,7 +3109,7 @@ export type PatientHasSampleSamplesConnection = {
   __typename?: "PatientHasSampleSamplesConnection";
   edges: Array<PatientHasSampleSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientHasSampleSamplesConnectionSort = {
@@ -3010,71 +3146,71 @@ export type PatientHasSampleSamplesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<PatientHasSampleSamplesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<PatientHasSampleSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<PatientHasSampleSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PatientHasSampleSamplesRelationship = {
   __typename?: "PatientHasSampleSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -3093,22 +3229,22 @@ export type PatientHasSampleSamplesUpdateFieldInput = {
 
 export type PatientIdsTriplet = {
   __typename?: "PatientIdsTriplet";
-  CMO_PATIENT_ID: Scalars["String"];
-  DMP_PATIENT_ID?: Maybe<Scalars["String"]>;
-  MRN: Scalars["String"];
-  RACE?: Maybe<Scalars["String"]>;
+  CMO_PATIENT_ID: Scalars["String"]["output"];
+  DMP_PATIENT_ID?: Maybe<Scalars["String"]["output"]>;
+  MRN: Scalars["String"]["output"];
+  RACE?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type PatientOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more PatientSort objects to sort Patients by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<PatientSort>>;
 };
 
 export type PatientPatientAliasPatientAliasesIsAliasAggregationSelection = {
   __typename?: "PatientPatientAliasPatientAliasesIsAliasAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<PatientPatientAliasPatientAliasesIsAliasNodeAggregateSelection>;
 };
 
@@ -3122,18 +3258,18 @@ export type PatientPatientAliasesIsAliasAggregateInput = {
   AND?: InputMaybe<Array<PatientPatientAliasesIsAliasAggregateInput>>;
   NOT?: InputMaybe<PatientPatientAliasesIsAliasAggregateInput>;
   OR?: InputMaybe<Array<PatientPatientAliasesIsAliasAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<PatientPatientAliasesIsAliasNodeAggregationWhereInput>;
 };
 
 export type PatientPatientAliasesIsAliasConnectFieldInput = {
   connect?: InputMaybe<Array<PatientAliasConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<PatientAliasConnectWhere>;
 };
 
@@ -3141,7 +3277,7 @@ export type PatientPatientAliasesIsAliasConnection = {
   __typename?: "PatientPatientAliasesIsAliasConnection";
   edges: Array<PatientPatientAliasesIsAliasRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientPatientAliasesIsAliasConnectionSort = {
@@ -3180,41 +3316,41 @@ export type PatientPatientAliasesIsAliasNodeAggregationWhereInput = {
   >;
   NOT?: InputMaybe<PatientPatientAliasesIsAliasNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<PatientPatientAliasesIsAliasNodeAggregationWhereInput>>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PatientPatientAliasesIsAliasRelationship = {
   __typename?: "PatientPatientAliasesIsAliasRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: PatientAlias;
 };
 
@@ -3242,7 +3378,7 @@ export type PatientRelationInput = {
 
 export type PatientSampleHasSampleSamplesAggregationSelection = {
   __typename?: "PatientSampleHasSampleSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<PatientSampleHasSampleSamplesNodeAggregateSelection>;
 };
 
@@ -3264,7 +3400,7 @@ export type PatientUpdateInput = {
   patientAliasesIsAlias?: InputMaybe<
     Array<PatientPatientAliasesIsAliasUpdateFieldInput>
   >;
-  smilePatientId?: InputMaybe<Scalars["String"]>;
+  smilePatientId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientWhere = {
@@ -3305,19 +3441,19 @@ export type PatientWhere = {
   patientAliasesIsAlias_SINGLE?: InputMaybe<PatientAliasWhere>;
   /** Return Patients where some of the related PatientAliases match this filter */
   patientAliasesIsAlias_SOME?: InputMaybe<PatientAliasWhere>;
-  smilePatientId?: InputMaybe<Scalars["String"]>;
-  smilePatientId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smilePatientId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smilePatientId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smilePatientId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smilePatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smilePatientId?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smilePatientId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientsConnection = {
   __typename?: "PatientsConnection";
   edges: Array<PatientEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Project = {
@@ -3325,32 +3461,32 @@ export type Project = {
   hasRequestRequests: Array<Request>;
   hasRequestRequestsAggregate?: Maybe<ProjectRequestHasRequestRequestsAggregationSelection>;
   hasRequestRequestsConnection: ProjectHasRequestRequestsConnection;
-  igoProjectId: Scalars["String"];
-  namespace: Scalars["String"];
+  igoProjectId: Scalars["String"]["output"];
+  namespace: Scalars["String"]["output"];
 };
 
 export type ProjectHasRequestRequestsArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type ProjectHasRequestRequestsAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type ProjectHasRequestRequestsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<ProjectHasRequestRequestsConnectionSort>>;
   where?: InputMaybe<ProjectHasRequestRequestsConnectionWhere>;
 };
 
 export type ProjectAggregateSelection = {
   __typename?: "ProjectAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   igoProjectId: StringAggregateSelection;
   namespace: StringAggregateSelection;
 };
@@ -3367,8 +3503,8 @@ export type ProjectConnectWhere = {
 
 export type ProjectCreateInput = {
   hasRequestRequests?: InputMaybe<ProjectHasRequestRequestsFieldInput>;
-  igoProjectId: Scalars["String"];
-  namespace: Scalars["String"];
+  igoProjectId: Scalars["String"]["input"];
+  namespace: Scalars["String"]["input"];
 };
 
 export type ProjectDeleteInput = {
@@ -3385,7 +3521,7 @@ export type ProjectDisconnectInput = {
 
 export type ProjectEdge = {
   __typename?: "ProjectEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Project;
 };
 
@@ -3393,18 +3529,18 @@ export type ProjectHasRequestRequestsAggregateInput = {
   AND?: InputMaybe<Array<ProjectHasRequestRequestsAggregateInput>>;
   NOT?: InputMaybe<ProjectHasRequestRequestsAggregateInput>;
   OR?: InputMaybe<Array<ProjectHasRequestRequestsAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<ProjectHasRequestRequestsNodeAggregationWhereInput>;
 };
 
 export type ProjectHasRequestRequestsConnectFieldInput = {
   connect?: InputMaybe<Array<RequestConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestConnectWhere>;
 };
 
@@ -3412,7 +3548,7 @@ export type ProjectHasRequestRequestsConnection = {
   __typename?: "ProjectHasRequestRequestsConnection";
   edges: Array<ProjectHasRequestRequestsRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type ProjectHasRequestRequestsConnectionSort = {
@@ -3449,331 +3585,341 @@ export type ProjectHasRequestRequestsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<ProjectHasRequestRequestsNodeAggregationWhereInput>>;
   NOT?: InputMaybe<ProjectHasRequestRequestsNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<ProjectHasRequestRequestsNodeAggregationWhereInput>>;
-  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type ProjectHasRequestRequestsRelationship = {
   __typename?: "ProjectHasRequestRequestsRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -3791,8 +3937,8 @@ export type ProjectHasRequestRequestsUpdateFieldInput = {
 };
 
 export type ProjectOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more ProjectSort objects to sort Projects by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<ProjectSort>>;
 };
@@ -3805,7 +3951,7 @@ export type ProjectRelationInput = {
 
 export type ProjectRequestHasRequestRequestsAggregationSelection = {
   __typename?: "ProjectRequestHasRequestRequestsAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<ProjectRequestHasRequestRequestsNodeAggregateSelection>;
 };
 
@@ -3844,8 +3990,8 @@ export type ProjectUpdateInput = {
   hasRequestRequests?: InputMaybe<
     Array<ProjectHasRequestRequestsUpdateFieldInput>
   >;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type ProjectWhere = {
@@ -3869,60 +4015,60 @@ export type ProjectWhere = {
   hasRequestRequests_SINGLE?: InputMaybe<RequestWhere>;
   /** Return Projects where some of the related Requests match this filter */
   hasRequestRequests_SOME?: InputMaybe<RequestWhere>;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type ProjectsConnection = {
   __typename?: "ProjectsConnection";
   edges: Array<ProjectEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type QcComplete = {
   __typename?: "QcComplete";
-  date: Scalars["String"];
-  reason: Scalars["String"];
-  result: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["output"];
+  reason: Scalars["String"]["output"];
+  result: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
   temposHasEvent: Array<Tempo>;
   temposHasEventAggregate?: Maybe<QcCompleteTempoTemposHasEventAggregationSelection>;
   temposHasEventConnection: QcCompleteTemposHasEventConnection;
 };
 
 export type QcCompleteTemposHasEventArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type QcCompleteTemposHasEventAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type QcCompleteTemposHasEventConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<QcCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<QcCompleteTemposHasEventConnectionWhere>;
 };
 
 export type QcCompleteAggregateSelection = {
   __typename?: "QcCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   reason: StringAggregateSelection;
   result: StringAggregateSelection;
@@ -3938,10 +4084,10 @@ export type QcCompleteConnectWhere = {
 };
 
 export type QcCompleteCreateInput = {
-  date: Scalars["String"];
-  reason: Scalars["String"];
-  result: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["input"];
+  reason: Scalars["String"]["input"];
+  result: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
   temposHasEvent?: InputMaybe<QcCompleteTemposHasEventFieldInput>;
 };
 
@@ -3957,13 +4103,13 @@ export type QcCompleteDisconnectInput = {
 
 export type QcCompleteEdge = {
   __typename?: "QcCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: QcComplete;
 };
 
 export type QcCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more QcCompleteSort objects to sort QcCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<QcCompleteSort>>;
 };
@@ -3982,7 +4128,7 @@ export type QcCompleteSort = {
 
 export type QcCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "QcCompleteTempoTemposHasEventAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<QcCompleteTempoTemposHasEventNodeAggregateSelection>;
 };
 
@@ -4001,18 +4147,18 @@ export type QcCompleteTemposHasEventAggregateInput = {
   AND?: InputMaybe<Array<QcCompleteTemposHasEventAggregateInput>>;
   NOT?: InputMaybe<QcCompleteTemposHasEventAggregateInput>;
   OR?: InputMaybe<Array<QcCompleteTemposHasEventAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<QcCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type QcCompleteTemposHasEventConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -4020,7 +4166,7 @@ export type QcCompleteTemposHasEventConnection = {
   __typename?: "QcCompleteTemposHasEventConnection";
   edges: Array<QcCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type QcCompleteTemposHasEventConnectionSort = {
@@ -4057,116 +4203,164 @@ export type QcCompleteTemposHasEventNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<QcCompleteTemposHasEventNodeAggregationWhereInput>>;
   NOT?: InputMaybe<QcCompleteTemposHasEventNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<QcCompleteTemposHasEventNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QcCompleteTemposHasEventRelationship = {
   __typename?: "QcCompleteTemposHasEventRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -4184,10 +4378,10 @@ export type QcCompleteTemposHasEventUpdateFieldInput = {
 };
 
 export type QcCompleteUpdateInput = {
-  date?: InputMaybe<Scalars["String"]>;
-  reason?: InputMaybe<Scalars["String"]>;
-  result?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  reason?: InputMaybe<Scalars["String"]["input"]>;
+  result?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEvent?: InputMaybe<Array<QcCompleteTemposHasEventUpdateFieldInput>>;
 };
 
@@ -4195,30 +4389,30 @@ export type QcCompleteWhere = {
   AND?: InputMaybe<Array<QcCompleteWhere>>;
   NOT?: InputMaybe<QcCompleteWhere>;
   OR?: InputMaybe<Array<QcCompleteWhere>>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  reason?: InputMaybe<Scalars["String"]>;
-  reason_CONTAINS?: InputMaybe<Scalars["String"]>;
-  reason_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  reason_IN?: InputMaybe<Array<Scalars["String"]>>;
-  reason_MATCHES?: InputMaybe<Scalars["String"]>;
-  reason_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  result?: InputMaybe<Scalars["String"]>;
-  result_CONTAINS?: InputMaybe<Scalars["String"]>;
-  result_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  result_IN?: InputMaybe<Array<Scalars["String"]>>;
-  result_MATCHES?: InputMaybe<Scalars["String"]>;
-  result_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  reason?: InputMaybe<Scalars["String"]["input"]>;
+  reason_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  reason_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  reason_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  reason_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  reason_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  result?: InputMaybe<Scalars["String"]["input"]>;
+  result_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  result_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  result_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  result_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  result_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEventAggregate?: InputMaybe<QcCompleteTemposHasEventAggregateInput>;
   /** Return QcCompletes where all of the related QcCompleteTemposHasEventConnections match this filter */
   temposHasEventConnection_ALL?: InputMaybe<QcCompleteTemposHasEventConnectionWhere>;
@@ -4242,13 +4436,13 @@ export type QcCompletesConnection = {
   __typename?: "QcCompletesConnection";
   edges: Array<QcCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Query = {
   __typename?: "Query";
   allAnchorSeqDateData: Array<AnchorSeqDateData>;
-  allBlockedCohortIds: Array<Scalars["String"]>;
+  allBlockedCohortIds: Array<Scalars["String"]["output"]>;
   bamCompletes: Array<BamComplete>;
   bamCompletesAggregate: BamCompleteAggregateSelection;
   bamCompletesConnection: BamCompletesConnection;
@@ -4305,7 +4499,7 @@ export type Query = {
 };
 
 export type QueryAllAnchorSeqDateDataArgs = {
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type QueryBamCompletesArgs = {
@@ -4318,8 +4512,8 @@ export type QueryBamCompletesAggregateArgs = {
 };
 
 export type QueryBamCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<BamCompleteSort>>>;
   where?: InputMaybe<BamCompleteWhere>;
 };
@@ -4334,8 +4528,8 @@ export type QueryCohortCompletesAggregateArgs = {
 };
 
 export type QueryCohortCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<CohortCompleteSort>>>;
   where?: InputMaybe<CohortCompleteWhere>;
 };
@@ -4350,52 +4544,52 @@ export type QueryCohortsAggregateArgs = {
 };
 
 export type QueryCohortsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<CohortSort>>>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type QueryDashboardCohortsArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardPatientsArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardRequestsArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardSampleHistoryArgs = {
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  searchVals: Array<Scalars["String"]>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  searchVals: Array<Scalars["String"]["input"]>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardSamplesArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  includeDemographics: Scalars["Boolean"];
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  includeDemographics: Scalars["Boolean"]["input"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   recordContexts?: InputMaybe<Array<InputMaybe<DashboardRecordContext>>>;
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
@@ -4409,8 +4603,8 @@ export type QueryDbGapsAggregateArgs = {
 };
 
 export type QueryDbGapsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<DbGapSort>>>;
   where?: InputMaybe<DbGapWhere>;
 };
@@ -4425,8 +4619,8 @@ export type QueryMafCompletesAggregateArgs = {
 };
 
 export type QueryMafCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<MafCompleteSort>>>;
   where?: InputMaybe<MafCompleteWhere>;
 };
@@ -4441,8 +4635,8 @@ export type QueryPatientAliasesAggregateArgs = {
 };
 
 export type QueryPatientAliasesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<PatientAliasSort>>>;
   where?: InputMaybe<PatientAliasWhere>;
 };
@@ -4457,8 +4651,8 @@ export type QueryPatientsAggregateArgs = {
 };
 
 export type QueryPatientsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<PatientSort>>>;
   where?: InputMaybe<PatientWhere>;
 };
@@ -4473,8 +4667,8 @@ export type QueryProjectsAggregateArgs = {
 };
 
 export type QueryProjectsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<ProjectSort>>>;
   where?: InputMaybe<ProjectWhere>;
 };
@@ -4489,8 +4683,8 @@ export type QueryQcCompletesAggregateArgs = {
 };
 
 export type QueryQcCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<QcCompleteSort>>>;
   where?: InputMaybe<QcCompleteWhere>;
 };
@@ -4505,8 +4699,8 @@ export type QueryRequestMetadataAggregateArgs = {
 };
 
 export type QueryRequestMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<RequestMetadataSort>>>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
@@ -4521,8 +4715,8 @@ export type QueryRequestsAggregateArgs = {
 };
 
 export type QueryRequestsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<RequestSort>>>;
   where?: InputMaybe<RequestWhere>;
 };
@@ -4537,8 +4731,8 @@ export type QuerySampleAliasesAggregateArgs = {
 };
 
 export type QuerySampleAliasesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<SampleAliasSort>>>;
   where?: InputMaybe<SampleAliasWhere>;
 };
@@ -4553,8 +4747,8 @@ export type QuerySampleMetadataAggregateArgs = {
 };
 
 export type QuerySampleMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<SampleMetadataSort>>>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
@@ -4569,8 +4763,8 @@ export type QuerySamplesAggregateArgs = {
 };
 
 export type QuerySamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<SampleSort>>>;
   where?: InputMaybe<SampleWhere>;
 };
@@ -4585,8 +4779,8 @@ export type QueryStatusesAggregateArgs = {
 };
 
 export type QueryStatusesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<StatusSort>>>;
   where?: InputMaybe<StatusWhere>;
 };
@@ -4601,109 +4795,109 @@ export type QueryTemposAggregateArgs = {
 };
 
 export type QueryTemposConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<TempoSort>>>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type Request = {
   __typename?: "Request";
-  bicAnalysis: Scalars["Boolean"];
-  dataAccessEmails: Scalars["String"];
-  dataAnalystEmail: Scalars["String"];
-  dataAnalystName: Scalars["String"];
-  genePanel: Scalars["String"];
+  bicAnalysis: Scalars["Boolean"]["output"];
+  dataAccessEmails: Scalars["String"]["output"];
+  dataAnalystEmail: Scalars["String"]["output"];
+  dataAnalystName: Scalars["String"]["output"];
+  genePanel: Scalars["String"]["output"];
   hasMetadataRequestMetadata: Array<RequestMetadata>;
   hasMetadataRequestMetadataAggregate?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection>;
   hasMetadataRequestMetadataConnection: RequestHasMetadataRequestMetadataConnection;
   hasSampleSamples: Array<Sample>;
   hasSampleSamplesAggregate?: Maybe<RequestSampleHasSampleSamplesAggregationSelection>;
   hasSampleSamplesConnection: RequestHasSampleSamplesConnection;
-  igoDeliveryDate?: Maybe<Scalars["BigInt"]>;
-  igoProjectId: Scalars["String"];
-  igoRequestId: Scalars["String"];
-  ilabRequestId?: Maybe<Scalars["String"]>;
-  investigatorEmail: Scalars["String"];
-  investigatorName: Scalars["String"];
-  isCmoRequest: Scalars["Boolean"];
-  labHeadEmail: Scalars["String"];
-  labHeadName: Scalars["String"];
-  libraryType?: Maybe<Scalars["String"]>;
-  namespace: Scalars["String"];
-  otherContactEmails: Scalars["String"];
-  piEmail: Scalars["String"];
-  pooledNormals?: Maybe<Array<Maybe<Scalars["String"]>>>;
-  projectManagerName: Scalars["String"];
+  igoDeliveryDate?: Maybe<Scalars["BigInt"]["output"]>;
+  igoProjectId: Scalars["String"]["output"];
+  igoRequestId: Scalars["String"]["output"];
+  ilabRequestId?: Maybe<Scalars["String"]["output"]>;
+  investigatorEmail: Scalars["String"]["output"];
+  investigatorName: Scalars["String"]["output"];
+  isCmoRequest: Scalars["Boolean"]["output"];
+  labHeadEmail: Scalars["String"]["output"];
+  labHeadName: Scalars["String"]["output"];
+  libraryType?: Maybe<Scalars["String"]["output"]>;
+  namespace: Scalars["String"]["output"];
+  otherContactEmails: Scalars["String"]["output"];
+  piEmail: Scalars["String"]["output"];
+  pooledNormals?: Maybe<Array<Maybe<Scalars["String"]["output"]>>>;
+  projectManagerName: Scalars["String"]["output"];
   projectsHasRequest: Array<Project>;
   projectsHasRequestAggregate?: Maybe<RequestProjectProjectsHasRequestAggregationSelection>;
   projectsHasRequestConnection: RequestProjectsHasRequestConnection;
-  qcAccessEmails: Scalars["String"];
-  requestJson: Scalars["String"];
-  smileRequestId: Scalars["String"];
-  strand?: Maybe<Scalars["String"]>;
+  qcAccessEmails: Scalars["String"]["output"];
+  requestJson: Scalars["String"]["output"];
+  smileRequestId: Scalars["String"]["output"];
+  strand?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type RequestHasMetadataRequestMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestMetadataOptions>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type RequestHasMetadataRequestMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type RequestHasMetadataRequestMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionSort>>;
   where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
 };
 
 export type RequestHasSampleSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type RequestHasSampleSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type RequestHasSampleSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestHasSampleSamplesConnectionSort>>;
   where?: InputMaybe<RequestHasSampleSamplesConnectionWhere>;
 };
 
 export type RequestProjectsHasRequestArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<ProjectOptions>;
   where?: InputMaybe<ProjectWhere>;
 };
 
 export type RequestProjectsHasRequestAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ProjectWhere>;
 };
 
 export type RequestProjectsHasRequestConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestProjectsHasRequestConnectionSort>>;
   where?: InputMaybe<RequestProjectsHasRequestConnectionWhere>;
 };
 
 export type RequestAggregateSelection = {
   __typename?: "RequestAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   dataAccessEmails: StringAggregateSelection;
   dataAnalystEmail: StringAggregateSelection;
   dataAnalystName: StringAggregateSelection;
@@ -4744,33 +4938,33 @@ export type RequestConnectWhere = {
 };
 
 export type RequestCreateInput = {
-  bicAnalysis: Scalars["Boolean"];
-  dataAccessEmails: Scalars["String"];
-  dataAnalystEmail: Scalars["String"];
-  dataAnalystName: Scalars["String"];
-  genePanel: Scalars["String"];
+  bicAnalysis: Scalars["Boolean"]["input"];
+  dataAccessEmails: Scalars["String"]["input"];
+  dataAnalystEmail: Scalars["String"]["input"];
+  dataAnalystName: Scalars["String"]["input"];
+  genePanel: Scalars["String"]["input"];
   hasMetadataRequestMetadata?: InputMaybe<RequestHasMetadataRequestMetadataFieldInput>;
   hasSampleSamples?: InputMaybe<RequestHasSampleSamplesFieldInput>;
-  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId: Scalars["String"];
-  igoRequestId: Scalars["String"];
-  ilabRequestId?: InputMaybe<Scalars["String"]>;
-  investigatorEmail: Scalars["String"];
-  investigatorName: Scalars["String"];
-  isCmoRequest: Scalars["Boolean"];
-  labHeadEmail: Scalars["String"];
-  labHeadName: Scalars["String"];
-  libraryType?: InputMaybe<Scalars["String"]>;
-  namespace: Scalars["String"];
-  otherContactEmails: Scalars["String"];
-  piEmail: Scalars["String"];
-  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  projectManagerName: Scalars["String"];
+  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId: Scalars["String"]["input"];
+  igoRequestId: Scalars["String"]["input"];
+  ilabRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail: Scalars["String"]["input"];
+  investigatorName: Scalars["String"]["input"];
+  isCmoRequest: Scalars["Boolean"]["input"];
+  labHeadEmail: Scalars["String"]["input"];
+  labHeadName: Scalars["String"]["input"];
+  libraryType?: InputMaybe<Scalars["String"]["input"]>;
+  namespace: Scalars["String"]["input"];
+  otherContactEmails: Scalars["String"]["input"];
+  piEmail: Scalars["String"]["input"];
+  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  projectManagerName: Scalars["String"]["input"];
   projectsHasRequest?: InputMaybe<RequestProjectsHasRequestFieldInput>;
-  qcAccessEmails: Scalars["String"];
-  requestJson: Scalars["String"];
-  smileRequestId: Scalars["String"];
-  strand?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails: Scalars["String"]["input"];
+  requestJson: Scalars["String"]["input"];
+  smileRequestId: Scalars["String"]["input"];
+  strand?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RequestDeleteInput = {
@@ -4797,7 +4991,7 @@ export type RequestDisconnectInput = {
 
 export type RequestEdge = {
   __typename?: "RequestEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -4805,18 +4999,18 @@ export type RequestHasMetadataRequestMetadataAggregateInput = {
   AND?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
   NOT?: InputMaybe<RequestHasMetadataRequestMetadataAggregateInput>;
   OR?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>;
 };
 
 export type RequestHasMetadataRequestMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<RequestMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestMetadataConnectWhere>;
 };
 
@@ -4824,7 +5018,7 @@ export type RequestHasMetadataRequestMetadataConnection = {
   __typename?: "RequestHasMetadataRequestMetadataConnection";
   edges: Array<RequestHasMetadataRequestMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestHasMetadataRequestMetadataConnectionSort = {
@@ -4867,61 +5061,71 @@ export type RequestHasMetadataRequestMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>
   >;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestHasMetadataRequestMetadataRelationship = {
   __typename?: "RequestHasMetadataRequestMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: RequestMetadata;
 };
 
@@ -4946,18 +5150,18 @@ export type RequestHasSampleSamplesAggregateInput = {
   AND?: InputMaybe<Array<RequestHasSampleSamplesAggregateInput>>;
   NOT?: InputMaybe<RequestHasSampleSamplesAggregateInput>;
   OR?: InputMaybe<Array<RequestHasSampleSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestHasSampleSamplesNodeAggregationWhereInput>;
 };
 
 export type RequestHasSampleSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -4965,7 +5169,7 @@ export type RequestHasSampleSamplesConnection = {
   __typename?: "RequestHasSampleSamplesConnection";
   edges: Array<RequestHasSampleSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestHasSampleSamplesConnectionSort = {
@@ -5002,71 +5206,71 @@ export type RequestHasSampleSamplesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<RequestHasSampleSamplesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<RequestHasSampleSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<RequestHasSampleSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestHasSampleSamplesRelationship = {
   __typename?: "RequestHasSampleSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -5088,55 +5292,55 @@ export type RequestMetadata = {
   hasStatusStatuses: Array<Status>;
   hasStatusStatusesAggregate?: Maybe<RequestMetadataStatusHasStatusStatusesAggregationSelection>;
   hasStatusStatusesConnection: RequestMetadataHasStatusStatusesConnection;
-  igoRequestId: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  requestMetadataJson: Scalars["String"];
+  igoRequestId: Scalars["String"]["output"];
+  importDate: Scalars["BigInt"]["output"];
+  requestMetadataJson: Scalars["String"]["output"];
   requestsHasMetadata: Array<Request>;
   requestsHasMetadataAggregate?: Maybe<RequestMetadataRequestRequestsHasMetadataAggregationSelection>;
   requestsHasMetadataConnection: RequestMetadataRequestsHasMetadataConnection;
 };
 
 export type RequestMetadataHasStatusStatusesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<StatusOptions>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type RequestMetadataHasStatusStatusesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type RequestMetadataHasStatusStatusesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestMetadataHasStatusStatusesConnectionSort>>;
   where?: InputMaybe<RequestMetadataHasStatusStatusesConnectionWhere>;
 };
 
 export type RequestMetadataRequestsHasMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type RequestMetadataRequestsHasMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type RequestMetadataRequestsHasMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionSort>>;
   where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
 };
 
 export type RequestMetadataAggregateSelection = {
   __typename?: "RequestMetadataAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   igoRequestId: StringAggregateSelection;
   importDate: BigIntAggregateSelection;
   requestMetadataJson: StringAggregateSelection;
@@ -5159,14 +5363,14 @@ export type RequestMetadataConnection = {
   __typename?: "RequestMetadataConnection";
   edges: Array<RequestMetadataEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestMetadataCreateInput = {
   hasStatusStatuses?: InputMaybe<RequestMetadataHasStatusStatusesFieldInput>;
-  igoRequestId: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  requestMetadataJson: Scalars["String"];
+  igoRequestId: Scalars["String"]["input"];
+  importDate: Scalars["BigInt"]["input"];
+  requestMetadataJson: Scalars["String"]["input"];
   requestsHasMetadata?: InputMaybe<RequestMetadataRequestsHasMetadataFieldInput>;
 };
 
@@ -5190,7 +5394,7 @@ export type RequestMetadataDisconnectInput = {
 
 export type RequestMetadataEdge = {
   __typename?: "RequestMetadataEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: RequestMetadata;
 };
 
@@ -5198,18 +5402,18 @@ export type RequestMetadataHasStatusStatusesAggregateInput = {
   AND?: InputMaybe<Array<RequestMetadataHasStatusStatusesAggregateInput>>;
   NOT?: InputMaybe<RequestMetadataHasStatusStatusesAggregateInput>;
   OR?: InputMaybe<Array<RequestMetadataHasStatusStatusesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestMetadataHasStatusStatusesNodeAggregationWhereInput>;
 };
 
 export type RequestMetadataHasStatusStatusesConnectFieldInput = {
   connect?: InputMaybe<Array<StatusConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<StatusConnectWhere>;
 };
 
@@ -5217,7 +5421,7 @@ export type RequestMetadataHasStatusStatusesConnection = {
   __typename?: "RequestMetadataHasStatusStatusesConnection";
   edges: Array<RequestMetadataHasStatusStatusesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestMetadataHasStatusStatusesConnectionSort = {
@@ -5260,26 +5464,26 @@ export type RequestMetadataHasStatusStatusesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesNodeAggregationWhereInput>
   >;
-  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestMetadataHasStatusStatusesRelationship = {
   __typename?: "RequestMetadataHasStatusStatusesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Status;
 };
 
@@ -5301,8 +5505,8 @@ export type RequestMetadataHasStatusStatusesUpdateFieldInput = {
 };
 
 export type RequestMetadataOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more RequestMetadataSort objects to sort RequestMetadata by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<RequestMetadataSort>>;
 };
@@ -5318,7 +5522,7 @@ export type RequestMetadataRelationInput = {
 
 export type RequestMetadataRequestRequestsHasMetadataAggregationSelection = {
   __typename?: "RequestMetadataRequestRequestsHasMetadataAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection>;
 };
 
@@ -5351,18 +5555,18 @@ export type RequestMetadataRequestsHasMetadataAggregateInput = {
   AND?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
   NOT?: InputMaybe<RequestMetadataRequestsHasMetadataAggregateInput>;
   OR?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>;
 };
 
 export type RequestMetadataRequestsHasMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<RequestConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestConnectWhere>;
 };
 
@@ -5370,7 +5574,7 @@ export type RequestMetadataRequestsHasMetadataConnection = {
   __typename?: "RequestMetadataRequestsHasMetadataConnection";
   edges: Array<RequestMetadataRequestsHasMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestMetadataRequestsHasMetadataConnectionSort = {
@@ -5415,331 +5619,341 @@ export type RequestMetadataRequestsHasMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>
   >;
-  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestMetadataRequestsHasMetadataRelationship = {
   __typename?: "RequestMetadataRequestsHasMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -5773,7 +5987,7 @@ export type RequestMetadataSort = {
 
 export type RequestMetadataStatusHasStatusStatusesAggregationSelection = {
   __typename?: "RequestMetadataStatusHasStatusStatusesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestMetadataStatusHasStatusStatusesNodeAggregateSelection>;
 };
 
@@ -5786,11 +6000,11 @@ export type RequestMetadataUpdateInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesUpdateFieldInput>
   >;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson?: InputMaybe<Scalars["String"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson?: InputMaybe<Scalars["String"]["input"]>;
   requestsHasMetadata?: InputMaybe<
     Array<RequestMetadataRequestsHasMetadataUpdateFieldInput>
   >;
@@ -5817,24 +6031,24 @@ export type RequestMetadataWhere = {
   hasStatusStatuses_SINGLE?: InputMaybe<StatusWhere>;
   /** Return RequestMetadata where some of the related Statuses match this filter */
   hasStatusStatuses_SOME?: InputMaybe<StatusWhere>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]>>;
-  importDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_CONTAINS?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_IN?: InputMaybe<Array<Scalars["String"]>>;
-  requestMetadataJson_MATCHES?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  importDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  requestMetadataJson_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   requestsHasMetadataAggregate?: InputMaybe<RequestMetadataRequestsHasMetadataAggregateInput>;
   /** Return RequestMetadata where all of the related RequestMetadataRequestsHasMetadataConnections match this filter */
   requestsHasMetadataConnection_ALL?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
@@ -5855,15 +6069,15 @@ export type RequestMetadataWhere = {
 };
 
 export type RequestOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more RequestSort objects to sort Requests by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<RequestSort>>;
 };
 
 export type RequestProjectProjectsHasRequestAggregationSelection = {
   __typename?: "RequestProjectProjectsHasRequestAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestProjectProjectsHasRequestNodeAggregateSelection>;
 };
 
@@ -5877,18 +6091,18 @@ export type RequestProjectsHasRequestAggregateInput = {
   AND?: InputMaybe<Array<RequestProjectsHasRequestAggregateInput>>;
   NOT?: InputMaybe<RequestProjectsHasRequestAggregateInput>;
   OR?: InputMaybe<Array<RequestProjectsHasRequestAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestProjectsHasRequestNodeAggregationWhereInput>;
 };
 
 export type RequestProjectsHasRequestConnectFieldInput = {
   connect?: InputMaybe<Array<ProjectConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<ProjectConnectWhere>;
 };
 
@@ -5896,7 +6110,7 @@ export type RequestProjectsHasRequestConnection = {
   __typename?: "RequestProjectsHasRequestConnection";
   edges: Array<RequestProjectsHasRequestRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestProjectsHasRequestConnectionSort = {
@@ -5933,41 +6147,41 @@ export type RequestProjectsHasRequestNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<RequestProjectsHasRequestNodeAggregationWhereInput>>;
   NOT?: InputMaybe<RequestProjectsHasRequestNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<RequestProjectsHasRequestNodeAggregationWhereInput>>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestProjectsHasRequestRelationship = {
   __typename?: "RequestProjectsHasRequestRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Project;
 };
 
@@ -5997,7 +6211,7 @@ export type RequestRelationInput = {
 export type RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection =
   {
     __typename?: "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection>;
   };
 
@@ -6011,7 +6225,7 @@ export type RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelecti
 
 export type RequestSampleHasSampleSamplesAggregationSelection = {
   __typename?: "RequestSampleHasSampleSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestSampleHasSampleSamplesNodeAggregateSelection>;
 };
 
@@ -6051,72 +6265,74 @@ export type RequestSort = {
 };
 
 export type RequestUpdateInput = {
-  bicAnalysis?: InputMaybe<Scalars["Boolean"]>;
-  dataAccessEmails?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail?: InputMaybe<Scalars["String"]>;
-  dataAnalystName?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
+  bicAnalysis?: InputMaybe<Scalars["Boolean"]["input"]>;
+  dataAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
   hasMetadataRequestMetadata?: InputMaybe<
     Array<RequestHasMetadataRequestMetadataUpdateFieldInput>
   >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesUpdateFieldInput>>;
-  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  ilabRequestId?: InputMaybe<Scalars["String"]>;
-  investigatorEmail?: InputMaybe<Scalars["String"]>;
-  investigatorName?: InputMaybe<Scalars["String"]>;
-  isCmoRequest?: InputMaybe<Scalars["Boolean"]>;
-  labHeadEmail?: InputMaybe<Scalars["String"]>;
-  labHeadName?: InputMaybe<Scalars["String"]>;
-  libraryType?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  otherContactEmails?: InputMaybe<Scalars["String"]>;
-  piEmail?: InputMaybe<Scalars["String"]>;
-  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pooledNormals_POP?: InputMaybe<Scalars["Int"]>;
-  pooledNormals_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  projectManagerName?: InputMaybe<Scalars["String"]>;
+  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName?: InputMaybe<Scalars["String"]["input"]>;
+  isCmoRequest?: InputMaybe<Scalars["Boolean"]["input"]>;
+  labHeadEmail?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail?: InputMaybe<Scalars["String"]["input"]>;
+  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pooledNormals_POP?: InputMaybe<Scalars["Int"]["input"]>;
+  pooledNormals_PUSH?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  projectManagerName?: InputMaybe<Scalars["String"]["input"]>;
   projectsHasRequest?: InputMaybe<
     Array<RequestProjectsHasRequestUpdateFieldInput>
   >;
-  qcAccessEmails?: InputMaybe<Scalars["String"]>;
-  requestJson?: InputMaybe<Scalars["String"]>;
-  smileRequestId?: InputMaybe<Scalars["String"]>;
-  strand?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  strand?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RequestWhere = {
   AND?: InputMaybe<Array<RequestWhere>>;
   NOT?: InputMaybe<RequestWhere>;
   OR?: InputMaybe<Array<RequestWhere>>;
-  bicAnalysis?: InputMaybe<Scalars["Boolean"]>;
-  dataAccessEmails?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dataAccessEmails_MATCHES?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dataAnalystEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystName?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dataAnalystName_MATCHES?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
-  genePanel_CONTAINS?: InputMaybe<Scalars["String"]>;
-  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel_IN?: InputMaybe<Array<Scalars["String"]>>;
-  genePanel_MATCHES?: InputMaybe<Scalars["String"]>;
-  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  bicAnalysis?: InputMaybe<Scalars["Boolean"]["input"]>;
+  dataAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dataAccessEmails_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dataAnalystEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dataAnalystName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  genePanel_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasMetadataRequestMetadataAggregate?: InputMaybe<RequestHasMetadataRequestMetadataAggregateInput>;
   /** Return Requests where all of the related RequestHasMetadataRequestMetadataConnections match this filter */
   hasMetadataRequestMetadataConnection_ALL?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
@@ -6151,87 +6367,89 @@ export type RequestWhere = {
   hasSampleSamples_SINGLE?: InputMaybe<SampleWhere>;
   /** Return Requests where some of the related Samples match this filter */
   hasSampleSamples_SOME?: InputMaybe<SampleWhere>;
-  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_IN?: InputMaybe<Array<InputMaybe<Scalars["BigInt"]>>>;
-  igoDeliveryDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  ilabRequestId?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  ilabRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorEmail?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  investigatorEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorName?: InputMaybe<Scalars["String"]>;
-  investigatorName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  investigatorName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  investigatorName_MATCHES?: InputMaybe<Scalars["String"]>;
-  investigatorName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  isCmoRequest?: InputMaybe<Scalars["Boolean"]>;
-  labHeadEmail?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  labHeadEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  labHeadName?: InputMaybe<Scalars["String"]>;
-  labHeadName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  labHeadName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  labHeadName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  labHeadName_MATCHES?: InputMaybe<Scalars["String"]>;
-  labHeadName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  libraryType?: InputMaybe<Scalars["String"]>;
-  libraryType_CONTAINS?: InputMaybe<Scalars["String"]>;
-  libraryType_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  libraryType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  libraryType_MATCHES?: InputMaybe<Scalars["String"]>;
-  libraryType_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  otherContactEmails?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_CONTAINS?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_IN?: InputMaybe<Array<Scalars["String"]>>;
-  otherContactEmails_MATCHES?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  piEmail?: InputMaybe<Scalars["String"]>;
-  piEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  piEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  piEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  piEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  piEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pooledNormals_INCLUDES?: InputMaybe<Scalars["String"]>;
-  projectManagerName?: InputMaybe<Scalars["String"]>;
-  projectManagerName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  projectManagerName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectManagerName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  projectManagerName_MATCHES?: InputMaybe<Scalars["String"]>;
-  projectManagerName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["BigInt"]["input"]>>
+  >;
+  igoDeliveryDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  ilabRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  investigatorEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  investigatorName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  isCmoRequest?: InputMaybe<Scalars["Boolean"]["input"]>;
+  labHeadEmail?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  labHeadEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  labHeadName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  libraryType_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  otherContactEmails_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  piEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pooledNormals_INCLUDES?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  projectManagerName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   projectsHasRequestAggregate?: InputMaybe<RequestProjectsHasRequestAggregateInput>;
   /** Return Requests where all of the related RequestProjectsHasRequestConnections match this filter */
   projectsHasRequestConnection_ALL?: InputMaybe<RequestProjectsHasRequestConnectionWhere>;
@@ -6249,37 +6467,37 @@ export type RequestWhere = {
   projectsHasRequest_SINGLE?: InputMaybe<ProjectWhere>;
   /** Return Requests where some of the related Projects match this filter */
   projectsHasRequest_SOME?: InputMaybe<ProjectWhere>;
-  qcAccessEmails?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_IN?: InputMaybe<Array<Scalars["String"]>>;
-  qcAccessEmails_MATCHES?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  requestJson?: InputMaybe<Scalars["String"]>;
-  requestJson_CONTAINS?: InputMaybe<Scalars["String"]>;
-  requestJson_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  requestJson_IN?: InputMaybe<Array<Scalars["String"]>>;
-  requestJson_MATCHES?: InputMaybe<Scalars["String"]>;
-  requestJson_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  smileRequestId?: InputMaybe<Scalars["String"]>;
-  smileRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileRequestId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  strand?: InputMaybe<Scalars["String"]>;
-  strand_CONTAINS?: InputMaybe<Scalars["String"]>;
-  strand_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  strand_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  strand_MATCHES?: InputMaybe<Scalars["String"]>;
-  strand_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  qcAccessEmails_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  requestJson_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  strand?: InputMaybe<Scalars["String"]["input"]>;
+  strand_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  strand_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  strand_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  strand_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  strand_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RequestsConnection = {
   __typename?: "RequestsConnection";
   edges: Array<RequestEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Sample = {
@@ -6287,7 +6505,7 @@ export type Sample = {
   cohortsHasCohortSample: Array<Cohort>;
   cohortsHasCohortSampleAggregate?: Maybe<SampleCohortCohortsHasCohortSampleAggregationSelection>;
   cohortsHasCohortSampleConnection: SampleCohortsHasCohortSampleConnection;
-  datasource: Scalars["String"];
+  datasource: Scalars["String"]["output"];
   hasDbgapDbGaps: Array<DbGap>;
   hasDbgapDbGapsAggregate?: Maybe<SampleDbGapHasDbgapDbGapsAggregationSelection>;
   hasDbgapDbGapsConnection: SampleHasDbgapDbGapsConnection;
@@ -6303,151 +6521,151 @@ export type Sample = {
   requestsHasSample: Array<Request>;
   requestsHasSampleAggregate?: Maybe<SampleRequestRequestsHasSampleAggregationSelection>;
   requestsHasSampleConnection: SampleRequestsHasSampleConnection;
-  revisable?: Maybe<Scalars["Boolean"]>;
+  revisable?: Maybe<Scalars["Boolean"]["output"]>;
   sampleAliasesIsAlias: Array<SampleAlias>;
   sampleAliasesIsAliasAggregate?: Maybe<SampleSampleAliasSampleAliasesIsAliasAggregationSelection>;
   sampleAliasesIsAliasConnection: SampleSampleAliasesIsAliasConnection;
-  sampleCategory: Scalars["String"];
-  sampleClass?: Maybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
+  sampleCategory: Scalars["String"]["output"];
+  sampleClass?: Maybe<Scalars["String"]["output"]>;
+  smileSampleId: Scalars["String"]["output"];
 };
 
 export type SampleCohortsHasCohortSampleArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<CohortOptions>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type SampleCohortsHasCohortSampleAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type SampleCohortsHasCohortSampleConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleCohortsHasCohortSampleConnectionSort>>;
   where?: InputMaybe<SampleCohortsHasCohortSampleConnectionWhere>;
 };
 
 export type SampleHasDbgapDbGapsArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<DbGapOptions>;
   where?: InputMaybe<DbGapWhere>;
 };
 
 export type SampleHasDbgapDbGapsAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<DbGapWhere>;
 };
 
 export type SampleHasDbgapDbGapsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleHasDbgapDbGapsConnectionSort>>;
   where?: InputMaybe<SampleHasDbgapDbGapsConnectionWhere>;
 };
 
 export type SampleHasMetadataSampleMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleMetadataOptions>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type SampleHasMetadataSampleMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type SampleHasMetadataSampleMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleHasMetadataSampleMetadataConnectionSort>>;
   where?: InputMaybe<SampleHasMetadataSampleMetadataConnectionWhere>;
 };
 
 export type SampleHasTempoTemposArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type SampleHasTempoTemposAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type SampleHasTempoTemposConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleHasTempoTemposConnectionSort>>;
   where?: InputMaybe<SampleHasTempoTemposConnectionWhere>;
 };
 
 export type SamplePatientsHasSampleArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<PatientOptions>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type SamplePatientsHasSampleAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type SamplePatientsHasSampleConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SamplePatientsHasSampleConnectionSort>>;
   where?: InputMaybe<SamplePatientsHasSampleConnectionWhere>;
 };
 
 export type SampleRequestsHasSampleArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type SampleRequestsHasSampleAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type SampleRequestsHasSampleConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleRequestsHasSampleConnectionSort>>;
   where?: InputMaybe<SampleRequestsHasSampleConnectionWhere>;
 };
 
 export type SampleSampleAliasesIsAliasArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleAliasOptions>;
   where?: InputMaybe<SampleAliasWhere>;
 };
 
 export type SampleSampleAliasesIsAliasAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleAliasWhere>;
 };
 
 export type SampleSampleAliasesIsAliasConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleSampleAliasesIsAliasConnectionSort>>;
   where?: InputMaybe<SampleSampleAliasesIsAliasConnectionWhere>;
 };
 
 export type SampleAggregateSelection = {
   __typename?: "SampleAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   datasource: StringAggregateSelection;
   sampleCategory: StringAggregateSelection;
   sampleClass: StringAggregateSelection;
@@ -6459,32 +6677,32 @@ export type SampleAlias = {
   isAliasSamples: Array<Sample>;
   isAliasSamplesAggregate?: Maybe<SampleAliasSampleIsAliasSamplesAggregationSelection>;
   isAliasSamplesConnection: SampleAliasIsAliasSamplesConnection;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["output"];
+  value: Scalars["String"]["output"];
 };
 
 export type SampleAliasIsAliasSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleAliasIsAliasSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleAliasIsAliasSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleAliasIsAliasSamplesConnectionSort>>;
   where?: InputMaybe<SampleAliasIsAliasSamplesConnectionWhere>;
 };
 
 export type SampleAliasAggregateSelection = {
   __typename?: "SampleAliasAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   namespace: StringAggregateSelection;
   value: StringAggregateSelection;
 };
@@ -6501,8 +6719,8 @@ export type SampleAliasConnectWhere = {
 
 export type SampleAliasCreateInput = {
   isAliasSamples?: InputMaybe<SampleAliasIsAliasSamplesFieldInput>;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["input"];
+  value: Scalars["String"]["input"];
 };
 
 export type SampleAliasDeleteInput = {
@@ -6517,7 +6735,7 @@ export type SampleAliasDisconnectInput = {
 
 export type SampleAliasEdge = {
   __typename?: "SampleAliasEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleAlias;
 };
 
@@ -6525,18 +6743,18 @@ export type SampleAliasIsAliasSamplesAggregateInput = {
   AND?: InputMaybe<Array<SampleAliasIsAliasSamplesAggregateInput>>;
   NOT?: InputMaybe<SampleAliasIsAliasSamplesAggregateInput>;
   OR?: InputMaybe<Array<SampleAliasIsAliasSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleAliasIsAliasSamplesNodeAggregationWhereInput>;
 };
 
 export type SampleAliasIsAliasSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -6544,7 +6762,7 @@ export type SampleAliasIsAliasSamplesConnection = {
   __typename?: "SampleAliasIsAliasSamplesConnection";
   edges: Array<SampleAliasIsAliasSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleAliasIsAliasSamplesConnectionSort = {
@@ -6581,71 +6799,71 @@ export type SampleAliasIsAliasSamplesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleAliasIsAliasSamplesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleAliasIsAliasSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleAliasIsAliasSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleAliasIsAliasSamplesRelationship = {
   __typename?: "SampleAliasIsAliasSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -6663,8 +6881,8 @@ export type SampleAliasIsAliasSamplesUpdateFieldInput = {
 };
 
 export type SampleAliasOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more SampleAliasSort objects to sort SampleAliases by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<SampleAliasSort>>;
 };
@@ -6675,7 +6893,7 @@ export type SampleAliasRelationInput = {
 
 export type SampleAliasSampleIsAliasSamplesAggregationSelection = {
   __typename?: "SampleAliasSampleIsAliasSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleAliasSampleIsAliasSamplesNodeAggregateSelection>;
 };
 
@@ -6695,8 +6913,8 @@ export type SampleAliasSort = {
 
 export type SampleAliasUpdateInput = {
   isAliasSamples?: InputMaybe<Array<SampleAliasIsAliasSamplesUpdateFieldInput>>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleAliasWhere = {
@@ -6720,54 +6938,55 @@ export type SampleAliasWhere = {
   isAliasSamples_SINGLE?: InputMaybe<SampleWhere>;
   /** Return SampleAliases where some of the related Samples match this filter */
   isAliasSamples_SOME?: InputMaybe<SampleWhere>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
-  value_CONTAINS?: InputMaybe<Scalars["String"]>;
-  value_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  value_IN?: InputMaybe<Array<Scalars["String"]>>;
-  value_MATCHES?: InputMaybe<Scalars["String"]>;
-  value_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
+  value_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  value_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  value_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  value_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleAliasesConnection = {
   __typename?: "SampleAliasesConnection";
   edges: Array<SampleAliasEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleCohortCohortsHasCohortSampleAggregationSelection = {
   __typename?: "SampleCohortCohortsHasCohortSampleAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleCohortCohortsHasCohortSampleNodeAggregateSelection>;
 };
 
 export type SampleCohortCohortsHasCohortSampleNodeAggregateSelection = {
   __typename?: "SampleCohortCohortsHasCohortSampleNodeAggregateSelection";
   cohortId: StringAggregateSelection;
+  cohortStatus: StringAggregateSelection;
 };
 
 export type SampleCohortsHasCohortSampleAggregateInput = {
   AND?: InputMaybe<Array<SampleCohortsHasCohortSampleAggregateInput>>;
   NOT?: InputMaybe<SampleCohortsHasCohortSampleAggregateInput>;
   OR?: InputMaybe<Array<SampleCohortsHasCohortSampleAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleCohortsHasCohortSampleNodeAggregationWhereInput>;
 };
 
 export type SampleCohortsHasCohortSampleConnectFieldInput = {
   connect?: InputMaybe<Array<CohortConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<CohortConnectWhere>;
 };
 
@@ -6775,7 +6994,7 @@ export type SampleCohortsHasCohortSampleConnection = {
   __typename?: "SampleCohortsHasCohortSampleConnection";
   edges: Array<SampleCohortsHasCohortSampleRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleCohortsHasCohortSampleConnectionSort = {
@@ -6814,26 +7033,41 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
   >;
   NOT?: InputMaybe<SampleCohortsHasCohortSampleNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleCohortsHasCohortSampleNodeAggregationWhereInput>>;
-  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleCohortsHasCohortSampleRelationship = {
   __typename?: "SampleCohortsHasCohortSampleRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Cohort;
 };
 
@@ -6878,22 +7112,22 @@ export type SampleConnectWhere = {
 
 export type SampleCreateInput = {
   cohortsHasCohortSample?: InputMaybe<SampleCohortsHasCohortSampleFieldInput>;
-  datasource: Scalars["String"];
+  datasource: Scalars["String"]["input"];
   hasDbgapDbGaps?: InputMaybe<SampleHasDbgapDbGapsFieldInput>;
   hasMetadataSampleMetadata?: InputMaybe<SampleHasMetadataSampleMetadataFieldInput>;
   hasTempoTempos?: InputMaybe<SampleHasTempoTemposFieldInput>;
   patientsHasSample?: InputMaybe<SamplePatientsHasSampleFieldInput>;
   requestsHasSample?: InputMaybe<SampleRequestsHasSampleFieldInput>;
-  revisable?: InputMaybe<Scalars["Boolean"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
   sampleAliasesIsAlias?: InputMaybe<SampleSampleAliasesIsAliasFieldInput>;
-  sampleCategory: Scalars["String"];
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
+  sampleCategory: Scalars["String"]["input"];
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId: Scalars["String"]["input"];
 };
 
 export type SampleDbGapHasDbgapDbGapsAggregationSelection = {
   __typename?: "SampleDbGapHasDbgapDbGapsAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleDbGapHasDbgapDbGapsNodeAggregateSelection>;
 };
 
@@ -6945,7 +7179,7 @@ export type SampleDisconnectInput = {
 
 export type SampleEdge = {
   __typename?: "SampleEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -6953,18 +7187,18 @@ export type SampleHasDbgapDbGapsAggregateInput = {
   AND?: InputMaybe<Array<SampleHasDbgapDbGapsAggregateInput>>;
   NOT?: InputMaybe<SampleHasDbgapDbGapsAggregateInput>;
   OR?: InputMaybe<Array<SampleHasDbgapDbGapsAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleHasDbgapDbGapsNodeAggregationWhereInput>;
 };
 
 export type SampleHasDbgapDbGapsConnectFieldInput = {
   connect?: InputMaybe<Array<DbGapConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<DbGapConnectWhere>;
 };
 
@@ -6972,7 +7206,7 @@ export type SampleHasDbgapDbGapsConnection = {
   __typename?: "SampleHasDbgapDbGapsConnection";
   edges: Array<SampleHasDbgapDbGapsRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleHasDbgapDbGapsConnectionSort = {
@@ -7009,41 +7243,41 @@ export type SampleHasDbgapDbGapsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleHasDbgapDbGapsNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleHasDbgapDbGapsNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleHasDbgapDbGapsNodeAggregationWhereInput>>;
-  dbGapStudy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dbGapStudy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleHasDbgapDbGapsRelationship = {
   __typename?: "SampleHasDbgapDbGapsRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: DbGap;
 };
 
@@ -7064,18 +7298,18 @@ export type SampleHasMetadataSampleMetadataAggregateInput = {
   AND?: InputMaybe<Array<SampleHasMetadataSampleMetadataAggregateInput>>;
   NOT?: InputMaybe<SampleHasMetadataSampleMetadataAggregateInput>;
   OR?: InputMaybe<Array<SampleHasMetadataSampleMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleHasMetadataSampleMetadataNodeAggregationWhereInput>;
 };
 
 export type SampleHasMetadataSampleMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<SampleMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleMetadataConnectWhere>;
 };
 
@@ -7083,7 +7317,7 @@ export type SampleHasMetadataSampleMetadataConnection = {
   __typename?: "SampleHasMetadataSampleMetadataConnection";
   edges: Array<SampleHasMetadataSampleMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleHasMetadataSampleMetadataConnectionSort = {
@@ -7124,406 +7358,444 @@ export type SampleHasMetadataSampleMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<SampleHasMetadataSampleMetadataNodeAggregationWhereInput>
   >;
-  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleHasMetadataSampleMetadataRelationship = {
   __typename?: "SampleHasMetadataSampleMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleMetadata;
 };
 
@@ -7546,18 +7818,18 @@ export type SampleHasTempoTemposAggregateInput = {
   AND?: InputMaybe<Array<SampleHasTempoTemposAggregateInput>>;
   NOT?: InputMaybe<SampleHasTempoTemposAggregateInput>;
   OR?: InputMaybe<Array<SampleHasTempoTemposAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleHasTempoTemposNodeAggregationWhereInput>;
 };
 
 export type SampleHasTempoTemposConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -7565,7 +7837,7 @@ export type SampleHasTempoTemposConnection = {
   __typename?: "SampleHasTempoTemposConnection";
   edges: Array<SampleHasTempoTemposRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleHasTempoTemposConnectionSort = {
@@ -7602,116 +7874,164 @@ export type SampleHasTempoTemposNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleHasTempoTemposNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleHasTempoTemposNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleHasTempoTemposNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleHasTempoTemposRelationship = {
   __typename?: "SampleHasTempoTemposRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -7730,75 +8050,75 @@ export type SampleHasTempoTemposUpdateFieldInput = {
 
 export type SampleMetadata = {
   __typename?: "SampleMetadata";
-  additionalProperties: Scalars["String"];
-  baitSet?: Maybe<Scalars["String"]>;
-  cfDNA2dBarcode?: Maybe<Scalars["String"]>;
-  cmoInfoIgoId?: Maybe<Scalars["String"]>;
-  cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleIdFields: Scalars["String"];
-  cmoSampleName?: Maybe<Scalars["String"]>;
-  collectionYear?: Maybe<Scalars["String"]>;
-  genePanel: Scalars["String"];
+  additionalProperties: Scalars["String"]["output"];
+  baitSet?: Maybe<Scalars["String"]["output"]>;
+  cfDNA2dBarcode?: Maybe<Scalars["String"]["output"]>;
+  cmoInfoIgoId?: Maybe<Scalars["String"]["output"]>;
+  cmoPatientId?: Maybe<Scalars["String"]["output"]>;
+  cmoSampleIdFields: Scalars["String"]["output"];
+  cmoSampleName?: Maybe<Scalars["String"]["output"]>;
+  collectionYear?: Maybe<Scalars["String"]["output"]>;
+  genePanel: Scalars["String"]["output"];
   hasStatusStatuses: Array<Status>;
   hasStatusStatusesAggregate?: Maybe<SampleMetadataStatusHasStatusStatusesAggregationSelection>;
   hasStatusStatusesConnection: SampleMetadataHasStatusStatusesConnection;
-  igoComplete?: Maybe<Scalars["Boolean"]>;
-  igoRequestId?: Maybe<Scalars["String"]>;
-  importDate: Scalars["BigInt"];
-  investigatorSampleId?: Maybe<Scalars["String"]>;
-  libraries: Scalars["String"];
-  oncotreeCode?: Maybe<Scalars["String"]>;
-  preservation?: Maybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
-  qcReports: Scalars["String"];
-  sampleClass?: Maybe<Scalars["String"]>;
-  sampleName?: Maybe<Scalars["String"]>;
-  sampleOrigin?: Maybe<Scalars["String"]>;
-  sampleType?: Maybe<Scalars["String"]>;
+  igoComplete?: Maybe<Scalars["Boolean"]["output"]>;
+  igoRequestId?: Maybe<Scalars["String"]["output"]>;
+  importDate: Scalars["BigInt"]["output"];
+  investigatorSampleId?: Maybe<Scalars["String"]["output"]>;
+  libraries: Scalars["String"]["output"];
+  oncotreeCode?: Maybe<Scalars["String"]["output"]>;
+  preservation?: Maybe<Scalars["String"]["output"]>;
+  primaryId: Scalars["String"]["output"];
+  qcReports: Scalars["String"]["output"];
+  sampleClass?: Maybe<Scalars["String"]["output"]>;
+  sampleName?: Maybe<Scalars["String"]["output"]>;
+  sampleOrigin?: Maybe<Scalars["String"]["output"]>;
+  sampleType?: Maybe<Scalars["String"]["output"]>;
   samplesHasMetadata: Array<Sample>;
   samplesHasMetadataAggregate?: Maybe<SampleMetadataSampleSamplesHasMetadataAggregationSelection>;
   samplesHasMetadataConnection: SampleMetadataSamplesHasMetadataConnection;
-  sex?: Maybe<Scalars["String"]>;
-  species?: Maybe<Scalars["String"]>;
-  tissueLocation?: Maybe<Scalars["String"]>;
-  tubeId?: Maybe<Scalars["String"]>;
-  tumorOrNormal?: Maybe<Scalars["String"]>;
+  sex?: Maybe<Scalars["String"]["output"]>;
+  species?: Maybe<Scalars["String"]["output"]>;
+  tissueLocation?: Maybe<Scalars["String"]["output"]>;
+  tubeId?: Maybe<Scalars["String"]["output"]>;
+  tumorOrNormal?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type SampleMetadataHasStatusStatusesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<StatusOptions>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type SampleMetadataHasStatusStatusesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type SampleMetadataHasStatusStatusesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleMetadataHasStatusStatusesConnectionSort>>;
   where?: InputMaybe<SampleMetadataHasStatusStatusesConnectionWhere>;
 };
 
 export type SampleMetadataSamplesHasMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleMetadataSamplesHasMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleMetadataSamplesHasMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleMetadataSamplesHasMetadataConnectionSort>>;
   where?: InputMaybe<SampleMetadataSamplesHasMetadataConnectionWhere>;
 };
@@ -7813,7 +8133,7 @@ export type SampleMetadataAggregateSelection = {
   cmoSampleIdFields: StringAggregateSelection;
   cmoSampleName: StringAggregateSelection;
   collectionYear: StringAggregateSelection;
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   genePanel: StringAggregateSelection;
   igoRequestId: StringAggregateSelection;
   importDate: BigIntAggregateSelection;
@@ -7851,39 +8171,39 @@ export type SampleMetadataConnection = {
   __typename?: "SampleMetadataConnection";
   edges: Array<SampleMetadataEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleMetadataCreateInput = {
-  additionalProperties: Scalars["String"];
-  baitSet?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields: Scalars["String"];
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  genePanel: Scalars["String"];
+  additionalProperties: Scalars["String"]["input"];
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields: Scalars["String"]["input"];
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel: Scalars["String"]["input"];
   hasStatusStatuses?: InputMaybe<SampleMetadataHasStatusStatusesFieldInput>;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  importDate: Scalars["BigInt"];
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  libraries: Scalars["String"];
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
-  qcReports: Scalars["String"];
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleName?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  importDate: Scalars["BigInt"]["input"];
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  libraries: Scalars["String"]["input"];
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId: Scalars["String"]["input"];
+  qcReports: Scalars["String"]["input"];
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasMetadata?: InputMaybe<SampleMetadataSamplesHasMetadataFieldInput>;
-  sex?: InputMaybe<Scalars["String"]>;
-  species?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tubeId?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleMetadataDeleteInput = {
@@ -7906,7 +8226,7 @@ export type SampleMetadataDisconnectInput = {
 
 export type SampleMetadataEdge = {
   __typename?: "SampleMetadataEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleMetadata;
 };
 
@@ -7914,18 +8234,18 @@ export type SampleMetadataHasStatusStatusesAggregateInput = {
   AND?: InputMaybe<Array<SampleMetadataHasStatusStatusesAggregateInput>>;
   NOT?: InputMaybe<SampleMetadataHasStatusStatusesAggregateInput>;
   OR?: InputMaybe<Array<SampleMetadataHasStatusStatusesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleMetadataHasStatusStatusesNodeAggregationWhereInput>;
 };
 
 export type SampleMetadataHasStatusStatusesConnectFieldInput = {
   connect?: InputMaybe<Array<StatusConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<StatusConnectWhere>;
 };
 
@@ -7933,7 +8253,7 @@ export type SampleMetadataHasStatusStatusesConnection = {
   __typename?: "SampleMetadataHasStatusStatusesConnection";
   edges: Array<SampleMetadataHasStatusStatusesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleMetadataHasStatusStatusesConnectionSort = {
@@ -7974,26 +8294,26 @@ export type SampleMetadataHasStatusStatusesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<SampleMetadataHasStatusStatusesNodeAggregationWhereInput>
   >;
-  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleMetadataHasStatusStatusesRelationship = {
   __typename?: "SampleMetadataHasStatusStatusesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Status;
 };
 
@@ -8013,8 +8333,8 @@ export type SampleMetadataHasStatusStatusesUpdateFieldInput = {
 };
 
 export type SampleMetadataOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more SampleMetadataSort objects to sort SampleMetadata by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<SampleMetadataSort>>;
 };
@@ -8030,7 +8350,7 @@ export type SampleMetadataRelationInput = {
 
 export type SampleMetadataSampleSamplesHasMetadataAggregationSelection = {
   __typename?: "SampleMetadataSampleSamplesHasMetadataAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleMetadataSampleSamplesHasMetadataNodeAggregateSelection>;
 };
 
@@ -8046,18 +8366,18 @@ export type SampleMetadataSamplesHasMetadataAggregateInput = {
   AND?: InputMaybe<Array<SampleMetadataSamplesHasMetadataAggregateInput>>;
   NOT?: InputMaybe<SampleMetadataSamplesHasMetadataAggregateInput>;
   OR?: InputMaybe<Array<SampleMetadataSamplesHasMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleMetadataSamplesHasMetadataNodeAggregationWhereInput>;
 };
 
 export type SampleMetadataSamplesHasMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -8065,7 +8385,7 @@ export type SampleMetadataSamplesHasMetadataConnection = {
   __typename?: "SampleMetadataSamplesHasMetadataConnection";
   edges: Array<SampleMetadataSamplesHasMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleMetadataSamplesHasMetadataConnectionSort = {
@@ -8108,71 +8428,71 @@ export type SampleMetadataSamplesHasMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<SampleMetadataSamplesHasMetadataNodeAggregationWhereInput>
   >;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleMetadataSamplesHasMetadataRelationship = {
   __typename?: "SampleMetadataSamplesHasMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -8226,7 +8546,7 @@ export type SampleMetadataSort = {
 
 export type SampleMetadataStatusHasStatusStatusesAggregationSelection = {
   __typename?: "SampleMetadataStatusHasStatusStatusesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleMetadataStatusHasStatusStatusesNodeAggregateSelection>;
 };
 
@@ -8236,101 +8556,101 @@ export type SampleMetadataStatusHasStatusStatusesNodeAggregateSelection = {
 };
 
 export type SampleMetadataUpdateInput = {
-  additionalProperties?: InputMaybe<Scalars["String"]>;
-  baitSet?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields?: InputMaybe<Scalars["String"]>;
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
+  additionalProperties?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
   hasStatusStatuses?: InputMaybe<
     Array<SampleMetadataHasStatusStatusesUpdateFieldInput>
   >;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  libraries?: InputMaybe<Scalars["String"]>;
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
-  qcReports?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleName?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  libraries?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasMetadata?: InputMaybe<
     Array<SampleMetadataSamplesHasMetadataUpdateFieldInput>
   >;
-  sex?: InputMaybe<Scalars["String"]>;
-  species?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tubeId?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleMetadataWhere = {
   AND?: InputMaybe<Array<SampleMetadataWhere>>;
   NOT?: InputMaybe<SampleMetadataWhere>;
   OR?: InputMaybe<Array<SampleMetadataWhere>>;
-  additionalProperties?: InputMaybe<Scalars["String"]>;
-  additionalProperties_CONTAINS?: InputMaybe<Scalars["String"]>;
-  additionalProperties_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  additionalProperties_IN?: InputMaybe<Array<Scalars["String"]>>;
-  additionalProperties_MATCHES?: InputMaybe<Scalars["String"]>;
-  additionalProperties_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  baitSet?: InputMaybe<Scalars["String"]>;
-  baitSet_CONTAINS?: InputMaybe<Scalars["String"]>;
-  baitSet_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  baitSet_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  baitSet_MATCHES?: InputMaybe<Scalars["String"]>;
-  baitSet_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cfDNA2dBarcode_MATCHES?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoInfoIgoId_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoPatientId_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_IN?: InputMaybe<Array<Scalars["String"]>>;
-  cmoSampleIdFields_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoSampleName_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  collectionYear_CONTAINS?: InputMaybe<Scalars["String"]>;
-  collectionYear_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  collectionYear_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  collectionYear_MATCHES?: InputMaybe<Scalars["String"]>;
-  collectionYear_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
-  genePanel_CONTAINS?: InputMaybe<Scalars["String"]>;
-  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel_IN?: InputMaybe<Array<Scalars["String"]>>;
-  genePanel_MATCHES?: InputMaybe<Scalars["String"]>;
-  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  additionalProperties?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  additionalProperties_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  baitSet_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cfDNA2dBarcode_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cmoInfoIgoId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cmoPatientId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  cmoSampleIdFields_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cmoSampleName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  collectionYear_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  genePanel_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasStatusStatusesAggregate?: InputMaybe<SampleMetadataHasStatusStatusesAggregateInput>;
   /** Return SampleMetadata where all of the related SampleMetadataHasStatusStatusesConnections match this filter */
   hasStatusStatusesConnection_ALL?: InputMaybe<SampleMetadataHasStatusStatusesConnectionWhere>;
@@ -8348,79 +8668,81 @@ export type SampleMetadataWhere = {
   hasStatusStatuses_SINGLE?: InputMaybe<StatusWhere>;
   /** Return SampleMetadata where some of the related Statuses match this filter */
   hasStatusStatuses_SOME?: InputMaybe<StatusWhere>;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]>>;
-  importDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  investigatorSampleId_MATCHES?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  libraries?: InputMaybe<Scalars["String"]>;
-  libraries_CONTAINS?: InputMaybe<Scalars["String"]>;
-  libraries_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  libraries_IN?: InputMaybe<Array<Scalars["String"]>>;
-  libraries_MATCHES?: InputMaybe<Scalars["String"]>;
-  libraries_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_CONTAINS?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  oncotreeCode_MATCHES?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  preservation_CONTAINS?: InputMaybe<Scalars["String"]>;
-  preservation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  preservation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  preservation_MATCHES?: InputMaybe<Scalars["String"]>;
-  preservation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
-  primaryId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  primaryId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  primaryId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  primaryId_MATCHES?: InputMaybe<Scalars["String"]>;
-  primaryId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  qcReports?: InputMaybe<Scalars["String"]>;
-  qcReports_CONTAINS?: InputMaybe<Scalars["String"]>;
-  qcReports_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  qcReports_IN?: InputMaybe<Array<Scalars["String"]>>;
-  qcReports_MATCHES?: InputMaybe<Scalars["String"]>;
-  qcReports_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleClass_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleName?: InputMaybe<Scalars["String"]>;
-  sampleName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleName_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleOrigin_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
-  sampleType_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleType_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleType_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleType_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  importDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  investigatorSampleId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraries?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  libraries_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  oncotreeCode_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  preservation_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  primaryId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  qcReports_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleClass_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleOrigin_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleType_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasMetadataAggregate?: InputMaybe<SampleMetadataSamplesHasMetadataAggregateInput>;
   /** Return SampleMetadata where all of the related SampleMetadataSamplesHasMetadataConnections match this filter */
   samplesHasMetadataConnection_ALL?: InputMaybe<SampleMetadataSamplesHasMetadataConnectionWhere>;
@@ -8438,48 +8760,48 @@ export type SampleMetadataWhere = {
   samplesHasMetadata_SINGLE?: InputMaybe<SampleWhere>;
   /** Return SampleMetadata where some of the related Samples match this filter */
   samplesHasMetadata_SOME?: InputMaybe<SampleWhere>;
-  sex?: InputMaybe<Scalars["String"]>;
-  sex_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sex_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sex_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sex_MATCHES?: InputMaybe<Scalars["String"]>;
-  sex_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  species?: InputMaybe<Scalars["String"]>;
-  species_CONTAINS?: InputMaybe<Scalars["String"]>;
-  species_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  species_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  species_MATCHES?: InputMaybe<Scalars["String"]>;
-  species_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tissueLocation_CONTAINS?: InputMaybe<Scalars["String"]>;
-  tissueLocation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  tissueLocation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  tissueLocation_MATCHES?: InputMaybe<Scalars["String"]>;
-  tissueLocation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  tubeId?: InputMaybe<Scalars["String"]>;
-  tubeId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  tubeId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  tubeId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  tubeId_MATCHES?: InputMaybe<Scalars["String"]>;
-  tubeId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_CONTAINS?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  tumorOrNormal_MATCHES?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  sex_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sex_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sex_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sex_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sex_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  species_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  species_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  species_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  species_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  species_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  tissueLocation_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  tubeId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  tumorOrNormal_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more SampleSort objects to sort Samples by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<SampleSort>>;
 };
 
 export type SamplePatientPatientsHasSampleAggregationSelection = {
   __typename?: "SamplePatientPatientsHasSampleAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SamplePatientPatientsHasSampleNodeAggregateSelection>;
 };
 
@@ -8492,18 +8814,18 @@ export type SamplePatientsHasSampleAggregateInput = {
   AND?: InputMaybe<Array<SamplePatientsHasSampleAggregateInput>>;
   NOT?: InputMaybe<SamplePatientsHasSampleAggregateInput>;
   OR?: InputMaybe<Array<SamplePatientsHasSampleAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SamplePatientsHasSampleNodeAggregationWhereInput>;
 };
 
 export type SamplePatientsHasSampleConnectFieldInput = {
   connect?: InputMaybe<Array<PatientConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<PatientConnectWhere>;
 };
 
@@ -8511,7 +8833,7 @@ export type SamplePatientsHasSampleConnection = {
   __typename?: "SamplePatientsHasSampleConnection";
   edges: Array<SamplePatientsHasSampleRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SamplePatientsHasSampleConnectionSort = {
@@ -8548,26 +8870,26 @@ export type SamplePatientsHasSampleNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SamplePatientsHasSampleNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SamplePatientsHasSampleNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SamplePatientsHasSampleNodeAggregationWhereInput>>;
-  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SamplePatientsHasSampleRelationship = {
   __typename?: "SamplePatientsHasSampleRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Patient;
 };
 
@@ -8606,7 +8928,7 @@ export type SampleRelationInput = {
 
 export type SampleRequestRequestsHasSampleAggregationSelection = {
   __typename?: "SampleRequestRequestsHasSampleAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleRequestRequestsHasSampleNodeAggregateSelection>;
 };
 
@@ -8639,18 +8961,18 @@ export type SampleRequestsHasSampleAggregateInput = {
   AND?: InputMaybe<Array<SampleRequestsHasSampleAggregateInput>>;
   NOT?: InputMaybe<SampleRequestsHasSampleAggregateInput>;
   OR?: InputMaybe<Array<SampleRequestsHasSampleAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleRequestsHasSampleNodeAggregationWhereInput>;
 };
 
 export type SampleRequestsHasSampleConnectFieldInput = {
   connect?: InputMaybe<Array<RequestConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestConnectWhere>;
 };
 
@@ -8658,7 +8980,7 @@ export type SampleRequestsHasSampleConnection = {
   __typename?: "SampleRequestsHasSampleConnection";
   edges: Array<SampleRequestsHasSampleRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleRequestsHasSampleConnectionSort = {
@@ -8695,331 +9017,341 @@ export type SampleRequestsHasSampleNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleRequestsHasSampleNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleRequestsHasSampleNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleRequestsHasSampleNodeAggregationWhereInput>>;
-  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleRequestsHasSampleRelationship = {
   __typename?: "SampleRequestsHasSampleRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -9038,7 +9370,7 @@ export type SampleRequestsHasSampleUpdateFieldInput = {
 
 export type SampleSampleAliasSampleAliasesIsAliasAggregationSelection = {
   __typename?: "SampleSampleAliasSampleAliasesIsAliasAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleSampleAliasSampleAliasesIsAliasNodeAggregateSelection>;
 };
 
@@ -9052,18 +9384,18 @@ export type SampleSampleAliasesIsAliasAggregateInput = {
   AND?: InputMaybe<Array<SampleSampleAliasesIsAliasAggregateInput>>;
   NOT?: InputMaybe<SampleSampleAliasesIsAliasAggregateInput>;
   OR?: InputMaybe<Array<SampleSampleAliasesIsAliasAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleSampleAliasesIsAliasNodeAggregationWhereInput>;
 };
 
 export type SampleSampleAliasesIsAliasConnectFieldInput = {
   connect?: InputMaybe<Array<SampleAliasConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleAliasConnectWhere>;
 };
 
@@ -9071,7 +9403,7 @@ export type SampleSampleAliasesIsAliasConnection = {
   __typename?: "SampleSampleAliasesIsAliasConnection";
   edges: Array<SampleSampleAliasesIsAliasRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleSampleAliasesIsAliasConnectionSort = {
@@ -9108,41 +9440,41 @@ export type SampleSampleAliasesIsAliasNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleSampleAliasesIsAliasNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleSampleAliasesIsAliasNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleSampleAliasesIsAliasNodeAggregationWhereInput>>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleSampleAliasesIsAliasRelationship = {
   __typename?: "SampleSampleAliasesIsAliasRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleAlias;
 };
 
@@ -9164,7 +9496,7 @@ export type SampleSampleAliasesIsAliasUpdateFieldInput = {
 export type SampleSampleMetadataHasMetadataSampleMetadataAggregationSelection =
   {
     __typename?: "SampleSampleMetadataHasMetadataSampleMetadataAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<SampleSampleMetadataHasMetadataSampleMetadataNodeAggregateSelection>;
   };
 
@@ -9210,7 +9542,7 @@ export type SampleSort = {
 
 export type SampleTempoHasTempoTemposAggregationSelection = {
   __typename?: "SampleTempoHasTempoTemposAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleTempoHasTempoTemposNodeAggregateSelection>;
 };
 
@@ -9229,7 +9561,7 @@ export type SampleUpdateInput = {
   cohortsHasCohortSample?: InputMaybe<
     Array<SampleCohortsHasCohortSampleUpdateFieldInput>
   >;
-  datasource?: InputMaybe<Scalars["String"]>;
+  datasource?: InputMaybe<Scalars["String"]["input"]>;
   hasDbgapDbGaps?: InputMaybe<Array<SampleHasDbgapDbGapsUpdateFieldInput>>;
   hasMetadataSampleMetadata?: InputMaybe<
     Array<SampleHasMetadataSampleMetadataUpdateFieldInput>
@@ -9241,13 +9573,13 @@ export type SampleUpdateInput = {
   requestsHasSample?: InputMaybe<
     Array<SampleRequestsHasSampleUpdateFieldInput>
   >;
-  revisable?: InputMaybe<Scalars["Boolean"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
   sampleAliasesIsAlias?: InputMaybe<
     Array<SampleSampleAliasesIsAliasUpdateFieldInput>
   >;
-  sampleCategory?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  smileSampleId?: InputMaybe<Scalars["String"]>;
+  sampleCategory?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleWhere = {
@@ -9271,12 +9603,12 @@ export type SampleWhere = {
   cohortsHasCohortSample_SINGLE?: InputMaybe<CohortWhere>;
   /** Return Samples where some of the related Cohorts match this filter */
   cohortsHasCohortSample_SOME?: InputMaybe<CohortWhere>;
-  datasource?: InputMaybe<Scalars["String"]>;
-  datasource_CONTAINS?: InputMaybe<Scalars["String"]>;
-  datasource_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  datasource_IN?: InputMaybe<Array<Scalars["String"]>>;
-  datasource_MATCHES?: InputMaybe<Scalars["String"]>;
-  datasource_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  datasource?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  datasource_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasDbgapDbGapsAggregate?: InputMaybe<SampleHasDbgapDbGapsAggregateInput>;
   /** Return Samples where all of the related SampleHasDbgapDbGapsConnections match this filter */
   hasDbgapDbGapsConnection_ALL?: InputMaybe<SampleHasDbgapDbGapsConnectionWhere>;
@@ -9362,7 +9694,7 @@ export type SampleWhere = {
   requestsHasSample_SINGLE?: InputMaybe<RequestWhere>;
   /** Return Samples where some of the related Requests match this filter */
   requestsHasSample_SOME?: InputMaybe<RequestWhere>;
-  revisable?: InputMaybe<Scalars["Boolean"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
   sampleAliasesIsAliasAggregate?: InputMaybe<SampleSampleAliasesIsAliasAggregateInput>;
   /** Return Samples where all of the related SampleSampleAliasesIsAliasConnections match this filter */
   sampleAliasesIsAliasConnection_ALL?: InputMaybe<SampleSampleAliasesIsAliasConnectionWhere>;
@@ -9380,38 +9712,38 @@ export type SampleWhere = {
   sampleAliasesIsAlias_SINGLE?: InputMaybe<SampleAliasWhere>;
   /** Return Samples where some of the related SampleAliases match this filter */
   sampleAliasesIsAlias_SOME?: InputMaybe<SampleAliasWhere>;
-  sampleCategory?: InputMaybe<Scalars["String"]>;
-  sampleCategory_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleCategory_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleCategory_IN?: InputMaybe<Array<Scalars["String"]>>;
-  sampleCategory_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleCategory_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleClass_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  smileSampleId?: InputMaybe<Scalars["String"]>;
-  smileSampleId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileSampleId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileSampleId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  sampleCategory?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  sampleCategory_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleClass_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileSampleId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SamplesConnection = {
   __typename?: "SamplesConnection";
   edges: Array<SampleEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SeqDateAccessionBySampleId = {
   __typename?: "SeqDateAccessionBySampleId";
-  DMP_SAMPLE_ID: Scalars["String"];
-  MOLECULAR_ACCESSION_NUMBER?: Maybe<Scalars["String"]>;
-  SEQUENCING_DATE: Scalars["String"];
+  DMP_SAMPLE_ID: Scalars["String"]["output"];
+  MOLECULAR_ACCESSION_NUMBER?: Maybe<Scalars["String"]["output"]>;
+  SEQUENCING_DATE: Scalars["String"]["output"];
 };
 
 /** An enum for sorting in either ascending or descending order. */
@@ -9430,51 +9762,51 @@ export type Status = {
   sampleMetadataHasStatus: Array<SampleMetadata>;
   sampleMetadataHasStatusAggregate?: Maybe<StatusSampleMetadataSampleMetadataHasStatusAggregationSelection>;
   sampleMetadataHasStatusConnection: StatusSampleMetadataHasStatusConnection;
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type StatusRequestMetadataHasStatusArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestMetadataOptions>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type StatusRequestMetadataHasStatusAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type StatusRequestMetadataHasStatusConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<StatusRequestMetadataHasStatusConnectionSort>>;
   where?: InputMaybe<StatusRequestMetadataHasStatusConnectionWhere>;
 };
 
 export type StatusSampleMetadataHasStatusArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleMetadataOptions>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type StatusSampleMetadataHasStatusAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type StatusSampleMetadataHasStatusConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<StatusSampleMetadataHasStatusConnectionSort>>;
   where?: InputMaybe<StatusSampleMetadataHasStatusConnectionWhere>;
 };
 
 export type StatusAggregateSelection = {
   __typename?: "StatusAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   validationReport: StringAggregateSelection;
 };
 
@@ -9494,8 +9826,8 @@ export type StatusConnectWhere = {
 export type StatusCreateInput = {
   requestMetadataHasStatus?: InputMaybe<StatusRequestMetadataHasStatusFieldInput>;
   sampleMetadataHasStatus?: InputMaybe<StatusSampleMetadataHasStatusFieldInput>;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type StatusDeleteInput = {
@@ -9518,13 +9850,13 @@ export type StatusDisconnectInput = {
 
 export type StatusEdge = {
   __typename?: "StatusEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Status;
 };
 
 export type StatusOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more StatusSort objects to sort Statuses by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<StatusSort>>;
 };
@@ -9542,18 +9874,18 @@ export type StatusRequestMetadataHasStatusAggregateInput = {
   AND?: InputMaybe<Array<StatusRequestMetadataHasStatusAggregateInput>>;
   NOT?: InputMaybe<StatusRequestMetadataHasStatusAggregateInput>;
   OR?: InputMaybe<Array<StatusRequestMetadataHasStatusAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<StatusRequestMetadataHasStatusNodeAggregationWhereInput>;
 };
 
 export type StatusRequestMetadataHasStatusConnectFieldInput = {
   connect?: InputMaybe<Array<RequestMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestMetadataConnectWhere>;
 };
 
@@ -9561,7 +9893,7 @@ export type StatusRequestMetadataHasStatusConnection = {
   __typename?: "StatusRequestMetadataHasStatusConnection";
   edges: Array<StatusRequestMetadataHasStatusRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type StatusRequestMetadataHasStatusConnectionSort = {
@@ -9602,61 +9934,71 @@ export type StatusRequestMetadataHasStatusNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<StatusRequestMetadataHasStatusNodeAggregationWhereInput>
   >;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type StatusRequestMetadataHasStatusRelationship = {
   __typename?: "StatusRequestMetadataHasStatusRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: RequestMetadata;
 };
 
@@ -9678,7 +10020,7 @@ export type StatusRequestMetadataHasStatusUpdateFieldInput = {
 export type StatusRequestMetadataRequestMetadataHasStatusAggregationSelection =
   {
     __typename?: "StatusRequestMetadataRequestMetadataHasStatusAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<StatusRequestMetadataRequestMetadataHasStatusNodeAggregateSelection>;
   };
 
@@ -9694,18 +10036,18 @@ export type StatusSampleMetadataHasStatusAggregateInput = {
   AND?: InputMaybe<Array<StatusSampleMetadataHasStatusAggregateInput>>;
   NOT?: InputMaybe<StatusSampleMetadataHasStatusAggregateInput>;
   OR?: InputMaybe<Array<StatusSampleMetadataHasStatusAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<StatusSampleMetadataHasStatusNodeAggregationWhereInput>;
 };
 
 export type StatusSampleMetadataHasStatusConnectFieldInput = {
   connect?: InputMaybe<Array<SampleMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleMetadataConnectWhere>;
 };
 
@@ -9713,7 +10055,7 @@ export type StatusSampleMetadataHasStatusConnection = {
   __typename?: "StatusSampleMetadataHasStatusConnection";
   edges: Array<StatusSampleMetadataHasStatusRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type StatusSampleMetadataHasStatusConnectionSort = {
@@ -9754,406 +10096,444 @@ export type StatusSampleMetadataHasStatusNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<StatusSampleMetadataHasStatusNodeAggregationWhereInput>
   >;
-  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type StatusSampleMetadataHasStatusRelationship = {
   __typename?: "StatusSampleMetadataHasStatusRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleMetadata;
 };
 
@@ -10174,7 +10554,7 @@ export type StatusSampleMetadataHasStatusUpdateFieldInput = {
 
 export type StatusSampleMetadataSampleMetadataHasStatusAggregationSelection = {
   __typename?: "StatusSampleMetadataSampleMetadataHasStatusAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<StatusSampleMetadataSampleMetadataHasStatusNodeAggregateSelection>;
 };
 
@@ -10222,8 +10602,8 @@ export type StatusUpdateInput = {
   sampleMetadataHasStatus?: InputMaybe<
     Array<StatusSampleMetadataHasStatusUpdateFieldInput>
   >;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type StatusWhere = {
@@ -10264,36 +10644,38 @@ export type StatusWhere = {
   sampleMetadataHasStatus_SINGLE?: InputMaybe<SampleMetadataWhere>;
   /** Return Statuses where some of the related SampleMetadata match this filter */
   sampleMetadataHasStatus_SOME?: InputMaybe<SampleMetadataWhere>;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationReport_CONTAINS?: InputMaybe<Scalars["String"]>;
-  validationReport_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  validationReport_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  validationReport_MATCHES?: InputMaybe<Scalars["String"]>;
-  validationReport_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  validationReport_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type StatusesConnection = {
   __typename?: "StatusesConnection";
   edges: Array<StatusEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type StringAggregateSelection = {
   __typename?: "StringAggregateSelection";
-  longest?: Maybe<Scalars["String"]>;
-  shortest?: Maybe<Scalars["String"]>;
+  longest?: Maybe<Scalars["String"]["output"]>;
+  shortest?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type Tempo = {
   __typename?: "Tempo";
-  accessLevel?: Maybe<Scalars["String"]>;
-  billed?: Maybe<Scalars["Boolean"]>;
-  billedBy?: Maybe<Scalars["String"]>;
-  costCenter?: Maybe<Scalars["String"]>;
-  custodianInformation?: Maybe<Scalars["String"]>;
-  embargoDate?: Maybe<Scalars["String"]>;
+  accessLevel?: Maybe<Scalars["String"]["output"]>;
+  billed?: Maybe<Scalars["Boolean"]["output"]>;
+  billedBy?: Maybe<Scalars["String"]["output"]>;
+  costCenter?: Maybe<Scalars["String"]["output"]>;
+  custodianInformation?: Maybe<Scalars["String"]["output"]>;
+  embargoDate?: Maybe<Scalars["String"]["output"]>;
   hasEventBamCompletes: Array<BamComplete>;
   hasEventBamCompletesAggregate?: Maybe<TempoBamCompleteHasEventBamCompletesAggregationSelection>;
   hasEventBamCompletesConnection: TempoHasEventBamCompletesConnection;
@@ -10303,85 +10685,85 @@ export type Tempo = {
   hasEventQcCompletes: Array<QcComplete>;
   hasEventQcCompletesAggregate?: Maybe<TempoQcCompleteHasEventQcCompletesAggregationSelection>;
   hasEventQcCompletesConnection: TempoHasEventQcCompletesConnection;
-  initialPipelineRunDate?: Maybe<Scalars["String"]>;
+  initialPipelineRunDate?: Maybe<Scalars["String"]["output"]>;
   samplesHasTempo: Array<Sample>;
   samplesHasTempoAggregate?: Maybe<TempoSampleSamplesHasTempoAggregationSelection>;
   samplesHasTempoConnection: TempoSamplesHasTempoConnection;
-  smileTempoId: Scalars["String"];
+  smileTempoId: Scalars["String"]["output"];
 };
 
 export type TempoHasEventBamCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<BamCompleteOptions>;
   where?: InputMaybe<BamCompleteWhere>;
 };
 
 export type TempoHasEventBamCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<BamCompleteWhere>;
 };
 
 export type TempoHasEventBamCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoHasEventBamCompletesConnectionSort>>;
   where?: InputMaybe<TempoHasEventBamCompletesConnectionWhere>;
 };
 
 export type TempoHasEventMafCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<MafCompleteOptions>;
   where?: InputMaybe<MafCompleteWhere>;
 };
 
 export type TempoHasEventMafCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<MafCompleteWhere>;
 };
 
 export type TempoHasEventMafCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoHasEventMafCompletesConnectionSort>>;
   where?: InputMaybe<TempoHasEventMafCompletesConnectionWhere>;
 };
 
 export type TempoHasEventQcCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<QcCompleteOptions>;
   where?: InputMaybe<QcCompleteWhere>;
 };
 
 export type TempoHasEventQcCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<QcCompleteWhere>;
 };
 
 export type TempoHasEventQcCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoHasEventQcCompletesConnectionSort>>;
   where?: InputMaybe<TempoHasEventQcCompletesConnectionWhere>;
 };
 
 export type TempoSamplesHasTempoArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type TempoSamplesHasTempoAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type TempoSamplesHasTempoConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoSamplesHasTempoConnectionSort>>;
   where?: InputMaybe<TempoSamplesHasTempoConnectionWhere>;
 };
@@ -10391,7 +10773,7 @@ export type TempoAggregateSelection = {
   accessLevel: StringAggregateSelection;
   billedBy: StringAggregateSelection;
   costCenter: StringAggregateSelection;
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   custodianInformation: StringAggregateSelection;
   embargoDate: StringAggregateSelection;
   initialPipelineRunDate: StringAggregateSelection;
@@ -10400,7 +10782,7 @@ export type TempoAggregateSelection = {
 
 export type TempoBamCompleteHasEventBamCompletesAggregationSelection = {
   __typename?: "TempoBamCompleteHasEventBamCompletesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoBamCompleteHasEventBamCompletesNodeAggregateSelection>;
 };
 
@@ -10412,36 +10794,36 @@ export type TempoBamCompleteHasEventBamCompletesNodeAggregateSelection = {
 
 export type TempoCohortRequest = {
   __typename?: "TempoCohortRequest";
-  cohortId: Scalars["String"];
-  endUsers: Scalars["String"];
-  pmUsers: Scalars["String"];
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
+  cohortId: Scalars["String"]["output"];
+  endUsers: Scalars["String"]["output"];
+  pmUsers: Scalars["String"]["output"];
+  projectSubtitle: Scalars["String"]["output"];
+  projectTitle: Scalars["String"]["output"];
   samples: Array<TempoCohortSample>;
-  type: Scalars["String"];
+  type: Scalars["String"]["output"];
 };
 
 export type TempoCohortRequestInput = {
-  cohortId: Scalars["String"];
-  endUsers: Array<Scalars["String"]>;
-  pmUsers: Array<Scalars["String"]>;
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
+  cohortId: Scalars["String"]["input"];
+  endUsers: Array<Scalars["String"]["input"]>;
+  pmUsers: Array<Scalars["String"]["input"]>;
+  projectSubtitle: Scalars["String"]["input"];
+  projectTitle: Scalars["String"]["input"];
   samples: Array<TempoCohortSampleInput>;
-  type: Scalars["String"];
+  type: Scalars["String"]["input"];
 };
 
 export type TempoCohortSample = {
   __typename?: "TempoCohortSample";
-  cmoId?: Maybe<Scalars["String"]>;
-  embargoDate?: Maybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
+  cmoId?: Maybe<Scalars["String"]["output"]>;
+  embargoDate?: Maybe<Scalars["String"]["output"]>;
+  primaryId: Scalars["String"]["output"];
 };
 
 export type TempoCohortSampleInput = {
-  cmoId?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
+  cmoId?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId: Scalars["String"]["input"];
 };
 
 export type TempoConnectInput = {
@@ -10462,18 +10844,18 @@ export type TempoConnectWhere = {
 };
 
 export type TempoCreateInput = {
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
   hasEventBamCompletes?: InputMaybe<TempoHasEventBamCompletesFieldInput>;
   hasEventMafCompletes?: InputMaybe<TempoHasEventMafCompletesFieldInput>;
   hasEventQcCompletes?: InputMaybe<TempoHasEventQcCompletesFieldInput>;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasTempo?: InputMaybe<TempoSamplesHasTempoFieldInput>;
-  smileTempoId: Scalars["String"];
+  smileTempoId: Scalars["String"]["input"];
 };
 
 export type TempoDeleteInput = {
@@ -10504,7 +10886,7 @@ export type TempoDisconnectInput = {
 
 export type TempoEdge = {
   __typename?: "TempoEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -10512,18 +10894,18 @@ export type TempoHasEventBamCompletesAggregateInput = {
   AND?: InputMaybe<Array<TempoHasEventBamCompletesAggregateInput>>;
   NOT?: InputMaybe<TempoHasEventBamCompletesAggregateInput>;
   OR?: InputMaybe<Array<TempoHasEventBamCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoHasEventBamCompletesNodeAggregationWhereInput>;
 };
 
 export type TempoHasEventBamCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<BamCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<BamCompleteConnectWhere>;
 };
 
@@ -10531,7 +10913,7 @@ export type TempoHasEventBamCompletesConnection = {
   __typename?: "TempoHasEventBamCompletesConnection";
   edges: Array<TempoHasEventBamCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoHasEventBamCompletesConnectionSort = {
@@ -10568,41 +10950,41 @@ export type TempoHasEventBamCompletesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoHasEventBamCompletesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoHasEventBamCompletesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoHasEventBamCompletesNodeAggregationWhereInput>>;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoHasEventBamCompletesRelationship = {
   __typename?: "TempoHasEventBamCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: BamComplete;
 };
 
@@ -10623,18 +11005,18 @@ export type TempoHasEventMafCompletesAggregateInput = {
   AND?: InputMaybe<Array<TempoHasEventMafCompletesAggregateInput>>;
   NOT?: InputMaybe<TempoHasEventMafCompletesAggregateInput>;
   OR?: InputMaybe<Array<TempoHasEventMafCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoHasEventMafCompletesNodeAggregationWhereInput>;
 };
 
 export type TempoHasEventMafCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<MafCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<MafCompleteConnectWhere>;
 };
 
@@ -10642,7 +11024,7 @@ export type TempoHasEventMafCompletesConnection = {
   __typename?: "TempoHasEventMafCompletesConnection";
   edges: Array<TempoHasEventMafCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoHasEventMafCompletesConnectionSort = {
@@ -10679,56 +11061,56 @@ export type TempoHasEventMafCompletesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoHasEventMafCompletesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoHasEventMafCompletesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoHasEventMafCompletesNodeAggregationWhereInput>>;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoHasEventMafCompletesRelationship = {
   __typename?: "TempoHasEventMafCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: MafComplete;
 };
 
@@ -10749,18 +11131,18 @@ export type TempoHasEventQcCompletesAggregateInput = {
   AND?: InputMaybe<Array<TempoHasEventQcCompletesAggregateInput>>;
   NOT?: InputMaybe<TempoHasEventQcCompletesAggregateInput>;
   OR?: InputMaybe<Array<TempoHasEventQcCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoHasEventQcCompletesNodeAggregationWhereInput>;
 };
 
 export type TempoHasEventQcCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<QcCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<QcCompleteConnectWhere>;
 };
 
@@ -10768,7 +11150,7 @@ export type TempoHasEventQcCompletesConnection = {
   __typename?: "TempoHasEventQcCompletesConnection";
   edges: Array<TempoHasEventQcCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoHasEventQcCompletesConnectionSort = {
@@ -10805,71 +11187,71 @@ export type TempoHasEventQcCompletesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoHasEventQcCompletesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoHasEventQcCompletesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoHasEventQcCompletesNodeAggregationWhereInput>>;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  reason_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  reason_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  result_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  result_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  result_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoHasEventQcCompletesRelationship = {
   __typename?: "TempoHasEventQcCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: QcComplete;
 };
 
@@ -10888,7 +11270,7 @@ export type TempoHasEventQcCompletesUpdateFieldInput = {
 
 export type TempoMafCompleteHasEventMafCompletesAggregationSelection = {
   __typename?: "TempoMafCompleteHasEventMafCompletesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoMafCompleteHasEventMafCompletesNodeAggregateSelection>;
 };
 
@@ -10900,15 +11282,15 @@ export type TempoMafCompleteHasEventMafCompletesNodeAggregateSelection = {
 };
 
 export type TempoOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more TempoSort objects to sort Tempos by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<TempoSort>>;
 };
 
 export type TempoQcCompleteHasEventQcCompletesAggregationSelection = {
   __typename?: "TempoQcCompleteHasEventQcCompletesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoQcCompleteHasEventQcCompletesNodeAggregateSelection>;
 };
 
@@ -10935,7 +11317,7 @@ export type TempoRelationInput = {
 
 export type TempoSampleSamplesHasTempoAggregationSelection = {
   __typename?: "TempoSampleSamplesHasTempoAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoSampleSamplesHasTempoNodeAggregateSelection>;
 };
 
@@ -10951,18 +11333,18 @@ export type TempoSamplesHasTempoAggregateInput = {
   AND?: InputMaybe<Array<TempoSamplesHasTempoAggregateInput>>;
   NOT?: InputMaybe<TempoSamplesHasTempoAggregateInput>;
   OR?: InputMaybe<Array<TempoSamplesHasTempoAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoSamplesHasTempoNodeAggregationWhereInput>;
 };
 
 export type TempoSamplesHasTempoConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -10970,7 +11352,7 @@ export type TempoSamplesHasTempoConnection = {
   __typename?: "TempoSamplesHasTempoConnection";
   edges: Array<TempoSamplesHasTempoRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoSamplesHasTempoConnectionSort = {
@@ -11007,71 +11389,71 @@ export type TempoSamplesHasTempoNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoSamplesHasTempoNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoSamplesHasTempoNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoSamplesHasTempoNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoSamplesHasTempoRelationship = {
   __typename?: "TempoSamplesHasTempoRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -11101,12 +11483,12 @@ export type TempoSort = {
 };
 
 export type TempoUpdateInput = {
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
   hasEventBamCompletes?: InputMaybe<
     Array<TempoHasEventBamCompletesUpdateFieldInput>
   >;
@@ -11116,46 +11498,48 @@ export type TempoUpdateInput = {
   hasEventQcCompletes?: InputMaybe<
     Array<TempoHasEventQcCompletesUpdateFieldInput>
   >;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasTempo?: InputMaybe<Array<TempoSamplesHasTempoUpdateFieldInput>>;
-  smileTempoId?: InputMaybe<Scalars["String"]>;
+  smileTempoId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type TempoWhere = {
   AND?: InputMaybe<Array<TempoWhere>>;
   NOT?: InputMaybe<TempoWhere>;
   OR?: InputMaybe<Array<TempoWhere>>;
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  accessLevel_CONTAINS?: InputMaybe<Scalars["String"]>;
-  accessLevel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  accessLevel_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  accessLevel_MATCHES?: InputMaybe<Scalars["String"]>;
-  accessLevel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  billedBy_CONTAINS?: InputMaybe<Scalars["String"]>;
-  billedBy_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  billedBy_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  billedBy_MATCHES?: InputMaybe<Scalars["String"]>;
-  billedBy_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  costCenter_CONTAINS?: InputMaybe<Scalars["String"]>;
-  costCenter_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  costCenter_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  costCenter_MATCHES?: InputMaybe<Scalars["String"]>;
-  costCenter_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  custodianInformation_CONTAINS?: InputMaybe<Scalars["String"]>;
-  custodianInformation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  custodianInformation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  custodianInformation_MATCHES?: InputMaybe<Scalars["String"]>;
-  custodianInformation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
-  embargoDate_CONTAINS?: InputMaybe<Scalars["String"]>;
-  embargoDate_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  embargoDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  embargoDate_MATCHES?: InputMaybe<Scalars["String"]>;
-  embargoDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  accessLevel_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  billedBy_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  costCenter_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  custodianInformation_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  embargoDate_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasEventBamCompletesAggregate?: InputMaybe<TempoHasEventBamCompletesAggregateInput>;
   /** Return Tempos where all of the related TempoHasEventBamCompletesConnections match this filter */
   hasEventBamCompletesConnection_ALL?: InputMaybe<TempoHasEventBamCompletesConnectionWhere>;
@@ -11207,12 +11591,14 @@ export type TempoWhere = {
   hasEventQcCompletes_SINGLE?: InputMaybe<QcCompleteWhere>;
   /** Return Tempos where some of the related QcCompletes match this filter */
   hasEventQcCompletes_SOME?: InputMaybe<QcCompleteWhere>;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_CONTAINS?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  initialPipelineRunDate_MATCHES?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  initialPipelineRunDate_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasTempoAggregate?: InputMaybe<TempoSamplesHasTempoAggregateInput>;
   /** Return Tempos where all of the related TempoSamplesHasTempoConnections match this filter */
   samplesHasTempoConnection_ALL?: InputMaybe<TempoSamplesHasTempoConnectionWhere>;
@@ -11230,26 +11616,26 @@ export type TempoWhere = {
   samplesHasTempo_SINGLE?: InputMaybe<SampleWhere>;
   /** Return Tempos where some of the related Samples match this filter */
   samplesHasTempo_SOME?: InputMaybe<SampleWhere>;
-  smileTempoId?: InputMaybe<Scalars["String"]>;
-  smileTempoId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileTempoId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileTempoId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileTempoId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileTempoId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smileTempoId?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileTempoId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type TemposConnection = {
   __typename?: "TemposConnection";
   edges: Array<TempoEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type ToleratedSampleValidationError = {
   __typename?: "ToleratedSampleValidationError";
-  primaryId: Scalars["String"];
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  primaryId: Scalars["String"]["output"];
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type UpdateBamCompletesMutationResponse = {
@@ -11280,11 +11666,11 @@ export type UpdateDbGapsMutationResponse = {
 export type UpdateInfo = {
   __typename?: "UpdateInfo";
   /** @deprecated This field has been deprecated because bookmarks are now handled by the driver. */
-  bookmark?: Maybe<Scalars["String"]>;
-  nodesCreated: Scalars["Int"];
-  nodesDeleted: Scalars["Int"];
-  relationshipsCreated: Scalars["Int"];
-  relationshipsDeleted: Scalars["Int"];
+  bookmark?: Maybe<Scalars["String"]["output"]>;
+  nodesCreated: Scalars["Int"]["output"];
+  nodesDeleted: Scalars["Int"]["output"];
+  relationshipsCreated: Scalars["Int"]["output"];
+  relationshipsDeleted: Scalars["Int"]["output"];
 };
 
 export type UpdateMafCompletesMutationResponse = {
@@ -11360,13 +11746,15 @@ export type UpdateTemposMutationResponse = {
 };
 
 export type DashboardRequestsQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
 }>;
 
 export type DashboardRequestsQuery = {
@@ -11406,14 +11794,16 @@ export type DashboardRequestsQuery = {
 };
 
 export type DashboardPatientsQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
 export type DashboardPatientsQuery = {
@@ -11437,13 +11827,15 @@ export type DashboardPatientsQuery = {
 };
 
 export type DashboardCohortsQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
 }>;
 
 export type DashboardCohortsQuery = {
@@ -11451,6 +11843,7 @@ export type DashboardCohortsQuery = {
   dashboardCohorts: Array<{
     __typename?: "DashboardCohort";
     cohortId: string;
+    cohortStatus?: string | null;
     totalSampleCount?: number | null;
     billed?: string | null;
     initialCohortDeliveryDate?: string | null;
@@ -11469,7 +11862,9 @@ export type DashboardCohortsQuery = {
 };
 
 export type DashboardSamplesQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   recordContexts?: InputMaybe<
     | Array<InputMaybe<DashboardRecordContext>>
     | InputMaybe<DashboardRecordContext>
@@ -11478,10 +11873,10 @@ export type DashboardSamplesQueryVariables = Exact<{
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
-  includeDemographics?: InputMaybe<Scalars["Boolean"]>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  includeDemographics?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
 export type DashboardSamplesQuery = {
@@ -11560,10 +11955,10 @@ export type DashboardSamplesQuery = {
 };
 
 export type DashboardSampleHistoryQueryVariables = Exact<{
-  searchVals: Array<Scalars["String"]> | Scalars["String"];
+  searchVals: Array<Scalars["String"]["input"]> | Scalars["String"]["input"];
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
 }>;
 
 export type DashboardSampleHistoryQuery = {
@@ -11825,7 +12220,7 @@ export type AllBlockedCohortIdsQuery = {
 };
 
 export type AllAnchorSeqDateDataQueryVariables = Exact<{
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
 export type AllAnchorSeqDateDataQuery = {
@@ -12205,6 +12600,7 @@ export const DashboardCohortsDocument = gql`
       offset: $offset
     ) {
       cohortId
+      cohortStatus
       totalSampleCount
       billed
       initialCohortDeliveryDate

--- a/frontend/src/pages/cohorts/config.tsx
+++ b/frontend/src/pages/cohorts/config.tsx
@@ -15,7 +15,11 @@ import {
   BuildDownloadOptionsParamsBase,
   RecordChange,
 } from "../../types/shared";
-import { createCustomHeader } from "../../configs/gridIcons";
+import {
+  createCustomHeader,
+  lockIcon,
+  toolTipIcon,
+} from "../../configs/gridIcons";
 import { buildFieldToHeaderName } from "../../utils/fieldToHeaderName";
 
 type BuildDownloadOptionsParams = BuildDownloadOptionsParamsBase & {
@@ -60,6 +64,13 @@ export const cohortColDefs: ColDef<DashboardCohort>[] = [
   {
     field: "cohortId",
     headerName: "Cohort ID",
+  },
+  {
+    field: "cohortStatus",
+    headerName: "Cohort Status",
+    headerTooltip:
+      "The status of the cohort in SMILE (e.g. PROVISONAL, DELIVERED)",
+    headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
   },
   {
     field: "totalSampleCount",

--- a/frontend/src/pages/patients/config.tsx
+++ b/frontend/src/pages/patients/config.tsx
@@ -49,7 +49,7 @@ export const allAnchorSeqDateColDefs: Array<ColDef<AnchorSeqDateData>> = [
 interface AdditionalBuildDownloadOptionsParams {
   queryAllSeqDates: LazyQueryExecFunction<
     AllAnchorSeqDateDataQuery,
-    Exact<{ phiEnabled?: InputMaybe<Scalars["Boolean"]> }>
+    Exact<{ phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]> }>
   >;
   phiEnabled: boolean;
   userEmail: string | undefined;

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -11,14 +11,23 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never;
+    };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  BigInt: any;
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  BigInt: { input: any; output: any };
 };
 
 export enum AgGridSortDirection {
@@ -28,43 +37,43 @@ export enum AgGridSortDirection {
 
 export type AnchorSeqDateData = {
   __typename?: "AnchorSeqDateData";
-  ANCHOR_ONCOTREE_CODE: Scalars["String"];
-  ANCHOR_SEQUENCING_DATE: Scalars["String"];
-  DMP_PATIENT_ID: Scalars["String"];
-  MRN: Scalars["String"];
+  ANCHOR_ONCOTREE_CODE: Scalars["String"]["output"];
+  ANCHOR_SEQUENCING_DATE: Scalars["String"]["output"];
+  DMP_PATIENT_ID: Scalars["String"]["output"];
+  MRN: Scalars["String"]["output"];
 };
 
 export type BamComplete = {
   __typename?: "BamComplete";
-  date: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
   temposHasEvent: Array<Tempo>;
   temposHasEventAggregate?: Maybe<BamCompleteTempoTemposHasEventAggregationSelection>;
   temposHasEventConnection: BamCompleteTemposHasEventConnection;
 };
 
 export type BamCompleteTemposHasEventArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type BamCompleteTemposHasEventAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type BamCompleteTemposHasEventConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<BamCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<BamCompleteTemposHasEventConnectionWhere>;
 };
 
 export type BamCompleteAggregateSelection = {
   __typename?: "BamCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   status: StringAggregateSelection;
 };
@@ -80,8 +89,8 @@ export type BamCompleteConnectWhere = {
 };
 
 export type BamCompleteCreateInput = {
-  date: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
   temposHasEvent?: InputMaybe<BamCompleteTemposHasEventFieldInput>;
 };
 
@@ -97,13 +106,13 @@ export type BamCompleteDisconnectInput = {
 
 export type BamCompleteEdge = {
   __typename?: "BamCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: BamComplete;
 };
 
 export type BamCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more BamCompleteSort objects to sort BamCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<BamCompleteSort>>;
 };
@@ -120,7 +129,7 @@ export type BamCompleteSort = {
 
 export type BamCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "BamCompleteTempoTemposHasEventAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<BamCompleteTempoTemposHasEventNodeAggregateSelection>;
 };
 
@@ -139,18 +148,18 @@ export type BamCompleteTemposHasEventAggregateInput = {
   AND?: InputMaybe<Array<BamCompleteTemposHasEventAggregateInput>>;
   NOT?: InputMaybe<BamCompleteTemposHasEventAggregateInput>;
   OR?: InputMaybe<Array<BamCompleteTemposHasEventAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<BamCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type BamCompleteTemposHasEventConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -158,7 +167,7 @@ export type BamCompleteTemposHasEventConnection = {
   __typename?: "BamCompleteTemposHasEventConnection";
   edges: Array<BamCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type BamCompleteTemposHasEventConnectionSort = {
@@ -195,116 +204,164 @@ export type BamCompleteTemposHasEventNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<BamCompleteTemposHasEventNodeAggregationWhereInput>>;
   NOT?: InputMaybe<BamCompleteTemposHasEventNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<BamCompleteTemposHasEventNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type BamCompleteTemposHasEventRelationship = {
   __typename?: "BamCompleteTemposHasEventRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -322,8 +379,8 @@ export type BamCompleteTemposHasEventUpdateFieldInput = {
 };
 
 export type BamCompleteUpdateInput = {
-  date?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEvent?: InputMaybe<Array<BamCompleteTemposHasEventUpdateFieldInput>>;
 };
 
@@ -331,18 +388,18 @@ export type BamCompleteWhere = {
   AND?: InputMaybe<Array<BamCompleteWhere>>;
   NOT?: InputMaybe<BamCompleteWhere>;
   OR?: InputMaybe<Array<BamCompleteWhere>>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEventAggregate?: InputMaybe<BamCompleteTemposHasEventAggregateInput>;
   /** Return BamCompletes where all of the related BamCompleteTemposHasEventConnections match this filter */
   temposHasEventConnection_ALL?: InputMaybe<BamCompleteTemposHasEventConnectionWhere>;
@@ -366,20 +423,21 @@ export type BamCompletesConnection = {
   __typename?: "BamCompletesConnection";
   edges: Array<BamCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type BigIntAggregateSelection = {
   __typename?: "BigIntAggregateSelection";
-  average?: Maybe<Scalars["BigInt"]>;
-  max?: Maybe<Scalars["BigInt"]>;
-  min?: Maybe<Scalars["BigInt"]>;
-  sum?: Maybe<Scalars["BigInt"]>;
+  average?: Maybe<Scalars["BigInt"]["output"]>;
+  max?: Maybe<Scalars["BigInt"]["output"]>;
+  min?: Maybe<Scalars["BigInt"]["output"]>;
+  sum?: Maybe<Scalars["BigInt"]["output"]>;
 };
 
 export type Cohort = {
   __typename?: "Cohort";
-  cohortId: Scalars["String"];
+  cohortId: Scalars["String"]["output"];
+  cohortStatus: Scalars["String"]["output"];
   hasCohortCompleteCohortCompletes: Array<CohortComplete>;
   hasCohortCompleteCohortCompletesAggregate?: Maybe<CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection>;
   hasCohortCompleteCohortCompletesConnection: CohortHasCohortCompleteCohortCompletesConnection;
@@ -389,20 +447,20 @@ export type Cohort = {
 };
 
 export type CohortHasCohortCompleteCohortCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<CohortCompleteOptions>;
   where?: InputMaybe<CohortCompleteWhere>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<CohortCompleteWhere>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesConnectionSort>
   >;
@@ -410,20 +468,20 @@ export type CohortHasCohortCompleteCohortCompletesConnectionArgs = {
 };
 
 export type CohortHasCohortSampleSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type CohortHasCohortSampleSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type CohortHasCohortSampleSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<CohortHasCohortSampleSamplesConnectionSort>>;
   where?: InputMaybe<CohortHasCohortSampleSamplesConnectionWhere>;
 };
@@ -431,13 +489,14 @@ export type CohortHasCohortSampleSamplesConnectionArgs = {
 export type CohortAggregateSelection = {
   __typename?: "CohortAggregateSelection";
   cohortId: StringAggregateSelection;
-  count: Scalars["Int"];
+  cohortStatus: StringAggregateSelection;
+  count: Scalars["Int"]["output"];
 };
 
 export type CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection =
   {
     __typename?: "CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSelection>;
   };
 
@@ -460,32 +519,32 @@ export type CohortComplete = {
   cohortsHasCohortComplete: Array<Cohort>;
   cohortsHasCohortCompleteAggregate?: Maybe<CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection>;
   cohortsHasCohortCompleteConnection: CohortCompleteCohortsHasCohortCompleteConnection;
-  date: Scalars["String"];
-  endUsers: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  pipelineVersion?: Maybe<Scalars["String"]>;
-  pmUsers: Scalars["String"];
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
-  status: Scalars["String"];
-  type: Scalars["String"];
+  date?: Maybe<Scalars["String"]["output"]>;
+  endUsers: Scalars["String"]["output"];
+  importDate: Scalars["BigInt"]["output"];
+  pipelineVersion?: Maybe<Scalars["String"]["output"]>;
+  pmUsers: Scalars["String"]["output"];
+  projectSubtitle: Scalars["String"]["output"];
+  projectTitle: Scalars["String"]["output"];
+  status?: Maybe<Scalars["String"]["output"]>;
+  type: Scalars["String"]["output"];
 };
 
 export type CohortCompleteCohortsHasCohortCompleteArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<CohortOptions>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteConnectionSort>
   >;
@@ -494,7 +553,7 @@ export type CohortCompleteCohortsHasCohortCompleteConnectionArgs = {
 
 export type CohortCompleteAggregateSelection = {
   __typename?: "CohortCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   endUsers: StringAggregateSelection;
   importDate: BigIntAggregateSelection;
@@ -508,7 +567,7 @@ export type CohortCompleteAggregateSelection = {
 
 export type CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection = {
   __typename?: "CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection>;
 };
 
@@ -516,24 +575,25 @@ export type CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection =
   {
     __typename?: "CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection";
     cohortId: StringAggregateSelection;
+    cohortStatus: StringAggregateSelection;
   };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateInput = {
   AND?: InputMaybe<Array<CohortCompleteCohortsHasCohortCompleteAggregateInput>>;
   NOT?: InputMaybe<CohortCompleteCohortsHasCohortCompleteAggregateInput>;
   OR?: InputMaybe<Array<CohortCompleteCohortsHasCohortCompleteAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteConnectFieldInput = {
   connect?: InputMaybe<Array<CohortConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<CohortConnectWhere>;
 };
 
@@ -541,7 +601,7 @@ export type CohortCompleteCohortsHasCohortCompleteConnection = {
   __typename?: "CohortCompleteCohortsHasCohortCompleteConnection";
   edges: Array<CohortCompleteCohortsHasCohortCompleteRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortCompleteCohortsHasCohortCompleteConnectionSort = {
@@ -588,26 +648,41 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput>
   >;
-  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteRelationship = {
   __typename?: "CohortCompleteCohortsHasCohortCompleteRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Cohort;
 };
 
@@ -644,15 +719,15 @@ export type CohortCompleteConnectWhere = {
 
 export type CohortCompleteCreateInput = {
   cohortsHasCohortComplete?: InputMaybe<CohortCompleteCohortsHasCohortCompleteFieldInput>;
-  date: Scalars["String"];
-  endUsers: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pmUsers: Scalars["String"];
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
-  status: Scalars["String"];
-  type: Scalars["String"];
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers: Scalars["String"]["input"];
+  importDate: Scalars["BigInt"]["input"];
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers: Scalars["String"]["input"];
+  projectSubtitle: Scalars["String"]["input"];
+  projectTitle: Scalars["String"]["input"];
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  type: Scalars["String"]["input"];
 };
 
 export type CohortCompleteDeleteInput = {
@@ -669,13 +744,13 @@ export type CohortCompleteDisconnectInput = {
 
 export type CohortCompleteEdge = {
   __typename?: "CohortCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: CohortComplete;
 };
 
 export type CohortCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more CohortCompleteSort objects to sort CohortCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<CohortCompleteSort>>;
 };
@@ -703,17 +778,17 @@ export type CohortCompleteUpdateInput = {
   cohortsHasCohortComplete?: InputMaybe<
     Array<CohortCompleteCohortsHasCohortCompleteUpdateFieldInput>
   >;
-  date?: InputMaybe<Scalars["String"]>;
-  endUsers?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Scalars["String"]>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  type?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type CohortCompleteWhere = {
@@ -737,67 +812,69 @@ export type CohortCompleteWhere = {
   cohortsHasCohortComplete_SINGLE?: InputMaybe<CohortWhere>;
   /** Return CohortCompletes where some of the related Cohorts match this filter */
   cohortsHasCohortComplete_SOME?: InputMaybe<CohortWhere>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  endUsers?: InputMaybe<Scalars["String"]>;
-  endUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
-  endUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  endUsers_IN?: InputMaybe<Array<Scalars["String"]>>;
-  endUsers_MATCHES?: InputMaybe<Scalars["String"]>;
-  endUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]>>;
-  importDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_CONTAINS?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pipelineVersion_MATCHES?: InputMaybe<Scalars["String"]>;
-  pipelineVersion_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Scalars["String"]>;
-  pmUsers_CONTAINS?: InputMaybe<Scalars["String"]>;
-  pmUsers_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  pmUsers_IN?: InputMaybe<Array<Scalars["String"]>>;
-  pmUsers_MATCHES?: InputMaybe<Scalars["String"]>;
-  pmUsers_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_IN?: InputMaybe<Array<Scalars["String"]>>;
-  projectSubtitle_MATCHES?: InputMaybe<Scalars["String"]>;
-  projectSubtitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
-  projectTitle_CONTAINS?: InputMaybe<Scalars["String"]>;
-  projectTitle_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectTitle_IN?: InputMaybe<Array<Scalars["String"]>>;
-  projectTitle_MATCHES?: InputMaybe<Scalars["String"]>;
-  projectTitle_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  type?: InputMaybe<Scalars["String"]>;
-  type_CONTAINS?: InputMaybe<Scalars["String"]>;
-  type_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  type_IN?: InputMaybe<Array<Scalars["String"]>>;
-  type_MATCHES?: InputMaybe<Scalars["String"]>;
-  type_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  endUsers_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  importDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  pipelineVersion_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  pmUsers_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  projectSubtitle_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  projectTitle_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
+  type_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  type_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  type_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  type_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  type_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type CohortCompletesConnection = {
   __typename?: "CohortCompletesConnection";
   edges: Array<CohortCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortConnectInput = {
@@ -814,7 +891,8 @@ export type CohortConnectWhere = {
 };
 
 export type CohortCreateInput = {
-  cohortId: Scalars["String"];
+  cohortId: Scalars["String"]["input"];
+  cohortStatus: Scalars["String"]["input"];
   hasCohortCompleteCohortCompletes?: InputMaybe<CohortHasCohortCompleteCohortCompletesFieldInput>;
   hasCohortSampleSamples?: InputMaybe<CohortHasCohortSampleSamplesFieldInput>;
 };
@@ -839,7 +917,7 @@ export type CohortDisconnectInput = {
 
 export type CohortEdge = {
   __typename?: "CohortEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Cohort;
 };
 
@@ -847,18 +925,18 @@ export type CohortHasCohortCompleteCohortCompletesAggregateInput = {
   AND?: InputMaybe<Array<CohortHasCohortCompleteCohortCompletesAggregateInput>>;
   NOT?: InputMaybe<CohortHasCohortCompleteCohortCompletesAggregateInput>;
   OR?: InputMaybe<Array<CohortHasCohortCompleteCohortCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<CohortCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<CohortCompleteConnectWhere>;
 };
 
@@ -866,7 +944,7 @@ export type CohortHasCohortCompleteCohortCompletesConnection = {
   __typename?: "CohortHasCohortCompleteCohortCompletesConnection";
   edges: Array<CohortHasCohortCompleteCohortCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortHasCohortCompleteCohortCompletesConnectionSort = {
@@ -913,151 +991,151 @@ export type CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput>
   >;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  endUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  endUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  endUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  endUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  pipelineVersion_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  pipelineVersion_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pipelineVersion_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  pmUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  pmUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  pmUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectSubtitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectSubtitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectTitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectTitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectTitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  type_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  type_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  type_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  type_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  type_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  endUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  endUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pipelineVersion_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  pmUsers_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  pmUsers_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectSubtitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectTitle_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectTitle_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  type_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  type_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  type_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type CohortHasCohortCompleteCohortCompletesRelationship = {
   __typename?: "CohortHasCohortCompleteCohortCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: CohortComplete;
 };
 
@@ -1086,18 +1164,18 @@ export type CohortHasCohortSampleSamplesAggregateInput = {
   AND?: InputMaybe<Array<CohortHasCohortSampleSamplesAggregateInput>>;
   NOT?: InputMaybe<CohortHasCohortSampleSamplesAggregateInput>;
   OR?: InputMaybe<Array<CohortHasCohortSampleSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<CohortHasCohortSampleSamplesNodeAggregationWhereInput>;
 };
 
 export type CohortHasCohortSampleSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -1105,7 +1183,7 @@ export type CohortHasCohortSampleSamplesConnection = {
   __typename?: "CohortHasCohortSampleSamplesConnection";
   edges: Array<CohortHasCohortSampleSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CohortHasCohortSampleSamplesConnectionSort = {
@@ -1144,71 +1222,71 @@ export type CohortHasCohortSampleSamplesNodeAggregationWhereInput = {
   >;
   NOT?: InputMaybe<CohortHasCohortSampleSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<CohortHasCohortSampleSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type CohortHasCohortSampleSamplesRelationship = {
   __typename?: "CohortHasCohortSampleSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -1228,8 +1306,8 @@ export type CohortHasCohortSampleSamplesUpdateFieldInput = {
 };
 
 export type CohortOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more CohortSort objects to sort Cohorts by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<CohortSort>>;
 };
@@ -1245,7 +1323,7 @@ export type CohortRelationInput = {
 
 export type CohortSampleHasCohortSampleSamplesAggregationSelection = {
   __typename?: "CohortSampleHasCohortSampleSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<CohortSampleHasCohortSampleSamplesNodeAggregateSelection>;
 };
 
@@ -1260,10 +1338,12 @@ export type CohortSampleHasCohortSampleSamplesNodeAggregateSelection = {
 /** Fields to sort Cohorts by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortSort object. */
 export type CohortSort = {
   cohortId?: InputMaybe<SortDirection>;
+  cohortStatus?: InputMaybe<SortDirection>;
 };
 
 export type CohortUpdateInput = {
-  cohortId?: InputMaybe<Scalars["String"]>;
+  cohortId?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus?: InputMaybe<Scalars["String"]["input"]>;
   hasCohortCompleteCohortCompletes?: InputMaybe<
     Array<CohortHasCohortCompleteCohortCompletesUpdateFieldInput>
   >;
@@ -1276,12 +1356,18 @@ export type CohortWhere = {
   AND?: InputMaybe<Array<CohortWhere>>;
   NOT?: InputMaybe<CohortWhere>;
   OR?: InputMaybe<Array<CohortWhere>>;
-  cohortId?: InputMaybe<Scalars["String"]>;
-  cohortId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cohortId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cohortId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  cohortId_MATCHES?: InputMaybe<Scalars["String"]>;
-  cohortId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  cohortId?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  cohortId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  cohortStatus_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cohortStatus_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasCohortCompleteCohortCompletesAggregate?: InputMaybe<CohortHasCohortCompleteCohortCompletesAggregateInput>;
   /** Return Cohorts where all of the related CohortHasCohortCompleteCohortCompletesConnections match this filter */
   hasCohortCompleteCohortCompletesConnection_ALL?: InputMaybe<CohortHasCohortCompleteCohortCompletesConnectionWhere>;
@@ -1322,7 +1408,7 @@ export type CohortsConnection = {
   __typename?: "CohortsConnection";
   edges: Array<CohortEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type CreateBamCompletesMutationResponse = {
@@ -1353,9 +1439,9 @@ export type CreateDbGapsMutationResponse = {
 export type CreateInfo = {
   __typename?: "CreateInfo";
   /** @deprecated This field has been deprecated because bookmarks are now handled by the driver. */
-  bookmark?: Maybe<Scalars["String"]>;
-  nodesCreated: Scalars["Int"];
-  relationshipsCreated: Scalars["Int"];
+  bookmark?: Maybe<Scalars["String"]["output"]>;
+  nodesCreated: Scalars["Int"]["output"];
+  relationshipsCreated: Scalars["Int"]["output"];
 };
 
 export type CreateMafCompletesMutationResponse = {
@@ -1432,265 +1518,267 @@ export type CreateTemposMutationResponse = {
 
 export type DashboardCohort = {
   __typename?: "DashboardCohort";
-  _total?: Maybe<Scalars["Int"]>;
-  _uniqueSampleCount?: Maybe<Scalars["Int"]>;
-  billed?: Maybe<Scalars["String"]>;
-  cohortId: Scalars["String"];
-  endUsers?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
-  initialCohortDeliveryDate?: Maybe<Scalars["String"]>;
-  pipelineVersion?: Maybe<Scalars["String"]>;
-  pmUsers?: Maybe<Scalars["String"]>;
-  projectSubtitle?: Maybe<Scalars["String"]>;
-  projectTitle?: Maybe<Scalars["String"]>;
-  searchableSampleIds?: Maybe<Scalars["String"]>;
-  status?: Maybe<Scalars["String"]>;
-  totalSampleCount?: Maybe<Scalars["Int"]>;
-  type?: Maybe<Scalars["String"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  _uniqueSampleCount?: Maybe<Scalars["Int"]["output"]>;
+  billed?: Maybe<Scalars["String"]["output"]>;
+  cohortId: Scalars["String"]["output"];
+  cohortStatus?: Maybe<Scalars["String"]["output"]>;
+  endUsers?: Maybe<Scalars["String"]["output"]>;
+  importDate?: Maybe<Scalars["String"]["output"]>;
+  initialCohortDeliveryDate?: Maybe<Scalars["String"]["output"]>;
+  pipelineVersion?: Maybe<Scalars["String"]["output"]>;
+  pmUsers?: Maybe<Scalars["String"]["output"]>;
+  projectSubtitle?: Maybe<Scalars["String"]["output"]>;
+  projectTitle?: Maybe<Scalars["String"]["output"]>;
+  searchableSampleIds?: Maybe<Scalars["String"]["output"]>;
+  status?: Maybe<Scalars["String"]["output"]>;
+  totalSampleCount?: Maybe<Scalars["Int"]["output"]>;
+  type?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type DashboardCohortInput = {
-  _total?: InputMaybe<Scalars["Int"]>;
-  _uniqueSampleCount?: InputMaybe<Scalars["Int"]>;
-  billed?: InputMaybe<Scalars["String"]>;
-  changedFieldNames: Array<Scalars["String"]>;
-  changelog?: InputMaybe<Scalars["String"]>;
-  cohortId: Scalars["String"];
-  endUsers?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["String"]>;
-  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]>;
-  pipelineVersion?: InputMaybe<Scalars["String"]>;
-  pmUsers?: InputMaybe<Scalars["String"]>;
-  projectSubtitle?: InputMaybe<Scalars["String"]>;
-  projectTitle?: InputMaybe<Scalars["String"]>;
-  searchableSampleIds?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  totalSampleCount?: InputMaybe<Scalars["Int"]>;
-  type?: InputMaybe<Scalars["String"]>;
+  _total?: InputMaybe<Scalars["Int"]["input"]>;
+  _uniqueSampleCount?: InputMaybe<Scalars["Int"]["input"]>;
+  billed?: InputMaybe<Scalars["String"]["input"]>;
+  changedFieldNames: Array<Scalars["String"]["input"]>;
+  changelog?: InputMaybe<Scalars["String"]["input"]>;
+  cohortId: Scalars["String"]["input"];
+  cohortStatus?: InputMaybe<Scalars["String"]["input"]>;
+  endUsers?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["String"]["input"]>;
+  initialCohortDeliveryDate?: InputMaybe<Scalars["String"]["input"]>;
+  pipelineVersion?: InputMaybe<Scalars["String"]["input"]>;
+  pmUsers?: InputMaybe<Scalars["String"]["input"]>;
+  projectSubtitle?: InputMaybe<Scalars["String"]["input"]>;
+  projectTitle?: InputMaybe<Scalars["String"]["input"]>;
+  searchableSampleIds?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  totalSampleCount?: InputMaybe<Scalars["Int"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type DashboardPatient = {
   __typename?: "DashboardPatient";
-  _total?: Maybe<Scalars["Int"]>;
-  anchorOncotreeCode?: Maybe<Scalars["String"]>;
-  anchorSequencingDate?: Maybe<Scalars["String"]>;
-  cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleIds?: Maybe<Scalars["String"]>;
-  consentPartA?: Maybe<Scalars["String"]>;
-  consentPartC?: Maybe<Scalars["String"]>;
-  dmpPatientId?: Maybe<Scalars["String"]>;
-  inDbGap?: Maybe<Scalars["Boolean"]>;
-  mrn?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  smilePatientId: Scalars["String"];
-  totalSampleCount?: Maybe<Scalars["Int"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  anchorOncotreeCode?: Maybe<Scalars["String"]["output"]>;
+  anchorSequencingDate?: Maybe<Scalars["String"]["output"]>;
+  cmoPatientId?: Maybe<Scalars["String"]["output"]>;
+  cmoSampleIds?: Maybe<Scalars["String"]["output"]>;
+  consentPartA?: Maybe<Scalars["String"]["output"]>;
+  consentPartC?: Maybe<Scalars["String"]["output"]>;
+  dmpPatientId?: Maybe<Scalars["String"]["output"]>;
+  inDbGap?: Maybe<Scalars["Boolean"]["output"]>;
+  mrn?: Maybe<Scalars["String"]["output"]>;
+  race?: Maybe<Scalars["String"]["output"]>;
+  smilePatientId: Scalars["String"]["output"];
+  totalSampleCount?: Maybe<Scalars["Int"]["output"]>;
 };
 
 export type DashboardRecordColumnFilter = {
-  field: Scalars["String"];
-  filter: Scalars["String"];
+  field: Scalars["String"]["input"];
+  filter: Scalars["String"]["input"];
 };
 
 export type DashboardRecordContext = {
-  fieldName?: InputMaybe<Scalars["String"]>;
-  values: Array<Scalars["String"]>;
+  fieldName?: InputMaybe<Scalars["String"]["input"]>;
+  values: Array<Scalars["String"]["input"]>;
 };
 
 export type DashboardRecordSort = {
-  colId: Scalars["String"];
+  colId: Scalars["String"]["input"];
   sort: AgGridSortDirection;
 };
 
 export type DashboardRequest = {
   __typename?: "DashboardRequest";
-  _total?: Maybe<Scalars["Int"]>;
-  bicAnalysis?: Maybe<Scalars["Boolean"]>;
-  dataAccessEmails?: Maybe<Scalars["String"]>;
-  dataAnalystEmail?: Maybe<Scalars["String"]>;
-  dataAnalystName?: Maybe<Scalars["String"]>;
-  genePanel?: Maybe<Scalars["String"]>;
-  igoDeliveryDate?: Maybe<Scalars["String"]>;
-  igoProjectId?: Maybe<Scalars["String"]>;
-  igoRequestId: Scalars["String"];
-  ilabRequestId?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
-  investigatorEmail?: Maybe<Scalars["String"]>;
-  investigatorName?: Maybe<Scalars["String"]>;
-  isCmoRequest?: Maybe<Scalars["Boolean"]>;
-  labHeadEmail?: Maybe<Scalars["String"]>;
-  labHeadName?: Maybe<Scalars["String"]>;
-  otherContactEmails?: Maybe<Scalars["String"]>;
-  piEmail?: Maybe<Scalars["String"]>;
-  projectManagerName?: Maybe<Scalars["String"]>;
-  qcAccessEmails?: Maybe<Scalars["String"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  bicAnalysis?: Maybe<Scalars["Boolean"]["output"]>;
+  dataAccessEmails?: Maybe<Scalars["String"]["output"]>;
+  dataAnalystEmail?: Maybe<Scalars["String"]["output"]>;
+  dataAnalystName?: Maybe<Scalars["String"]["output"]>;
+  genePanel?: Maybe<Scalars["String"]["output"]>;
+  igoDeliveryDate?: Maybe<Scalars["String"]["output"]>;
+  igoProjectId?: Maybe<Scalars["String"]["output"]>;
+  igoRequestId: Scalars["String"]["output"];
+  ilabRequestId?: Maybe<Scalars["String"]["output"]>;
+  importDate?: Maybe<Scalars["String"]["output"]>;
+  investigatorEmail?: Maybe<Scalars["String"]["output"]>;
+  investigatorName?: Maybe<Scalars["String"]["output"]>;
+  isCmoRequest?: Maybe<Scalars["Boolean"]["output"]>;
+  labHeadEmail?: Maybe<Scalars["String"]["output"]>;
+  labHeadName?: Maybe<Scalars["String"]["output"]>;
+  otherContactEmails?: Maybe<Scalars["String"]["output"]>;
+  piEmail?: Maybe<Scalars["String"]["output"]>;
+  projectManagerName?: Maybe<Scalars["String"]["output"]>;
+  qcAccessEmails?: Maybe<Scalars["String"]["output"]>;
   toleratedSampleErrors?: Maybe<Array<Maybe<ToleratedSampleValidationError>>>;
-  totalSampleCount?: Maybe<Scalars["Int"]>;
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  totalSampleCount?: Maybe<Scalars["Int"]["output"]>;
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type DashboardSample = {
   __typename?: "DashboardSample";
-  _total?: Maybe<Scalars["Int"]>;
-  accessLevel?: Maybe<Scalars["String"]>;
-  altId?: Maybe<Scalars["String"]>;
-  analyteType?: Maybe<Scalars["String"]>;
-  baitSet?: Maybe<Scalars["String"]>;
-  bamCompleteDate?: Maybe<Scalars["String"]>;
-  bamCompleteStatus?: Maybe<Scalars["String"]>;
-  billed?: Maybe<Scalars["Boolean"]>;
-  billedBy?: Maybe<Scalars["String"]>;
-  cancerType?: Maybe<Scalars["String"]>;
-  cancerTypeDetailed?: Maybe<Scalars["String"]>;
-  cfDNA2dBarcode?: Maybe<Scalars["String"]>;
-  changelog?: Maybe<Scalars["String"]>;
-  cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleName?: Maybe<Scalars["String"]>;
-  collectionYear?: Maybe<Scalars["String"]>;
-  costCenter?: Maybe<Scalars["String"]>;
-  custodianInformation?: Maybe<Scalars["String"]>;
-  dbGapStudy?: Maybe<Scalars["String"]>;
-  dmpPatientAlias?: Maybe<Scalars["String"]>;
-  dmpRecommendedCoverage?: Maybe<Scalars["String"]>;
-  embargoDate?: Maybe<Scalars["String"]>;
-  genePanel?: Maybe<Scalars["String"]>;
-  historicalCmoSampleNames?: Maybe<Scalars["String"]>;
-  igoComplete?: Maybe<Scalars["Boolean"]>;
-  igoDeliveryDate?: Maybe<Scalars["String"]>;
+  _total?: Maybe<Scalars["Int"]["output"]>;
+  accessLevel?: Maybe<Scalars["String"]["output"]>;
+  altId?: Maybe<Scalars["String"]["output"]>;
+  analyteType?: Maybe<Scalars["String"]["output"]>;
+  baitSet?: Maybe<Scalars["String"]["output"]>;
+  bamCompleteDate?: Maybe<Scalars["String"]["output"]>;
+  bamCompleteStatus?: Maybe<Scalars["String"]["output"]>;
+  billed?: Maybe<Scalars["Boolean"]["output"]>;
+  billedBy?: Maybe<Scalars["String"]["output"]>;
+  cancerType?: Maybe<Scalars["String"]["output"]>;
+  cancerTypeDetailed?: Maybe<Scalars["String"]["output"]>;
+  cfDNA2dBarcode?: Maybe<Scalars["String"]["output"]>;
+  changelog?: Maybe<Scalars["String"]["output"]>;
+  cmoPatientId?: Maybe<Scalars["String"]["output"]>;
+  cmoSampleName?: Maybe<Scalars["String"]["output"]>;
+  collectionYear?: Maybe<Scalars["String"]["output"]>;
+  costCenter?: Maybe<Scalars["String"]["output"]>;
+  custodianInformation?: Maybe<Scalars["String"]["output"]>;
+  dbGapStudy?: Maybe<Scalars["String"]["output"]>;
+  dmpPatientAlias?: Maybe<Scalars["String"]["output"]>;
+  dmpRecommendedCoverage?: Maybe<Scalars["String"]["output"]>;
+  embargoDate?: Maybe<Scalars["String"]["output"]>;
+  genePanel?: Maybe<Scalars["String"]["output"]>;
+  historicalCmoSampleNames?: Maybe<Scalars["String"]["output"]>;
+  igoComplete?: Maybe<Scalars["Boolean"]["output"]>;
+  igoDeliveryDate?: Maybe<Scalars["String"]["output"]>;
   igoQcReports?: Maybe<Array<Maybe<IgoQcReport>>>;
-  igoSampleStatus?: Maybe<Scalars["String"]>;
-  importDate?: Maybe<Scalars["String"]>;
-  initialPipelineRunDate?: Maybe<Scalars["String"]>;
-  instrumentModel?: Maybe<Scalars["String"]>;
-  investigatorSampleId?: Maybe<Scalars["String"]>;
-  irbConsentProtocol?: Maybe<Scalars["String"]>;
-  mafCompleteDate?: Maybe<Scalars["String"]>;
-  mafCompleteNormalPrimaryId?: Maybe<Scalars["String"]>;
-  mafCompleteStatus?: Maybe<Scalars["String"]>;
-  molecularAccessionNumber?: Maybe<Scalars["String"]>;
-  oncotreeCode?: Maybe<Scalars["String"]>;
-  platform?: Maybe<Scalars["String"]>;
-  preservation?: Maybe<Scalars["String"]>;
-  primaryId?: Maybe<Scalars["String"]>;
-  qcCompleteDate?: Maybe<Scalars["String"]>;
-  qcCompleteReason?: Maybe<Scalars["String"]>;
-  qcCompleteResult?: Maybe<Scalars["String"]>;
-  qcCompleteStatus?: Maybe<Scalars["String"]>;
-  race?: Maybe<Scalars["String"]>;
-  recipe?: Maybe<Scalars["String"]>;
-  recordId: Scalars["String"];
-  revisable?: Maybe<Scalars["Boolean"]>;
-  sampleCategory: Scalars["String"];
-  sampleClass?: Maybe<Scalars["String"]>;
-  sampleCohortIds?: Maybe<Scalars["String"]>;
-  sampleOrigin?: Maybe<Scalars["String"]>;
-  sampleType?: Maybe<Scalars["String"]>;
-  sequencingDate?: Maybe<Scalars["String"]>;
-  sex?: Maybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
-  species?: Maybe<Scalars["String"]>;
-  tissueLocation?: Maybe<Scalars["String"]>;
-  tumorOrNormal?: Maybe<Scalars["String"]>;
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  igoSampleStatus?: Maybe<Scalars["String"]["output"]>;
+  importDate?: Maybe<Scalars["String"]["output"]>;
+  initialPipelineRunDate?: Maybe<Scalars["String"]["output"]>;
+  instrumentModel?: Maybe<Scalars["String"]["output"]>;
+  investigatorSampleId?: Maybe<Scalars["String"]["output"]>;
+  irbConsentProtocol?: Maybe<Scalars["String"]["output"]>;
+  mafCompleteDate?: Maybe<Scalars["String"]["output"]>;
+  mafCompleteNormalPrimaryId?: Maybe<Scalars["String"]["output"]>;
+  mafCompleteStatus?: Maybe<Scalars["String"]["output"]>;
+  molecularAccessionNumber?: Maybe<Scalars["String"]["output"]>;
+  oncotreeCode?: Maybe<Scalars["String"]["output"]>;
+  platform?: Maybe<Scalars["String"]["output"]>;
+  preservation?: Maybe<Scalars["String"]["output"]>;
+  primaryId?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteDate?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteReason?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteResult?: Maybe<Scalars["String"]["output"]>;
+  qcCompleteStatus?: Maybe<Scalars["String"]["output"]>;
+  race?: Maybe<Scalars["String"]["output"]>;
+  recipe?: Maybe<Scalars["String"]["output"]>;
+  recordId: Scalars["String"]["output"];
+  revisable?: Maybe<Scalars["Boolean"]["output"]>;
+  sampleCategory: Scalars["String"]["output"];
+  sampleClass?: Maybe<Scalars["String"]["output"]>;
+  sampleCohortIds?: Maybe<Scalars["String"]["output"]>;
+  sampleOrigin?: Maybe<Scalars["String"]["output"]>;
+  sampleType?: Maybe<Scalars["String"]["output"]>;
+  sequencingDate?: Maybe<Scalars["String"]["output"]>;
+  sex?: Maybe<Scalars["String"]["output"]>;
+  smileSampleId: Scalars["String"]["output"];
+  species?: Maybe<Scalars["String"]["output"]>;
+  tissueLocation?: Maybe<Scalars["String"]["output"]>;
+  tumorOrNormal?: Maybe<Scalars["String"]["output"]>;
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type DashboardSampleInput = {
-  _total?: InputMaybe<Scalars["Int"]>;
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  altId?: InputMaybe<Scalars["String"]>;
-  analyteType?: InputMaybe<Scalars["String"]>;
-  baitSet?: InputMaybe<Scalars["String"]>;
-  bamCompleteDate?: InputMaybe<Scalars["String"]>;
-  bamCompleteStatus?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  cancerType?: InputMaybe<Scalars["String"]>;
-  cancerTypeDetailed?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  changedFieldNames: Array<Scalars["String"]>;
-  changelog?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  dbGapStudy?: InputMaybe<Scalars["String"]>;
-  dmpPatientAlias?: InputMaybe<Scalars["String"]>;
-  dmpRecommendedCoverage?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
-  historicalCmoSampleNames?: InputMaybe<Scalars["String"]>;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoDeliveryDate?: InputMaybe<Scalars["String"]>;
-  igoSampleStatus?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
-  instrumentModel?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  irbConsentProtocol?: InputMaybe<Scalars["String"]>;
-  mafCompleteDate?: InputMaybe<Scalars["String"]>;
-  mafCompleteNormalPrimaryId?: InputMaybe<Scalars["String"]>;
-  mafCompleteStatus?: InputMaybe<Scalars["String"]>;
-  molecularAccessionNumber?: InputMaybe<Scalars["String"]>;
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  platform?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
-  qcCompleteDate?: InputMaybe<Scalars["String"]>;
-  qcCompleteReason?: InputMaybe<Scalars["String"]>;
-  qcCompleteResult?: InputMaybe<Scalars["String"]>;
-  qcCompleteStatus?: InputMaybe<Scalars["String"]>;
-  race?: InputMaybe<Scalars["String"]>;
-  recipe?: InputMaybe<Scalars["String"]>;
-  recordId: Scalars["String"];
-  revisable?: InputMaybe<Scalars["Boolean"]>;
-  sampleCategory: Scalars["String"];
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleCohortIds?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
-  sequencingDate?: InputMaybe<Scalars["String"]>;
-  sex?: InputMaybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
-  species?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  _total?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  altId?: InputMaybe<Scalars["String"]["input"]>;
+  analyteType?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  bamCompleteDate?: InputMaybe<Scalars["String"]["input"]>;
+  bamCompleteStatus?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  cancerType?: InputMaybe<Scalars["String"]["input"]>;
+  cancerTypeDetailed?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  changedFieldNames: Array<Scalars["String"]["input"]>;
+  changelog?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy?: InputMaybe<Scalars["String"]["input"]>;
+  dmpPatientAlias?: InputMaybe<Scalars["String"]["input"]>;
+  dmpRecommendedCoverage?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
+  historicalCmoSampleNames?: InputMaybe<Scalars["String"]["input"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoDeliveryDate?: InputMaybe<Scalars["String"]["input"]>;
+  igoSampleStatus?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
+  instrumentModel?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  irbConsentProtocol?: InputMaybe<Scalars["String"]["input"]>;
+  mafCompleteDate?: InputMaybe<Scalars["String"]["input"]>;
+  mafCompleteNormalPrimaryId?: InputMaybe<Scalars["String"]["input"]>;
+  mafCompleteStatus?: InputMaybe<Scalars["String"]["input"]>;
+  molecularAccessionNumber?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  platform?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteDate?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteReason?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteResult?: InputMaybe<Scalars["String"]["input"]>;
+  qcCompleteStatus?: InputMaybe<Scalars["String"]["input"]>;
+  race?: InputMaybe<Scalars["String"]["input"]>;
+  recipe?: InputMaybe<Scalars["String"]["input"]>;
+  recordId: Scalars["String"]["input"];
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
+  sampleCategory: Scalars["String"]["input"];
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCohortIds?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
+  sequencingDate?: InputMaybe<Scalars["String"]["input"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId: Scalars["String"]["input"];
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type DbGap = {
   __typename?: "DbGap";
-  dbGapStudy: Scalars["String"];
+  dbGapStudy: Scalars["String"]["output"];
   samplesHasDbgap: Array<Sample>;
   samplesHasDbgapAggregate?: Maybe<DbGapSampleSamplesHasDbgapAggregationSelection>;
   samplesHasDbgapConnection: DbGapSamplesHasDbgapConnection;
-  smileDbGapId: Scalars["String"];
+  smileDbGapId: Scalars["String"]["output"];
 };
 
 export type DbGapSamplesHasDbgapArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type DbGapSamplesHasDbgapAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type DbGapSamplesHasDbgapConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<DbGapSamplesHasDbgapConnectionSort>>;
   where?: InputMaybe<DbGapSamplesHasDbgapConnectionWhere>;
 };
 
 export type DbGapAggregateSelection = {
   __typename?: "DbGapAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   dbGapStudy: StringAggregateSelection;
   smileDbGapId: StringAggregateSelection;
 };
@@ -1704,9 +1792,9 @@ export type DbGapConnectWhere = {
 };
 
 export type DbGapCreateInput = {
-  dbGapStudy: Scalars["String"];
+  dbGapStudy: Scalars["String"]["input"];
   samplesHasDbgap?: InputMaybe<DbGapSamplesHasDbgapFieldInput>;
-  smileDbGapId: Scalars["String"];
+  smileDbGapId: Scalars["String"]["input"];
 };
 
 export type DbGapDeleteInput = {
@@ -1719,13 +1807,13 @@ export type DbGapDisconnectInput = {
 
 export type DbGapEdge = {
   __typename?: "DbGapEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: DbGap;
 };
 
 export type DbGapOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more DbGapSort objects to sort DbGaps by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<DbGapSort>>;
 };
@@ -1736,7 +1824,7 @@ export type DbGapRelationInput = {
 
 export type DbGapSampleSamplesHasDbgapAggregationSelection = {
   __typename?: "DbGapSampleSamplesHasDbgapAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<DbGapSampleSamplesHasDbgapNodeAggregateSelection>;
 };
 
@@ -1752,18 +1840,18 @@ export type DbGapSamplesHasDbgapAggregateInput = {
   AND?: InputMaybe<Array<DbGapSamplesHasDbgapAggregateInput>>;
   NOT?: InputMaybe<DbGapSamplesHasDbgapAggregateInput>;
   OR?: InputMaybe<Array<DbGapSamplesHasDbgapAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<DbGapSamplesHasDbgapNodeAggregationWhereInput>;
 };
 
 export type DbGapSamplesHasDbgapConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -1771,7 +1859,7 @@ export type DbGapSamplesHasDbgapConnection = {
   __typename?: "DbGapSamplesHasDbgapConnection";
   edges: Array<DbGapSamplesHasDbgapRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type DbGapSamplesHasDbgapConnectionSort = {
@@ -1808,71 +1896,71 @@ export type DbGapSamplesHasDbgapNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<DbGapSamplesHasDbgapNodeAggregationWhereInput>>;
   NOT?: InputMaybe<DbGapSamplesHasDbgapNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<DbGapSamplesHasDbgapNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type DbGapSamplesHasDbgapRelationship = {
   __typename?: "DbGapSamplesHasDbgapRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -1896,21 +1984,21 @@ export type DbGapSort = {
 };
 
 export type DbGapUpdateInput = {
-  dbGapStudy?: InputMaybe<Scalars["String"]>;
+  dbGapStudy?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasDbgap?: InputMaybe<Array<DbGapSamplesHasDbgapUpdateFieldInput>>;
-  smileDbGapId?: InputMaybe<Scalars["String"]>;
+  smileDbGapId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type DbGapWhere = {
   AND?: InputMaybe<Array<DbGapWhere>>;
   NOT?: InputMaybe<DbGapWhere>;
   OR?: InputMaybe<Array<DbGapWhere>>;
-  dbGapStudy?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dbGapStudy_MATCHES?: InputMaybe<Scalars["String"]>;
-  dbGapStudy_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  dbGapStudy?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dbGapStudy_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dbGapStudy_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasDbgapAggregate?: InputMaybe<DbGapSamplesHasDbgapAggregateInput>;
   /** Return DbGaps where all of the related DbGapSamplesHasDbgapConnections match this filter */
   samplesHasDbgapConnection_ALL?: InputMaybe<DbGapSamplesHasDbgapConnectionWhere>;
@@ -1928,70 +2016,70 @@ export type DbGapWhere = {
   samplesHasDbgap_SINGLE?: InputMaybe<SampleWhere>;
   /** Return DbGaps where some of the related Samples match this filter */
   samplesHasDbgap_SOME?: InputMaybe<SampleWhere>;
-  smileDbGapId?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileDbGapId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileDbGapId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smileDbGapId?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileDbGapId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileDbGapId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type DbGapsConnection = {
   __typename?: "DbGapsConnection";
   edges: Array<DbGapEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 /** Information about the number of nodes and relationships deleted during a delete mutation */
 export type DeleteInfo = {
   __typename?: "DeleteInfo";
   /** @deprecated This field has been deprecated because bookmarks are now handled by the driver. */
-  bookmark?: Maybe<Scalars["String"]>;
-  nodesDeleted: Scalars["Int"];
-  relationshipsDeleted: Scalars["Int"];
+  bookmark?: Maybe<Scalars["String"]["output"]>;
+  nodesDeleted: Scalars["Int"]["output"];
+  relationshipsDeleted: Scalars["Int"]["output"];
 };
 
 export type IgoQcReport = {
   __typename?: "IgoQcReport";
-  IGORecommendation?: Maybe<Scalars["String"]>;
-  comments?: Maybe<Scalars["String"]>;
-  investigatorDecision?: Maybe<Scalars["String"]>;
-  qcReportType?: Maybe<Scalars["String"]>;
+  IGORecommendation?: Maybe<Scalars["String"]["output"]>;
+  comments?: Maybe<Scalars["String"]["output"]>;
+  investigatorDecision?: Maybe<Scalars["String"]["output"]>;
+  qcReportType?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type MafComplete = {
   __typename?: "MafComplete";
-  date: Scalars["String"];
-  normalPrimaryId: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["output"];
+  normalPrimaryId: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
   temposHasEvent: Array<Tempo>;
   temposHasEventAggregate?: Maybe<MafCompleteTempoTemposHasEventAggregationSelection>;
   temposHasEventConnection: MafCompleteTemposHasEventConnection;
 };
 
 export type MafCompleteTemposHasEventArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type MafCompleteTemposHasEventAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type MafCompleteTemposHasEventConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<MafCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<MafCompleteTemposHasEventConnectionWhere>;
 };
 
 export type MafCompleteAggregateSelection = {
   __typename?: "MafCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   normalPrimaryId: StringAggregateSelection;
   status: StringAggregateSelection;
@@ -2008,9 +2096,9 @@ export type MafCompleteConnectWhere = {
 };
 
 export type MafCompleteCreateInput = {
-  date: Scalars["String"];
-  normalPrimaryId: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["input"];
+  normalPrimaryId: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
   temposHasEvent?: InputMaybe<MafCompleteTemposHasEventFieldInput>;
 };
 
@@ -2026,13 +2114,13 @@ export type MafCompleteDisconnectInput = {
 
 export type MafCompleteEdge = {
   __typename?: "MafCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: MafComplete;
 };
 
 export type MafCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more MafCompleteSort objects to sort MafCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<MafCompleteSort>>;
 };
@@ -2050,7 +2138,7 @@ export type MafCompleteSort = {
 
 export type MafCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "MafCompleteTempoTemposHasEventAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<MafCompleteTempoTemposHasEventNodeAggregateSelection>;
 };
 
@@ -2069,18 +2157,18 @@ export type MafCompleteTemposHasEventAggregateInput = {
   AND?: InputMaybe<Array<MafCompleteTemposHasEventAggregateInput>>;
   NOT?: InputMaybe<MafCompleteTemposHasEventAggregateInput>;
   OR?: InputMaybe<Array<MafCompleteTemposHasEventAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<MafCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type MafCompleteTemposHasEventConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -2088,7 +2176,7 @@ export type MafCompleteTemposHasEventConnection = {
   __typename?: "MafCompleteTemposHasEventConnection";
   edges: Array<MafCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type MafCompleteTemposHasEventConnectionSort = {
@@ -2125,116 +2213,164 @@ export type MafCompleteTemposHasEventNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<MafCompleteTemposHasEventNodeAggregationWhereInput>>;
   NOT?: InputMaybe<MafCompleteTemposHasEventNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<MafCompleteTemposHasEventNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type MafCompleteTemposHasEventRelationship = {
   __typename?: "MafCompleteTemposHasEventRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -2252,9 +2388,9 @@ export type MafCompleteTemposHasEventUpdateFieldInput = {
 };
 
 export type MafCompleteUpdateInput = {
-  date?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEvent?: InputMaybe<Array<MafCompleteTemposHasEventUpdateFieldInput>>;
 };
 
@@ -2262,24 +2398,24 @@ export type MafCompleteWhere = {
   AND?: InputMaybe<Array<MafCompleteWhere>>;
   NOT?: InputMaybe<MafCompleteWhere>;
   OR?: InputMaybe<Array<MafCompleteWhere>>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  normalPrimaryId_MATCHES?: InputMaybe<Scalars["String"]>;
-  normalPrimaryId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  normalPrimaryId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  normalPrimaryId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEventAggregate?: InputMaybe<MafCompleteTemposHasEventAggregateInput>;
   /** Return MafCompletes where all of the related MafCompleteTemposHasEventConnections match this filter */
   temposHasEventConnection_ALL?: InputMaybe<MafCompleteTemposHasEventConnectionWhere>;
@@ -2303,7 +2439,7 @@ export type MafCompletesConnection = {
   __typename?: "MafCompletesConnection";
   edges: Array<MafCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Mutation = {
@@ -2600,10 +2736,10 @@ export type MutationUpdateTemposArgs = {
 /** Pagination information (Relay) */
 export type PageInfo = {
   __typename?: "PageInfo";
-  endCursor?: Maybe<Scalars["String"]>;
-  hasNextPage: Scalars["Boolean"];
-  hasPreviousPage: Scalars["Boolean"];
-  startCursor?: Maybe<Scalars["String"]>;
+  endCursor?: Maybe<Scalars["String"]["output"]>;
+  hasNextPage: Scalars["Boolean"]["output"];
+  hasPreviousPage: Scalars["Boolean"]["output"];
+  startCursor?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type Patient = {
@@ -2614,50 +2750,50 @@ export type Patient = {
   patientAliasesIsAlias: Array<PatientAlias>;
   patientAliasesIsAliasAggregate?: Maybe<PatientPatientAliasPatientAliasesIsAliasAggregationSelection>;
   patientAliasesIsAliasConnection: PatientPatientAliasesIsAliasConnection;
-  smilePatientId: Scalars["String"];
+  smilePatientId: Scalars["String"]["output"];
 };
 
 export type PatientHasSampleSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type PatientHasSampleSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type PatientHasSampleSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<PatientHasSampleSamplesConnectionSort>>;
   where?: InputMaybe<PatientHasSampleSamplesConnectionWhere>;
 };
 
 export type PatientPatientAliasesIsAliasArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<PatientAliasOptions>;
   where?: InputMaybe<PatientAliasWhere>;
 };
 
 export type PatientPatientAliasesIsAliasAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PatientAliasWhere>;
 };
 
 export type PatientPatientAliasesIsAliasConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<PatientPatientAliasesIsAliasConnectionSort>>;
   where?: InputMaybe<PatientPatientAliasesIsAliasConnectionWhere>;
 };
 
 export type PatientAggregateSelection = {
   __typename?: "PatientAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   smilePatientId: StringAggregateSelection;
 };
 
@@ -2666,32 +2802,32 @@ export type PatientAlias = {
   isAliasPatients: Array<Patient>;
   isAliasPatientsAggregate?: Maybe<PatientAliasPatientIsAliasPatientsAggregationSelection>;
   isAliasPatientsConnection: PatientAliasIsAliasPatientsConnection;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["output"];
+  value: Scalars["String"]["output"];
 };
 
 export type PatientAliasIsAliasPatientsArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<PatientOptions>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type PatientAliasIsAliasPatientsAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type PatientAliasIsAliasPatientsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<PatientAliasIsAliasPatientsConnectionSort>>;
   where?: InputMaybe<PatientAliasIsAliasPatientsConnectionWhere>;
 };
 
 export type PatientAliasAggregateSelection = {
   __typename?: "PatientAliasAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   namespace: StringAggregateSelection;
   value: StringAggregateSelection;
 };
@@ -2708,8 +2844,8 @@ export type PatientAliasConnectWhere = {
 
 export type PatientAliasCreateInput = {
   isAliasPatients?: InputMaybe<PatientAliasIsAliasPatientsFieldInput>;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["input"];
+  value: Scalars["String"]["input"];
 };
 
 export type PatientAliasDeleteInput = {
@@ -2726,7 +2862,7 @@ export type PatientAliasDisconnectInput = {
 
 export type PatientAliasEdge = {
   __typename?: "PatientAliasEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: PatientAlias;
 };
 
@@ -2734,18 +2870,18 @@ export type PatientAliasIsAliasPatientsAggregateInput = {
   AND?: InputMaybe<Array<PatientAliasIsAliasPatientsAggregateInput>>;
   NOT?: InputMaybe<PatientAliasIsAliasPatientsAggregateInput>;
   OR?: InputMaybe<Array<PatientAliasIsAliasPatientsAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<PatientAliasIsAliasPatientsNodeAggregationWhereInput>;
 };
 
 export type PatientAliasIsAliasPatientsConnectFieldInput = {
   connect?: InputMaybe<Array<PatientConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<PatientConnectWhere>;
 };
 
@@ -2753,7 +2889,7 @@ export type PatientAliasIsAliasPatientsConnection = {
   __typename?: "PatientAliasIsAliasPatientsConnection";
   edges: Array<PatientAliasIsAliasPatientsRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientAliasIsAliasPatientsConnectionSort = {
@@ -2790,26 +2926,26 @@ export type PatientAliasIsAliasPatientsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<PatientAliasIsAliasPatientsNodeAggregationWhereInput>>;
   NOT?: InputMaybe<PatientAliasIsAliasPatientsNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<PatientAliasIsAliasPatientsNodeAggregationWhereInput>>;
-  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PatientAliasIsAliasPatientsRelationship = {
   __typename?: "PatientAliasIsAliasPatientsRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Patient;
 };
 
@@ -2829,15 +2965,15 @@ export type PatientAliasIsAliasPatientsUpdateFieldInput = {
 };
 
 export type PatientAliasOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more PatientAliasSort objects to sort PatientAliases by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<PatientAliasSort>>;
 };
 
 export type PatientAliasPatientIsAliasPatientsAggregationSelection = {
   __typename?: "PatientAliasPatientIsAliasPatientsAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<PatientAliasPatientIsAliasPatientsNodeAggregateSelection>;
 };
 
@@ -2862,8 +2998,8 @@ export type PatientAliasUpdateInput = {
   isAliasPatients?: InputMaybe<
     Array<PatientAliasIsAliasPatientsUpdateFieldInput>
   >;
-  namespace?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientAliasWhere = {
@@ -2887,25 +3023,25 @@ export type PatientAliasWhere = {
   isAliasPatients_SINGLE?: InputMaybe<PatientWhere>;
   /** Return PatientAliases where some of the related Patients match this filter */
   isAliasPatients_SOME?: InputMaybe<PatientWhere>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
-  value_CONTAINS?: InputMaybe<Scalars["String"]>;
-  value_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  value_IN?: InputMaybe<Array<Scalars["String"]>>;
-  value_MATCHES?: InputMaybe<Scalars["String"]>;
-  value_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
+  value_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  value_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  value_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  value_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientAliasesConnection = {
   __typename?: "PatientAliasesConnection";
   edges: Array<PatientAliasEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientConnectInput = {
@@ -2924,7 +3060,7 @@ export type PatientConnectWhere = {
 export type PatientCreateInput = {
   hasSampleSamples?: InputMaybe<PatientHasSampleSamplesFieldInput>;
   patientAliasesIsAlias?: InputMaybe<PatientPatientAliasesIsAliasFieldInput>;
-  smilePatientId: Scalars["String"];
+  smilePatientId: Scalars["String"]["input"];
 };
 
 export type PatientDeleteInput = {
@@ -2945,7 +3081,7 @@ export type PatientDisconnectInput = {
 
 export type PatientEdge = {
   __typename?: "PatientEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Patient;
 };
 
@@ -2953,18 +3089,18 @@ export type PatientHasSampleSamplesAggregateInput = {
   AND?: InputMaybe<Array<PatientHasSampleSamplesAggregateInput>>;
   NOT?: InputMaybe<PatientHasSampleSamplesAggregateInput>;
   OR?: InputMaybe<Array<PatientHasSampleSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<PatientHasSampleSamplesNodeAggregationWhereInput>;
 };
 
 export type PatientHasSampleSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -2972,7 +3108,7 @@ export type PatientHasSampleSamplesConnection = {
   __typename?: "PatientHasSampleSamplesConnection";
   edges: Array<PatientHasSampleSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientHasSampleSamplesConnectionSort = {
@@ -3009,71 +3145,71 @@ export type PatientHasSampleSamplesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<PatientHasSampleSamplesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<PatientHasSampleSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<PatientHasSampleSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PatientHasSampleSamplesRelationship = {
   __typename?: "PatientHasSampleSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -3092,22 +3228,22 @@ export type PatientHasSampleSamplesUpdateFieldInput = {
 
 export type PatientIdsTriplet = {
   __typename?: "PatientIdsTriplet";
-  CMO_PATIENT_ID: Scalars["String"];
-  DMP_PATIENT_ID?: Maybe<Scalars["String"]>;
-  MRN: Scalars["String"];
-  RACE?: Maybe<Scalars["String"]>;
+  CMO_PATIENT_ID: Scalars["String"]["output"];
+  DMP_PATIENT_ID?: Maybe<Scalars["String"]["output"]>;
+  MRN: Scalars["String"]["output"];
+  RACE?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type PatientOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more PatientSort objects to sort Patients by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<PatientSort>>;
 };
 
 export type PatientPatientAliasPatientAliasesIsAliasAggregationSelection = {
   __typename?: "PatientPatientAliasPatientAliasesIsAliasAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<PatientPatientAliasPatientAliasesIsAliasNodeAggregateSelection>;
 };
 
@@ -3121,18 +3257,18 @@ export type PatientPatientAliasesIsAliasAggregateInput = {
   AND?: InputMaybe<Array<PatientPatientAliasesIsAliasAggregateInput>>;
   NOT?: InputMaybe<PatientPatientAliasesIsAliasAggregateInput>;
   OR?: InputMaybe<Array<PatientPatientAliasesIsAliasAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<PatientPatientAliasesIsAliasNodeAggregationWhereInput>;
 };
 
 export type PatientPatientAliasesIsAliasConnectFieldInput = {
   connect?: InputMaybe<Array<PatientAliasConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<PatientAliasConnectWhere>;
 };
 
@@ -3140,7 +3276,7 @@ export type PatientPatientAliasesIsAliasConnection = {
   __typename?: "PatientPatientAliasesIsAliasConnection";
   edges: Array<PatientPatientAliasesIsAliasRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type PatientPatientAliasesIsAliasConnectionSort = {
@@ -3179,41 +3315,41 @@ export type PatientPatientAliasesIsAliasNodeAggregationWhereInput = {
   >;
   NOT?: InputMaybe<PatientPatientAliasesIsAliasNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<PatientPatientAliasesIsAliasNodeAggregationWhereInput>>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PatientPatientAliasesIsAliasRelationship = {
   __typename?: "PatientPatientAliasesIsAliasRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: PatientAlias;
 };
 
@@ -3241,7 +3377,7 @@ export type PatientRelationInput = {
 
 export type PatientSampleHasSampleSamplesAggregationSelection = {
   __typename?: "PatientSampleHasSampleSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<PatientSampleHasSampleSamplesNodeAggregateSelection>;
 };
 
@@ -3263,7 +3399,7 @@ export type PatientUpdateInput = {
   patientAliasesIsAlias?: InputMaybe<
     Array<PatientPatientAliasesIsAliasUpdateFieldInput>
   >;
-  smilePatientId?: InputMaybe<Scalars["String"]>;
+  smilePatientId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientWhere = {
@@ -3304,19 +3440,19 @@ export type PatientWhere = {
   patientAliasesIsAlias_SINGLE?: InputMaybe<PatientAliasWhere>;
   /** Return Patients where some of the related PatientAliases match this filter */
   patientAliasesIsAlias_SOME?: InputMaybe<PatientAliasWhere>;
-  smilePatientId?: InputMaybe<Scalars["String"]>;
-  smilePatientId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smilePatientId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smilePatientId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smilePatientId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smilePatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smilePatientId?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smilePatientId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smilePatientId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type PatientsConnection = {
   __typename?: "PatientsConnection";
   edges: Array<PatientEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Project = {
@@ -3324,32 +3460,32 @@ export type Project = {
   hasRequestRequests: Array<Request>;
   hasRequestRequestsAggregate?: Maybe<ProjectRequestHasRequestRequestsAggregationSelection>;
   hasRequestRequestsConnection: ProjectHasRequestRequestsConnection;
-  igoProjectId: Scalars["String"];
-  namespace: Scalars["String"];
+  igoProjectId: Scalars["String"]["output"];
+  namespace: Scalars["String"]["output"];
 };
 
 export type ProjectHasRequestRequestsArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type ProjectHasRequestRequestsAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type ProjectHasRequestRequestsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<ProjectHasRequestRequestsConnectionSort>>;
   where?: InputMaybe<ProjectHasRequestRequestsConnectionWhere>;
 };
 
 export type ProjectAggregateSelection = {
   __typename?: "ProjectAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   igoProjectId: StringAggregateSelection;
   namespace: StringAggregateSelection;
 };
@@ -3366,8 +3502,8 @@ export type ProjectConnectWhere = {
 
 export type ProjectCreateInput = {
   hasRequestRequests?: InputMaybe<ProjectHasRequestRequestsFieldInput>;
-  igoProjectId: Scalars["String"];
-  namespace: Scalars["String"];
+  igoProjectId: Scalars["String"]["input"];
+  namespace: Scalars["String"]["input"];
 };
 
 export type ProjectDeleteInput = {
@@ -3384,7 +3520,7 @@ export type ProjectDisconnectInput = {
 
 export type ProjectEdge = {
   __typename?: "ProjectEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Project;
 };
 
@@ -3392,18 +3528,18 @@ export type ProjectHasRequestRequestsAggregateInput = {
   AND?: InputMaybe<Array<ProjectHasRequestRequestsAggregateInput>>;
   NOT?: InputMaybe<ProjectHasRequestRequestsAggregateInput>;
   OR?: InputMaybe<Array<ProjectHasRequestRequestsAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<ProjectHasRequestRequestsNodeAggregationWhereInput>;
 };
 
 export type ProjectHasRequestRequestsConnectFieldInput = {
   connect?: InputMaybe<Array<RequestConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestConnectWhere>;
 };
 
@@ -3411,7 +3547,7 @@ export type ProjectHasRequestRequestsConnection = {
   __typename?: "ProjectHasRequestRequestsConnection";
   edges: Array<ProjectHasRequestRequestsRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type ProjectHasRequestRequestsConnectionSort = {
@@ -3448,331 +3584,341 @@ export type ProjectHasRequestRequestsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<ProjectHasRequestRequestsNodeAggregationWhereInput>>;
   NOT?: InputMaybe<ProjectHasRequestRequestsNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<ProjectHasRequestRequestsNodeAggregationWhereInput>>;
-  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type ProjectHasRequestRequestsRelationship = {
   __typename?: "ProjectHasRequestRequestsRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -3790,8 +3936,8 @@ export type ProjectHasRequestRequestsUpdateFieldInput = {
 };
 
 export type ProjectOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more ProjectSort objects to sort Projects by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<ProjectSort>>;
 };
@@ -3804,7 +3950,7 @@ export type ProjectRelationInput = {
 
 export type ProjectRequestHasRequestRequestsAggregationSelection = {
   __typename?: "ProjectRequestHasRequestRequestsAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<ProjectRequestHasRequestRequestsNodeAggregateSelection>;
 };
 
@@ -3843,8 +3989,8 @@ export type ProjectUpdateInput = {
   hasRequestRequests?: InputMaybe<
     Array<ProjectHasRequestRequestsUpdateFieldInput>
   >;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type ProjectWhere = {
@@ -3868,60 +4014,60 @@ export type ProjectWhere = {
   hasRequestRequests_SINGLE?: InputMaybe<RequestWhere>;
   /** Return Projects where some of the related Requests match this filter */
   hasRequestRequests_SOME?: InputMaybe<RequestWhere>;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type ProjectsConnection = {
   __typename?: "ProjectsConnection";
   edges: Array<ProjectEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type QcComplete = {
   __typename?: "QcComplete";
-  date: Scalars["String"];
-  reason: Scalars["String"];
-  result: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["output"];
+  reason: Scalars["String"]["output"];
+  result: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
   temposHasEvent: Array<Tempo>;
   temposHasEventAggregate?: Maybe<QcCompleteTempoTemposHasEventAggregationSelection>;
   temposHasEventConnection: QcCompleteTemposHasEventConnection;
 };
 
 export type QcCompleteTemposHasEventArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type QcCompleteTemposHasEventAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type QcCompleteTemposHasEventConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<QcCompleteTemposHasEventConnectionSort>>;
   where?: InputMaybe<QcCompleteTemposHasEventConnectionWhere>;
 };
 
 export type QcCompleteAggregateSelection = {
   __typename?: "QcCompleteAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   date: StringAggregateSelection;
   reason: StringAggregateSelection;
   result: StringAggregateSelection;
@@ -3937,10 +4083,10 @@ export type QcCompleteConnectWhere = {
 };
 
 export type QcCompleteCreateInput = {
-  date: Scalars["String"];
-  reason: Scalars["String"];
-  result: Scalars["String"];
-  status: Scalars["String"];
+  date: Scalars["String"]["input"];
+  reason: Scalars["String"]["input"];
+  result: Scalars["String"]["input"];
+  status: Scalars["String"]["input"];
   temposHasEvent?: InputMaybe<QcCompleteTemposHasEventFieldInput>;
 };
 
@@ -3956,13 +4102,13 @@ export type QcCompleteDisconnectInput = {
 
 export type QcCompleteEdge = {
   __typename?: "QcCompleteEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: QcComplete;
 };
 
 export type QcCompleteOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more QcCompleteSort objects to sort QcCompletes by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<QcCompleteSort>>;
 };
@@ -3981,7 +4127,7 @@ export type QcCompleteSort = {
 
 export type QcCompleteTempoTemposHasEventAggregationSelection = {
   __typename?: "QcCompleteTempoTemposHasEventAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<QcCompleteTempoTemposHasEventNodeAggregateSelection>;
 };
 
@@ -4000,18 +4146,18 @@ export type QcCompleteTemposHasEventAggregateInput = {
   AND?: InputMaybe<Array<QcCompleteTemposHasEventAggregateInput>>;
   NOT?: InputMaybe<QcCompleteTemposHasEventAggregateInput>;
   OR?: InputMaybe<Array<QcCompleteTemposHasEventAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<QcCompleteTemposHasEventNodeAggregationWhereInput>;
 };
 
 export type QcCompleteTemposHasEventConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -4019,7 +4165,7 @@ export type QcCompleteTemposHasEventConnection = {
   __typename?: "QcCompleteTemposHasEventConnection";
   edges: Array<QcCompleteTemposHasEventRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type QcCompleteTemposHasEventConnectionSort = {
@@ -4056,116 +4202,164 @@ export type QcCompleteTemposHasEventNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<QcCompleteTemposHasEventNodeAggregationWhereInput>>;
   NOT?: InputMaybe<QcCompleteTemposHasEventNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<QcCompleteTemposHasEventNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QcCompleteTemposHasEventRelationship = {
   __typename?: "QcCompleteTemposHasEventRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -4183,10 +4377,10 @@ export type QcCompleteTemposHasEventUpdateFieldInput = {
 };
 
 export type QcCompleteUpdateInput = {
-  date?: InputMaybe<Scalars["String"]>;
-  reason?: InputMaybe<Scalars["String"]>;
-  result?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  reason?: InputMaybe<Scalars["String"]["input"]>;
+  result?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEvent?: InputMaybe<Array<QcCompleteTemposHasEventUpdateFieldInput>>;
 };
 
@@ -4194,30 +4388,30 @@ export type QcCompleteWhere = {
   AND?: InputMaybe<Array<QcCompleteWhere>>;
   NOT?: InputMaybe<QcCompleteWhere>;
   OR?: InputMaybe<Array<QcCompleteWhere>>;
-  date?: InputMaybe<Scalars["String"]>;
-  date_CONTAINS?: InputMaybe<Scalars["String"]>;
-  date_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  date_IN?: InputMaybe<Array<Scalars["String"]>>;
-  date_MATCHES?: InputMaybe<Scalars["String"]>;
-  date_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  reason?: InputMaybe<Scalars["String"]>;
-  reason_CONTAINS?: InputMaybe<Scalars["String"]>;
-  reason_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  reason_IN?: InputMaybe<Array<Scalars["String"]>>;
-  reason_MATCHES?: InputMaybe<Scalars["String"]>;
-  reason_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  result?: InputMaybe<Scalars["String"]>;
-  result_CONTAINS?: InputMaybe<Scalars["String"]>;
-  result_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  result_IN?: InputMaybe<Array<Scalars["String"]>>;
-  result_MATCHES?: InputMaybe<Scalars["String"]>;
-  result_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  status?: InputMaybe<Scalars["String"]>;
-  status_CONTAINS?: InputMaybe<Scalars["String"]>;
-  status_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  status_IN?: InputMaybe<Array<Scalars["String"]>>;
-  status_MATCHES?: InputMaybe<Scalars["String"]>;
-  status_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  date?: InputMaybe<Scalars["String"]["input"]>;
+  date_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  date_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  date_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  date_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  date_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  reason?: InputMaybe<Scalars["String"]["input"]>;
+  reason_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  reason_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  reason_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  reason_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  reason_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  result?: InputMaybe<Scalars["String"]["input"]>;
+  result_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  result_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  result_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  result_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  result_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  status_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  status_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  status_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  status_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  status_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   temposHasEventAggregate?: InputMaybe<QcCompleteTemposHasEventAggregateInput>;
   /** Return QcCompletes where all of the related QcCompleteTemposHasEventConnections match this filter */
   temposHasEventConnection_ALL?: InputMaybe<QcCompleteTemposHasEventConnectionWhere>;
@@ -4241,13 +4435,13 @@ export type QcCompletesConnection = {
   __typename?: "QcCompletesConnection";
   edges: Array<QcCompleteEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Query = {
   __typename?: "Query";
   allAnchorSeqDateData: Array<AnchorSeqDateData>;
-  allBlockedCohortIds: Array<Scalars["String"]>;
+  allBlockedCohortIds: Array<Scalars["String"]["output"]>;
   bamCompletes: Array<BamComplete>;
   bamCompletesAggregate: BamCompleteAggregateSelection;
   bamCompletesConnection: BamCompletesConnection;
@@ -4304,7 +4498,7 @@ export type Query = {
 };
 
 export type QueryAllAnchorSeqDateDataArgs = {
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type QueryBamCompletesArgs = {
@@ -4317,8 +4511,8 @@ export type QueryBamCompletesAggregateArgs = {
 };
 
 export type QueryBamCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<BamCompleteSort>>>;
   where?: InputMaybe<BamCompleteWhere>;
 };
@@ -4333,8 +4527,8 @@ export type QueryCohortCompletesAggregateArgs = {
 };
 
 export type QueryCohortCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<CohortCompleteSort>>>;
   where?: InputMaybe<CohortCompleteWhere>;
 };
@@ -4349,52 +4543,52 @@ export type QueryCohortsAggregateArgs = {
 };
 
 export type QueryCohortsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<CohortSort>>>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type QueryDashboardCohortsArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardPatientsArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardRequestsArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardSampleHistoryArgs = {
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  searchVals: Array<Scalars["String"]>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  searchVals: Array<Scalars["String"]["input"]>;
   sort: DashboardRecordSort;
 };
 
 export type QueryDashboardSamplesArgs = {
   columnFilters?: InputMaybe<Array<DashboardRecordColumnFilter>>;
-  includeDemographics: Scalars["Boolean"];
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  includeDemographics: Scalars["Boolean"]["input"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   recordContexts?: InputMaybe<Array<InputMaybe<DashboardRecordContext>>>;
-  searchVals?: InputMaybe<Array<Scalars["String"]>>;
+  searchVals?: InputMaybe<Array<Scalars["String"]["input"]>>;
   sort: DashboardRecordSort;
 };
 
@@ -4408,8 +4602,8 @@ export type QueryDbGapsAggregateArgs = {
 };
 
 export type QueryDbGapsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<DbGapSort>>>;
   where?: InputMaybe<DbGapWhere>;
 };
@@ -4424,8 +4618,8 @@ export type QueryMafCompletesAggregateArgs = {
 };
 
 export type QueryMafCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<MafCompleteSort>>>;
   where?: InputMaybe<MafCompleteWhere>;
 };
@@ -4440,8 +4634,8 @@ export type QueryPatientAliasesAggregateArgs = {
 };
 
 export type QueryPatientAliasesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<PatientAliasSort>>>;
   where?: InputMaybe<PatientAliasWhere>;
 };
@@ -4456,8 +4650,8 @@ export type QueryPatientsAggregateArgs = {
 };
 
 export type QueryPatientsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<PatientSort>>>;
   where?: InputMaybe<PatientWhere>;
 };
@@ -4472,8 +4666,8 @@ export type QueryProjectsAggregateArgs = {
 };
 
 export type QueryProjectsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<ProjectSort>>>;
   where?: InputMaybe<ProjectWhere>;
 };
@@ -4488,8 +4682,8 @@ export type QueryQcCompletesAggregateArgs = {
 };
 
 export type QueryQcCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<QcCompleteSort>>>;
   where?: InputMaybe<QcCompleteWhere>;
 };
@@ -4504,8 +4698,8 @@ export type QueryRequestMetadataAggregateArgs = {
 };
 
 export type QueryRequestMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<RequestMetadataSort>>>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
@@ -4520,8 +4714,8 @@ export type QueryRequestsAggregateArgs = {
 };
 
 export type QueryRequestsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<RequestSort>>>;
   where?: InputMaybe<RequestWhere>;
 };
@@ -4536,8 +4730,8 @@ export type QuerySampleAliasesAggregateArgs = {
 };
 
 export type QuerySampleAliasesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<SampleAliasSort>>>;
   where?: InputMaybe<SampleAliasWhere>;
 };
@@ -4552,8 +4746,8 @@ export type QuerySampleMetadataAggregateArgs = {
 };
 
 export type QuerySampleMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<SampleMetadataSort>>>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
@@ -4568,8 +4762,8 @@ export type QuerySamplesAggregateArgs = {
 };
 
 export type QuerySamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<SampleSort>>>;
   where?: InputMaybe<SampleWhere>;
 };
@@ -4584,8 +4778,8 @@ export type QueryStatusesAggregateArgs = {
 };
 
 export type QueryStatusesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<StatusSort>>>;
   where?: InputMaybe<StatusWhere>;
 };
@@ -4600,109 +4794,109 @@ export type QueryTemposAggregateArgs = {
 };
 
 export type QueryTemposConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<TempoSort>>>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type Request = {
   __typename?: "Request";
-  bicAnalysis: Scalars["Boolean"];
-  dataAccessEmails: Scalars["String"];
-  dataAnalystEmail: Scalars["String"];
-  dataAnalystName: Scalars["String"];
-  genePanel: Scalars["String"];
+  bicAnalysis: Scalars["Boolean"]["output"];
+  dataAccessEmails: Scalars["String"]["output"];
+  dataAnalystEmail: Scalars["String"]["output"];
+  dataAnalystName: Scalars["String"]["output"];
+  genePanel: Scalars["String"]["output"];
   hasMetadataRequestMetadata: Array<RequestMetadata>;
   hasMetadataRequestMetadataAggregate?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection>;
   hasMetadataRequestMetadataConnection: RequestHasMetadataRequestMetadataConnection;
   hasSampleSamples: Array<Sample>;
   hasSampleSamplesAggregate?: Maybe<RequestSampleHasSampleSamplesAggregationSelection>;
   hasSampleSamplesConnection: RequestHasSampleSamplesConnection;
-  igoDeliveryDate?: Maybe<Scalars["BigInt"]>;
-  igoProjectId: Scalars["String"];
-  igoRequestId: Scalars["String"];
-  ilabRequestId?: Maybe<Scalars["String"]>;
-  investigatorEmail: Scalars["String"];
-  investigatorName: Scalars["String"];
-  isCmoRequest: Scalars["Boolean"];
-  labHeadEmail: Scalars["String"];
-  labHeadName: Scalars["String"];
-  libraryType?: Maybe<Scalars["String"]>;
-  namespace: Scalars["String"];
-  otherContactEmails: Scalars["String"];
-  piEmail: Scalars["String"];
-  pooledNormals?: Maybe<Array<Maybe<Scalars["String"]>>>;
-  projectManagerName: Scalars["String"];
+  igoDeliveryDate?: Maybe<Scalars["BigInt"]["output"]>;
+  igoProjectId: Scalars["String"]["output"];
+  igoRequestId: Scalars["String"]["output"];
+  ilabRequestId?: Maybe<Scalars["String"]["output"]>;
+  investigatorEmail: Scalars["String"]["output"];
+  investigatorName: Scalars["String"]["output"];
+  isCmoRequest: Scalars["Boolean"]["output"];
+  labHeadEmail: Scalars["String"]["output"];
+  labHeadName: Scalars["String"]["output"];
+  libraryType?: Maybe<Scalars["String"]["output"]>;
+  namespace: Scalars["String"]["output"];
+  otherContactEmails: Scalars["String"]["output"];
+  piEmail: Scalars["String"]["output"];
+  pooledNormals?: Maybe<Array<Maybe<Scalars["String"]["output"]>>>;
+  projectManagerName: Scalars["String"]["output"];
   projectsHasRequest: Array<Project>;
   projectsHasRequestAggregate?: Maybe<RequestProjectProjectsHasRequestAggregationSelection>;
   projectsHasRequestConnection: RequestProjectsHasRequestConnection;
-  qcAccessEmails: Scalars["String"];
-  requestJson: Scalars["String"];
-  smileRequestId: Scalars["String"];
-  strand?: Maybe<Scalars["String"]>;
+  qcAccessEmails: Scalars["String"]["output"];
+  requestJson: Scalars["String"]["output"];
+  smileRequestId: Scalars["String"]["output"];
+  strand?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type RequestHasMetadataRequestMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestMetadataOptions>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type RequestHasMetadataRequestMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type RequestHasMetadataRequestMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestHasMetadataRequestMetadataConnectionSort>>;
   where?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
 };
 
 export type RequestHasSampleSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type RequestHasSampleSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type RequestHasSampleSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestHasSampleSamplesConnectionSort>>;
   where?: InputMaybe<RequestHasSampleSamplesConnectionWhere>;
 };
 
 export type RequestProjectsHasRequestArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<ProjectOptions>;
   where?: InputMaybe<ProjectWhere>;
 };
 
 export type RequestProjectsHasRequestAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ProjectWhere>;
 };
 
 export type RequestProjectsHasRequestConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestProjectsHasRequestConnectionSort>>;
   where?: InputMaybe<RequestProjectsHasRequestConnectionWhere>;
 };
 
 export type RequestAggregateSelection = {
   __typename?: "RequestAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   dataAccessEmails: StringAggregateSelection;
   dataAnalystEmail: StringAggregateSelection;
   dataAnalystName: StringAggregateSelection;
@@ -4743,33 +4937,33 @@ export type RequestConnectWhere = {
 };
 
 export type RequestCreateInput = {
-  bicAnalysis: Scalars["Boolean"];
-  dataAccessEmails: Scalars["String"];
-  dataAnalystEmail: Scalars["String"];
-  dataAnalystName: Scalars["String"];
-  genePanel: Scalars["String"];
+  bicAnalysis: Scalars["Boolean"]["input"];
+  dataAccessEmails: Scalars["String"]["input"];
+  dataAnalystEmail: Scalars["String"]["input"];
+  dataAnalystName: Scalars["String"]["input"];
+  genePanel: Scalars["String"]["input"];
   hasMetadataRequestMetadata?: InputMaybe<RequestHasMetadataRequestMetadataFieldInput>;
   hasSampleSamples?: InputMaybe<RequestHasSampleSamplesFieldInput>;
-  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId: Scalars["String"];
-  igoRequestId: Scalars["String"];
-  ilabRequestId?: InputMaybe<Scalars["String"]>;
-  investigatorEmail: Scalars["String"];
-  investigatorName: Scalars["String"];
-  isCmoRequest: Scalars["Boolean"];
-  labHeadEmail: Scalars["String"];
-  labHeadName: Scalars["String"];
-  libraryType?: InputMaybe<Scalars["String"]>;
-  namespace: Scalars["String"];
-  otherContactEmails: Scalars["String"];
-  piEmail: Scalars["String"];
-  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  projectManagerName: Scalars["String"];
+  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId: Scalars["String"]["input"];
+  igoRequestId: Scalars["String"]["input"];
+  ilabRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail: Scalars["String"]["input"];
+  investigatorName: Scalars["String"]["input"];
+  isCmoRequest: Scalars["Boolean"]["input"];
+  labHeadEmail: Scalars["String"]["input"];
+  labHeadName: Scalars["String"]["input"];
+  libraryType?: InputMaybe<Scalars["String"]["input"]>;
+  namespace: Scalars["String"]["input"];
+  otherContactEmails: Scalars["String"]["input"];
+  piEmail: Scalars["String"]["input"];
+  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  projectManagerName: Scalars["String"]["input"];
   projectsHasRequest?: InputMaybe<RequestProjectsHasRequestFieldInput>;
-  qcAccessEmails: Scalars["String"];
-  requestJson: Scalars["String"];
-  smileRequestId: Scalars["String"];
-  strand?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails: Scalars["String"]["input"];
+  requestJson: Scalars["String"]["input"];
+  smileRequestId: Scalars["String"]["input"];
+  strand?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RequestDeleteInput = {
@@ -4796,7 +4990,7 @@ export type RequestDisconnectInput = {
 
 export type RequestEdge = {
   __typename?: "RequestEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -4804,18 +4998,18 @@ export type RequestHasMetadataRequestMetadataAggregateInput = {
   AND?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
   NOT?: InputMaybe<RequestHasMetadataRequestMetadataAggregateInput>;
   OR?: InputMaybe<Array<RequestHasMetadataRequestMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>;
 };
 
 export type RequestHasMetadataRequestMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<RequestMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestMetadataConnectWhere>;
 };
 
@@ -4823,7 +5017,7 @@ export type RequestHasMetadataRequestMetadataConnection = {
   __typename?: "RequestHasMetadataRequestMetadataConnection";
   edges: Array<RequestHasMetadataRequestMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestHasMetadataRequestMetadataConnectionSort = {
@@ -4866,61 +5060,71 @@ export type RequestHasMetadataRequestMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<RequestHasMetadataRequestMetadataNodeAggregationWhereInput>
   >;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestHasMetadataRequestMetadataRelationship = {
   __typename?: "RequestHasMetadataRequestMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: RequestMetadata;
 };
 
@@ -4945,18 +5149,18 @@ export type RequestHasSampleSamplesAggregateInput = {
   AND?: InputMaybe<Array<RequestHasSampleSamplesAggregateInput>>;
   NOT?: InputMaybe<RequestHasSampleSamplesAggregateInput>;
   OR?: InputMaybe<Array<RequestHasSampleSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestHasSampleSamplesNodeAggregationWhereInput>;
 };
 
 export type RequestHasSampleSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -4964,7 +5168,7 @@ export type RequestHasSampleSamplesConnection = {
   __typename?: "RequestHasSampleSamplesConnection";
   edges: Array<RequestHasSampleSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestHasSampleSamplesConnectionSort = {
@@ -5001,71 +5205,71 @@ export type RequestHasSampleSamplesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<RequestHasSampleSamplesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<RequestHasSampleSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<RequestHasSampleSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestHasSampleSamplesRelationship = {
   __typename?: "RequestHasSampleSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -5087,55 +5291,55 @@ export type RequestMetadata = {
   hasStatusStatuses: Array<Status>;
   hasStatusStatusesAggregate?: Maybe<RequestMetadataStatusHasStatusStatusesAggregationSelection>;
   hasStatusStatusesConnection: RequestMetadataHasStatusStatusesConnection;
-  igoRequestId: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  requestMetadataJson: Scalars["String"];
+  igoRequestId: Scalars["String"]["output"];
+  importDate: Scalars["BigInt"]["output"];
+  requestMetadataJson: Scalars["String"]["output"];
   requestsHasMetadata: Array<Request>;
   requestsHasMetadataAggregate?: Maybe<RequestMetadataRequestRequestsHasMetadataAggregationSelection>;
   requestsHasMetadataConnection: RequestMetadataRequestsHasMetadataConnection;
 };
 
 export type RequestMetadataHasStatusStatusesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<StatusOptions>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type RequestMetadataHasStatusStatusesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type RequestMetadataHasStatusStatusesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestMetadataHasStatusStatusesConnectionSort>>;
   where?: InputMaybe<RequestMetadataHasStatusStatusesConnectionWhere>;
 };
 
 export type RequestMetadataRequestsHasMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type RequestMetadataRequestsHasMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type RequestMetadataRequestsHasMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<RequestMetadataRequestsHasMetadataConnectionSort>>;
   where?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
 };
 
 export type RequestMetadataAggregateSelection = {
   __typename?: "RequestMetadataAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   igoRequestId: StringAggregateSelection;
   importDate: BigIntAggregateSelection;
   requestMetadataJson: StringAggregateSelection;
@@ -5158,14 +5362,14 @@ export type RequestMetadataConnection = {
   __typename?: "RequestMetadataConnection";
   edges: Array<RequestMetadataEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestMetadataCreateInput = {
   hasStatusStatuses?: InputMaybe<RequestMetadataHasStatusStatusesFieldInput>;
-  igoRequestId: Scalars["String"];
-  importDate: Scalars["BigInt"];
-  requestMetadataJson: Scalars["String"];
+  igoRequestId: Scalars["String"]["input"];
+  importDate: Scalars["BigInt"]["input"];
+  requestMetadataJson: Scalars["String"]["input"];
   requestsHasMetadata?: InputMaybe<RequestMetadataRequestsHasMetadataFieldInput>;
 };
 
@@ -5189,7 +5393,7 @@ export type RequestMetadataDisconnectInput = {
 
 export type RequestMetadataEdge = {
   __typename?: "RequestMetadataEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: RequestMetadata;
 };
 
@@ -5197,18 +5401,18 @@ export type RequestMetadataHasStatusStatusesAggregateInput = {
   AND?: InputMaybe<Array<RequestMetadataHasStatusStatusesAggregateInput>>;
   NOT?: InputMaybe<RequestMetadataHasStatusStatusesAggregateInput>;
   OR?: InputMaybe<Array<RequestMetadataHasStatusStatusesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestMetadataHasStatusStatusesNodeAggregationWhereInput>;
 };
 
 export type RequestMetadataHasStatusStatusesConnectFieldInput = {
   connect?: InputMaybe<Array<StatusConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<StatusConnectWhere>;
 };
 
@@ -5216,7 +5420,7 @@ export type RequestMetadataHasStatusStatusesConnection = {
   __typename?: "RequestMetadataHasStatusStatusesConnection";
   edges: Array<RequestMetadataHasStatusStatusesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestMetadataHasStatusStatusesConnectionSort = {
@@ -5259,26 +5463,26 @@ export type RequestMetadataHasStatusStatusesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesNodeAggregationWhereInput>
   >;
-  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestMetadataHasStatusStatusesRelationship = {
   __typename?: "RequestMetadataHasStatusStatusesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Status;
 };
 
@@ -5300,8 +5504,8 @@ export type RequestMetadataHasStatusStatusesUpdateFieldInput = {
 };
 
 export type RequestMetadataOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more RequestMetadataSort objects to sort RequestMetadata by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<RequestMetadataSort>>;
 };
@@ -5317,7 +5521,7 @@ export type RequestMetadataRelationInput = {
 
 export type RequestMetadataRequestRequestsHasMetadataAggregationSelection = {
   __typename?: "RequestMetadataRequestRequestsHasMetadataAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection>;
 };
 
@@ -5350,18 +5554,18 @@ export type RequestMetadataRequestsHasMetadataAggregateInput = {
   AND?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
   NOT?: InputMaybe<RequestMetadataRequestsHasMetadataAggregateInput>;
   OR?: InputMaybe<Array<RequestMetadataRequestsHasMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>;
 };
 
 export type RequestMetadataRequestsHasMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<RequestConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestConnectWhere>;
 };
 
@@ -5369,7 +5573,7 @@ export type RequestMetadataRequestsHasMetadataConnection = {
   __typename?: "RequestMetadataRequestsHasMetadataConnection";
   edges: Array<RequestMetadataRequestsHasMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestMetadataRequestsHasMetadataConnectionSort = {
@@ -5414,331 +5618,341 @@ export type RequestMetadataRequestsHasMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<RequestMetadataRequestsHasMetadataNodeAggregationWhereInput>
   >;
-  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestMetadataRequestsHasMetadataRelationship = {
   __typename?: "RequestMetadataRequestsHasMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -5772,7 +5986,7 @@ export type RequestMetadataSort = {
 
 export type RequestMetadataStatusHasStatusStatusesAggregationSelection = {
   __typename?: "RequestMetadataStatusHasStatusStatusesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestMetadataStatusHasStatusStatusesNodeAggregateSelection>;
 };
 
@@ -5785,11 +5999,11 @@ export type RequestMetadataUpdateInput = {
   hasStatusStatuses?: InputMaybe<
     Array<RequestMetadataHasStatusStatusesUpdateFieldInput>
   >;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson?: InputMaybe<Scalars["String"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson?: InputMaybe<Scalars["String"]["input"]>;
   requestsHasMetadata?: InputMaybe<
     Array<RequestMetadataRequestsHasMetadataUpdateFieldInput>
   >;
@@ -5816,24 +6030,24 @@ export type RequestMetadataWhere = {
   hasStatusStatuses_SINGLE?: InputMaybe<StatusWhere>;
   /** Return RequestMetadata where some of the related Statuses match this filter */
   hasStatusStatuses_SOME?: InputMaybe<StatusWhere>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]>>;
-  importDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_CONTAINS?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_IN?: InputMaybe<Array<Scalars["String"]>>;
-  requestMetadataJson_MATCHES?: InputMaybe<Scalars["String"]>;
-  requestMetadataJson_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  importDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  requestMetadataJson_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  requestMetadataJson_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   requestsHasMetadataAggregate?: InputMaybe<RequestMetadataRequestsHasMetadataAggregateInput>;
   /** Return RequestMetadata where all of the related RequestMetadataRequestsHasMetadataConnections match this filter */
   requestsHasMetadataConnection_ALL?: InputMaybe<RequestMetadataRequestsHasMetadataConnectionWhere>;
@@ -5854,15 +6068,15 @@ export type RequestMetadataWhere = {
 };
 
 export type RequestOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more RequestSort objects to sort Requests by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<RequestSort>>;
 };
 
 export type RequestProjectProjectsHasRequestAggregationSelection = {
   __typename?: "RequestProjectProjectsHasRequestAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestProjectProjectsHasRequestNodeAggregateSelection>;
 };
 
@@ -5876,18 +6090,18 @@ export type RequestProjectsHasRequestAggregateInput = {
   AND?: InputMaybe<Array<RequestProjectsHasRequestAggregateInput>>;
   NOT?: InputMaybe<RequestProjectsHasRequestAggregateInput>;
   OR?: InputMaybe<Array<RequestProjectsHasRequestAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<RequestProjectsHasRequestNodeAggregationWhereInput>;
 };
 
 export type RequestProjectsHasRequestConnectFieldInput = {
   connect?: InputMaybe<Array<ProjectConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<ProjectConnectWhere>;
 };
 
@@ -5895,7 +6109,7 @@ export type RequestProjectsHasRequestConnection = {
   __typename?: "RequestProjectsHasRequestConnection";
   edges: Array<RequestProjectsHasRequestRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type RequestProjectsHasRequestConnectionSort = {
@@ -5932,41 +6146,41 @@ export type RequestProjectsHasRequestNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<RequestProjectsHasRequestNodeAggregationWhereInput>>;
   NOT?: InputMaybe<RequestProjectsHasRequestNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<RequestProjectsHasRequestNodeAggregationWhereInput>>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RequestProjectsHasRequestRelationship = {
   __typename?: "RequestProjectsHasRequestRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Project;
 };
 
@@ -5996,7 +6210,7 @@ export type RequestRelationInput = {
 export type RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection =
   {
     __typename?: "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection>;
   };
 
@@ -6010,7 +6224,7 @@ export type RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelecti
 
 export type RequestSampleHasSampleSamplesAggregationSelection = {
   __typename?: "RequestSampleHasSampleSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<RequestSampleHasSampleSamplesNodeAggregateSelection>;
 };
 
@@ -6050,72 +6264,74 @@ export type RequestSort = {
 };
 
 export type RequestUpdateInput = {
-  bicAnalysis?: InputMaybe<Scalars["Boolean"]>;
-  dataAccessEmails?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail?: InputMaybe<Scalars["String"]>;
-  dataAnalystName?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
+  bicAnalysis?: InputMaybe<Scalars["Boolean"]["input"]>;
+  dataAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
   hasMetadataRequestMetadata?: InputMaybe<
     Array<RequestHasMetadataRequestMetadataUpdateFieldInput>
   >;
   hasSampleSamples?: InputMaybe<Array<RequestHasSampleSamplesUpdateFieldInput>>;
-  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  ilabRequestId?: InputMaybe<Scalars["String"]>;
-  investigatorEmail?: InputMaybe<Scalars["String"]>;
-  investigatorName?: InputMaybe<Scalars["String"]>;
-  isCmoRequest?: InputMaybe<Scalars["Boolean"]>;
-  labHeadEmail?: InputMaybe<Scalars["String"]>;
-  labHeadName?: InputMaybe<Scalars["String"]>;
-  libraryType?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  otherContactEmails?: InputMaybe<Scalars["String"]>;
-  piEmail?: InputMaybe<Scalars["String"]>;
-  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pooledNormals_POP?: InputMaybe<Scalars["Int"]>;
-  pooledNormals_PUSH?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  projectManagerName?: InputMaybe<Scalars["String"]>;
+  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName?: InputMaybe<Scalars["String"]["input"]>;
+  isCmoRequest?: InputMaybe<Scalars["Boolean"]["input"]>;
+  labHeadEmail?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail?: InputMaybe<Scalars["String"]["input"]>;
+  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pooledNormals_POP?: InputMaybe<Scalars["Int"]["input"]>;
+  pooledNormals_PUSH?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  projectManagerName?: InputMaybe<Scalars["String"]["input"]>;
   projectsHasRequest?: InputMaybe<
     Array<RequestProjectsHasRequestUpdateFieldInput>
   >;
-  qcAccessEmails?: InputMaybe<Scalars["String"]>;
-  requestJson?: InputMaybe<Scalars["String"]>;
-  smileRequestId?: InputMaybe<Scalars["String"]>;
-  strand?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  strand?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RequestWhere = {
   AND?: InputMaybe<Array<RequestWhere>>;
   NOT?: InputMaybe<RequestWhere>;
   OR?: InputMaybe<Array<RequestWhere>>;
-  bicAnalysis?: InputMaybe<Scalars["Boolean"]>;
-  dataAccessEmails?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dataAccessEmails_MATCHES?: InputMaybe<Scalars["String"]>;
-  dataAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dataAnalystEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  dataAnalystEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystName?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  dataAnalystName_MATCHES?: InputMaybe<Scalars["String"]>;
-  dataAnalystName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
-  genePanel_CONTAINS?: InputMaybe<Scalars["String"]>;
-  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel_IN?: InputMaybe<Array<Scalars["String"]>>;
-  genePanel_MATCHES?: InputMaybe<Scalars["String"]>;
-  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  bicAnalysis?: InputMaybe<Scalars["Boolean"]["input"]>;
+  dataAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dataAccessEmails_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dataAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dataAnalystEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  dataAnalystName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  dataAnalystName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  genePanel_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasMetadataRequestMetadataAggregate?: InputMaybe<RequestHasMetadataRequestMetadataAggregateInput>;
   /** Return Requests where all of the related RequestHasMetadataRequestMetadataConnections match this filter */
   hasMetadataRequestMetadataConnection_ALL?: InputMaybe<RequestHasMetadataRequestMetadataConnectionWhere>;
@@ -6150,87 +6366,89 @@ export type RequestWhere = {
   hasSampleSamples_SINGLE?: InputMaybe<SampleWhere>;
   /** Return Requests where some of the related Samples match this filter */
   hasSampleSamples_SOME?: InputMaybe<SampleWhere>;
-  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_IN?: InputMaybe<Array<InputMaybe<Scalars["BigInt"]>>>;
-  igoDeliveryDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId?: InputMaybe<Scalars["String"]>;
-  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  ilabRequestId?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  ilabRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  ilabRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorEmail?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  investigatorEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  investigatorEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorName?: InputMaybe<Scalars["String"]>;
-  investigatorName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  investigatorName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  investigatorName_MATCHES?: InputMaybe<Scalars["String"]>;
-  investigatorName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  isCmoRequest?: InputMaybe<Scalars["Boolean"]>;
-  labHeadEmail?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  labHeadEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  labHeadEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  labHeadName?: InputMaybe<Scalars["String"]>;
-  labHeadName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  labHeadName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  labHeadName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  labHeadName_MATCHES?: InputMaybe<Scalars["String"]>;
-  labHeadName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  libraryType?: InputMaybe<Scalars["String"]>;
-  libraryType_CONTAINS?: InputMaybe<Scalars["String"]>;
-  libraryType_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  libraryType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  libraryType_MATCHES?: InputMaybe<Scalars["String"]>;
-  libraryType_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  otherContactEmails?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_CONTAINS?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_IN?: InputMaybe<Array<Scalars["String"]>>;
-  otherContactEmails_MATCHES?: InputMaybe<Scalars["String"]>;
-  otherContactEmails_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  piEmail?: InputMaybe<Scalars["String"]>;
-  piEmail_CONTAINS?: InputMaybe<Scalars["String"]>;
-  piEmail_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  piEmail_IN?: InputMaybe<Array<Scalars["String"]>>;
-  piEmail_MATCHES?: InputMaybe<Scalars["String"]>;
-  piEmail_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  pooledNormals_INCLUDES?: InputMaybe<Scalars["String"]>;
-  projectManagerName?: InputMaybe<Scalars["String"]>;
-  projectManagerName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  projectManagerName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  projectManagerName_IN?: InputMaybe<Array<Scalars["String"]>>;
-  projectManagerName_MATCHES?: InputMaybe<Scalars["String"]>;
-  projectManagerName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoDeliveryDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["BigInt"]["input"]>>
+  >;
+  igoDeliveryDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoProjectId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoProjectId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  ilabRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  ilabRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  investigatorEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  investigatorName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  isCmoRequest?: InputMaybe<Scalars["Boolean"]["input"]>;
+  labHeadEmail?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  labHeadEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  labHeadName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  labHeadName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  libraryType_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  libraryType_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  otherContactEmails_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  otherContactEmails_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  piEmail_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  piEmail_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  pooledNormals?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pooledNormals_INCLUDES?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  projectManagerName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  projectManagerName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   projectsHasRequestAggregate?: InputMaybe<RequestProjectsHasRequestAggregateInput>;
   /** Return Requests where all of the related RequestProjectsHasRequestConnections match this filter */
   projectsHasRequestConnection_ALL?: InputMaybe<RequestProjectsHasRequestConnectionWhere>;
@@ -6248,37 +6466,37 @@ export type RequestWhere = {
   projectsHasRequest_SINGLE?: InputMaybe<ProjectWhere>;
   /** Return Requests where some of the related Projects match this filter */
   projectsHasRequest_SOME?: InputMaybe<ProjectWhere>;
-  qcAccessEmails?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_IN?: InputMaybe<Array<Scalars["String"]>>;
-  qcAccessEmails_MATCHES?: InputMaybe<Scalars["String"]>;
-  qcAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  requestJson?: InputMaybe<Scalars["String"]>;
-  requestJson_CONTAINS?: InputMaybe<Scalars["String"]>;
-  requestJson_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  requestJson_IN?: InputMaybe<Array<Scalars["String"]>>;
-  requestJson_MATCHES?: InputMaybe<Scalars["String"]>;
-  requestJson_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  smileRequestId?: InputMaybe<Scalars["String"]>;
-  smileRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileRequestId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  strand?: InputMaybe<Scalars["String"]>;
-  strand_CONTAINS?: InputMaybe<Scalars["String"]>;
-  strand_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  strand_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  strand_MATCHES?: InputMaybe<Scalars["String"]>;
-  strand_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  qcAccessEmails?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  qcAccessEmails_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  qcAccessEmails_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  requestJson_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  requestJson_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  strand?: InputMaybe<Scalars["String"]["input"]>;
+  strand_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  strand_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  strand_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  strand_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  strand_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RequestsConnection = {
   __typename?: "RequestsConnection";
   edges: Array<RequestEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type Sample = {
@@ -6286,7 +6504,7 @@ export type Sample = {
   cohortsHasCohortSample: Array<Cohort>;
   cohortsHasCohortSampleAggregate?: Maybe<SampleCohortCohortsHasCohortSampleAggregationSelection>;
   cohortsHasCohortSampleConnection: SampleCohortsHasCohortSampleConnection;
-  datasource: Scalars["String"];
+  datasource: Scalars["String"]["output"];
   hasDbgapDbGaps: Array<DbGap>;
   hasDbgapDbGapsAggregate?: Maybe<SampleDbGapHasDbgapDbGapsAggregationSelection>;
   hasDbgapDbGapsConnection: SampleHasDbgapDbGapsConnection;
@@ -6302,151 +6520,151 @@ export type Sample = {
   requestsHasSample: Array<Request>;
   requestsHasSampleAggregate?: Maybe<SampleRequestRequestsHasSampleAggregationSelection>;
   requestsHasSampleConnection: SampleRequestsHasSampleConnection;
-  revisable?: Maybe<Scalars["Boolean"]>;
+  revisable?: Maybe<Scalars["Boolean"]["output"]>;
   sampleAliasesIsAlias: Array<SampleAlias>;
   sampleAliasesIsAliasAggregate?: Maybe<SampleSampleAliasSampleAliasesIsAliasAggregationSelection>;
   sampleAliasesIsAliasConnection: SampleSampleAliasesIsAliasConnection;
-  sampleCategory: Scalars["String"];
-  sampleClass?: Maybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
+  sampleCategory: Scalars["String"]["output"];
+  sampleClass?: Maybe<Scalars["String"]["output"]>;
+  smileSampleId: Scalars["String"]["output"];
 };
 
 export type SampleCohortsHasCohortSampleArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<CohortOptions>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type SampleCohortsHasCohortSampleAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<CohortWhere>;
 };
 
 export type SampleCohortsHasCohortSampleConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleCohortsHasCohortSampleConnectionSort>>;
   where?: InputMaybe<SampleCohortsHasCohortSampleConnectionWhere>;
 };
 
 export type SampleHasDbgapDbGapsArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<DbGapOptions>;
   where?: InputMaybe<DbGapWhere>;
 };
 
 export type SampleHasDbgapDbGapsAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<DbGapWhere>;
 };
 
 export type SampleHasDbgapDbGapsConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleHasDbgapDbGapsConnectionSort>>;
   where?: InputMaybe<SampleHasDbgapDbGapsConnectionWhere>;
 };
 
 export type SampleHasMetadataSampleMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleMetadataOptions>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type SampleHasMetadataSampleMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type SampleHasMetadataSampleMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleHasMetadataSampleMetadataConnectionSort>>;
   where?: InputMaybe<SampleHasMetadataSampleMetadataConnectionWhere>;
 };
 
 export type SampleHasTempoTemposArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<TempoOptions>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type SampleHasTempoTemposAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<TempoWhere>;
 };
 
 export type SampleHasTempoTemposConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleHasTempoTemposConnectionSort>>;
   where?: InputMaybe<SampleHasTempoTemposConnectionWhere>;
 };
 
 export type SamplePatientsHasSampleArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<PatientOptions>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type SamplePatientsHasSampleAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PatientWhere>;
 };
 
 export type SamplePatientsHasSampleConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SamplePatientsHasSampleConnectionSort>>;
   where?: InputMaybe<SamplePatientsHasSampleConnectionWhere>;
 };
 
 export type SampleRequestsHasSampleArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestOptions>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type SampleRequestsHasSampleAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestWhere>;
 };
 
 export type SampleRequestsHasSampleConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleRequestsHasSampleConnectionSort>>;
   where?: InputMaybe<SampleRequestsHasSampleConnectionWhere>;
 };
 
 export type SampleSampleAliasesIsAliasArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleAliasOptions>;
   where?: InputMaybe<SampleAliasWhere>;
 };
 
 export type SampleSampleAliasesIsAliasAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleAliasWhere>;
 };
 
 export type SampleSampleAliasesIsAliasConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleSampleAliasesIsAliasConnectionSort>>;
   where?: InputMaybe<SampleSampleAliasesIsAliasConnectionWhere>;
 };
 
 export type SampleAggregateSelection = {
   __typename?: "SampleAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   datasource: StringAggregateSelection;
   sampleCategory: StringAggregateSelection;
   sampleClass: StringAggregateSelection;
@@ -6458,32 +6676,32 @@ export type SampleAlias = {
   isAliasSamples: Array<Sample>;
   isAliasSamplesAggregate?: Maybe<SampleAliasSampleIsAliasSamplesAggregationSelection>;
   isAliasSamplesConnection: SampleAliasIsAliasSamplesConnection;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["output"];
+  value: Scalars["String"]["output"];
 };
 
 export type SampleAliasIsAliasSamplesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleAliasIsAliasSamplesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleAliasIsAliasSamplesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleAliasIsAliasSamplesConnectionSort>>;
   where?: InputMaybe<SampleAliasIsAliasSamplesConnectionWhere>;
 };
 
 export type SampleAliasAggregateSelection = {
   __typename?: "SampleAliasAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   namespace: StringAggregateSelection;
   value: StringAggregateSelection;
 };
@@ -6500,8 +6718,8 @@ export type SampleAliasConnectWhere = {
 
 export type SampleAliasCreateInput = {
   isAliasSamples?: InputMaybe<SampleAliasIsAliasSamplesFieldInput>;
-  namespace: Scalars["String"];
-  value: Scalars["String"];
+  namespace: Scalars["String"]["input"];
+  value: Scalars["String"]["input"];
 };
 
 export type SampleAliasDeleteInput = {
@@ -6516,7 +6734,7 @@ export type SampleAliasDisconnectInput = {
 
 export type SampleAliasEdge = {
   __typename?: "SampleAliasEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleAlias;
 };
 
@@ -6524,18 +6742,18 @@ export type SampleAliasIsAliasSamplesAggregateInput = {
   AND?: InputMaybe<Array<SampleAliasIsAliasSamplesAggregateInput>>;
   NOT?: InputMaybe<SampleAliasIsAliasSamplesAggregateInput>;
   OR?: InputMaybe<Array<SampleAliasIsAliasSamplesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleAliasIsAliasSamplesNodeAggregationWhereInput>;
 };
 
 export type SampleAliasIsAliasSamplesConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -6543,7 +6761,7 @@ export type SampleAliasIsAliasSamplesConnection = {
   __typename?: "SampleAliasIsAliasSamplesConnection";
   edges: Array<SampleAliasIsAliasSamplesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleAliasIsAliasSamplesConnectionSort = {
@@ -6580,71 +6798,71 @@ export type SampleAliasIsAliasSamplesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleAliasIsAliasSamplesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleAliasIsAliasSamplesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleAliasIsAliasSamplesNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleAliasIsAliasSamplesRelationship = {
   __typename?: "SampleAliasIsAliasSamplesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -6662,8 +6880,8 @@ export type SampleAliasIsAliasSamplesUpdateFieldInput = {
 };
 
 export type SampleAliasOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more SampleAliasSort objects to sort SampleAliases by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<SampleAliasSort>>;
 };
@@ -6674,7 +6892,7 @@ export type SampleAliasRelationInput = {
 
 export type SampleAliasSampleIsAliasSamplesAggregationSelection = {
   __typename?: "SampleAliasSampleIsAliasSamplesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleAliasSampleIsAliasSamplesNodeAggregateSelection>;
 };
 
@@ -6694,8 +6912,8 @@ export type SampleAliasSort = {
 
 export type SampleAliasUpdateInput = {
   isAliasSamples?: InputMaybe<Array<SampleAliasIsAliasSamplesUpdateFieldInput>>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleAliasWhere = {
@@ -6719,54 +6937,55 @@ export type SampleAliasWhere = {
   isAliasSamples_SINGLE?: InputMaybe<SampleWhere>;
   /** Return SampleAliases where some of the related Samples match this filter */
   isAliasSamples_SOME?: InputMaybe<SampleWhere>;
-  namespace?: InputMaybe<Scalars["String"]>;
-  namespace_CONTAINS?: InputMaybe<Scalars["String"]>;
-  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  namespace_IN?: InputMaybe<Array<Scalars["String"]>>;
-  namespace_MATCHES?: InputMaybe<Scalars["String"]>;
-  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  value?: InputMaybe<Scalars["String"]>;
-  value_CONTAINS?: InputMaybe<Scalars["String"]>;
-  value_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  value_IN?: InputMaybe<Array<Scalars["String"]>>;
-  value_MATCHES?: InputMaybe<Scalars["String"]>;
-  value_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  namespace?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  namespace_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  namespace_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value?: InputMaybe<Scalars["String"]["input"]>;
+  value_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  value_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  value_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  value_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  value_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleAliasesConnection = {
   __typename?: "SampleAliasesConnection";
   edges: Array<SampleAliasEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleCohortCohortsHasCohortSampleAggregationSelection = {
   __typename?: "SampleCohortCohortsHasCohortSampleAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleCohortCohortsHasCohortSampleNodeAggregateSelection>;
 };
 
 export type SampleCohortCohortsHasCohortSampleNodeAggregateSelection = {
   __typename?: "SampleCohortCohortsHasCohortSampleNodeAggregateSelection";
   cohortId: StringAggregateSelection;
+  cohortStatus: StringAggregateSelection;
 };
 
 export type SampleCohortsHasCohortSampleAggregateInput = {
   AND?: InputMaybe<Array<SampleCohortsHasCohortSampleAggregateInput>>;
   NOT?: InputMaybe<SampleCohortsHasCohortSampleAggregateInput>;
   OR?: InputMaybe<Array<SampleCohortsHasCohortSampleAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleCohortsHasCohortSampleNodeAggregationWhereInput>;
 };
 
 export type SampleCohortsHasCohortSampleConnectFieldInput = {
   connect?: InputMaybe<Array<CohortConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<CohortConnectWhere>;
 };
 
@@ -6774,7 +6993,7 @@ export type SampleCohortsHasCohortSampleConnection = {
   __typename?: "SampleCohortsHasCohortSampleConnection";
   edges: Array<SampleCohortsHasCohortSampleRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleCohortsHasCohortSampleConnectionSort = {
@@ -6813,26 +7032,41 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
   >;
   NOT?: InputMaybe<SampleCohortsHasCohortSampleNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleCohortsHasCohortSampleNodeAggregationWhereInput>>;
-  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  cohortId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cohortStatus_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleCohortsHasCohortSampleRelationship = {
   __typename?: "SampleCohortsHasCohortSampleRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Cohort;
 };
 
@@ -6877,22 +7111,22 @@ export type SampleConnectWhere = {
 
 export type SampleCreateInput = {
   cohortsHasCohortSample?: InputMaybe<SampleCohortsHasCohortSampleFieldInput>;
-  datasource: Scalars["String"];
+  datasource: Scalars["String"]["input"];
   hasDbgapDbGaps?: InputMaybe<SampleHasDbgapDbGapsFieldInput>;
   hasMetadataSampleMetadata?: InputMaybe<SampleHasMetadataSampleMetadataFieldInput>;
   hasTempoTempos?: InputMaybe<SampleHasTempoTemposFieldInput>;
   patientsHasSample?: InputMaybe<SamplePatientsHasSampleFieldInput>;
   requestsHasSample?: InputMaybe<SampleRequestsHasSampleFieldInput>;
-  revisable?: InputMaybe<Scalars["Boolean"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
   sampleAliasesIsAlias?: InputMaybe<SampleSampleAliasesIsAliasFieldInput>;
-  sampleCategory: Scalars["String"];
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  smileSampleId: Scalars["String"];
+  sampleCategory: Scalars["String"]["input"];
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId: Scalars["String"]["input"];
 };
 
 export type SampleDbGapHasDbgapDbGapsAggregationSelection = {
   __typename?: "SampleDbGapHasDbgapDbGapsAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleDbGapHasDbgapDbGapsNodeAggregateSelection>;
 };
 
@@ -6944,7 +7178,7 @@ export type SampleDisconnectInput = {
 
 export type SampleEdge = {
   __typename?: "SampleEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -6952,18 +7186,18 @@ export type SampleHasDbgapDbGapsAggregateInput = {
   AND?: InputMaybe<Array<SampleHasDbgapDbGapsAggregateInput>>;
   NOT?: InputMaybe<SampleHasDbgapDbGapsAggregateInput>;
   OR?: InputMaybe<Array<SampleHasDbgapDbGapsAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleHasDbgapDbGapsNodeAggregationWhereInput>;
 };
 
 export type SampleHasDbgapDbGapsConnectFieldInput = {
   connect?: InputMaybe<Array<DbGapConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<DbGapConnectWhere>;
 };
 
@@ -6971,7 +7205,7 @@ export type SampleHasDbgapDbGapsConnection = {
   __typename?: "SampleHasDbgapDbGapsConnection";
   edges: Array<SampleHasDbgapDbGapsRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleHasDbgapDbGapsConnectionSort = {
@@ -7008,41 +7242,41 @@ export type SampleHasDbgapDbGapsNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleHasDbgapDbGapsNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleHasDbgapDbGapsNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleHasDbgapDbGapsNodeAggregationWhereInput>>;
-  dbGapStudy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dbGapStudy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dbGapStudy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileDbGapId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileDbGapId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dbGapStudy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dbGapStudy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileDbGapId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleHasDbgapDbGapsRelationship = {
   __typename?: "SampleHasDbgapDbGapsRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: DbGap;
 };
 
@@ -7063,18 +7297,18 @@ export type SampleHasMetadataSampleMetadataAggregateInput = {
   AND?: InputMaybe<Array<SampleHasMetadataSampleMetadataAggregateInput>>;
   NOT?: InputMaybe<SampleHasMetadataSampleMetadataAggregateInput>;
   OR?: InputMaybe<Array<SampleHasMetadataSampleMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleHasMetadataSampleMetadataNodeAggregationWhereInput>;
 };
 
 export type SampleHasMetadataSampleMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<SampleMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleMetadataConnectWhere>;
 };
 
@@ -7082,7 +7316,7 @@ export type SampleHasMetadataSampleMetadataConnection = {
   __typename?: "SampleHasMetadataSampleMetadataConnection";
   edges: Array<SampleHasMetadataSampleMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleHasMetadataSampleMetadataConnectionSort = {
@@ -7123,406 +7357,444 @@ export type SampleHasMetadataSampleMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<SampleHasMetadataSampleMetadataNodeAggregationWhereInput>
   >;
-  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleHasMetadataSampleMetadataRelationship = {
   __typename?: "SampleHasMetadataSampleMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleMetadata;
 };
 
@@ -7545,18 +7817,18 @@ export type SampleHasTempoTemposAggregateInput = {
   AND?: InputMaybe<Array<SampleHasTempoTemposAggregateInput>>;
   NOT?: InputMaybe<SampleHasTempoTemposAggregateInput>;
   OR?: InputMaybe<Array<SampleHasTempoTemposAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleHasTempoTemposNodeAggregationWhereInput>;
 };
 
 export type SampleHasTempoTemposConnectFieldInput = {
   connect?: InputMaybe<Array<TempoConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<TempoConnectWhere>;
 };
 
@@ -7564,7 +7836,7 @@ export type SampleHasTempoTemposConnection = {
   __typename?: "SampleHasTempoTemposConnection";
   edges: Array<SampleHasTempoTemposRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleHasTempoTemposConnectionSort = {
@@ -7601,116 +7873,164 @@ export type SampleHasTempoTemposNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleHasTempoTemposNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleHasTempoTemposNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleHasTempoTemposNodeAggregationWhereInput>>;
-  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  accessLevel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  accessLevel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  accessLevel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  billedBy_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  billedBy_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  costCenter_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  costCenter_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  custodianInformation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  custodianInformation_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  embargoDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  embargoDate_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  embargoDate_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  initialPipelineRunDate_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_LONGEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LT?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  initialPipelineRunDate_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  smileTempoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileTempoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleHasTempoTemposRelationship = {
   __typename?: "SampleHasTempoTemposRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -7729,75 +8049,75 @@ export type SampleHasTempoTemposUpdateFieldInput = {
 
 export type SampleMetadata = {
   __typename?: "SampleMetadata";
-  additionalProperties: Scalars["String"];
-  baitSet?: Maybe<Scalars["String"]>;
-  cfDNA2dBarcode?: Maybe<Scalars["String"]>;
-  cmoInfoIgoId?: Maybe<Scalars["String"]>;
-  cmoPatientId?: Maybe<Scalars["String"]>;
-  cmoSampleIdFields: Scalars["String"];
-  cmoSampleName?: Maybe<Scalars["String"]>;
-  collectionYear?: Maybe<Scalars["String"]>;
-  genePanel: Scalars["String"];
+  additionalProperties: Scalars["String"]["output"];
+  baitSet?: Maybe<Scalars["String"]["output"]>;
+  cfDNA2dBarcode?: Maybe<Scalars["String"]["output"]>;
+  cmoInfoIgoId?: Maybe<Scalars["String"]["output"]>;
+  cmoPatientId?: Maybe<Scalars["String"]["output"]>;
+  cmoSampleIdFields: Scalars["String"]["output"];
+  cmoSampleName?: Maybe<Scalars["String"]["output"]>;
+  collectionYear?: Maybe<Scalars["String"]["output"]>;
+  genePanel: Scalars["String"]["output"];
   hasStatusStatuses: Array<Status>;
   hasStatusStatusesAggregate?: Maybe<SampleMetadataStatusHasStatusStatusesAggregationSelection>;
   hasStatusStatusesConnection: SampleMetadataHasStatusStatusesConnection;
-  igoComplete?: Maybe<Scalars["Boolean"]>;
-  igoRequestId?: Maybe<Scalars["String"]>;
-  importDate: Scalars["BigInt"];
-  investigatorSampleId?: Maybe<Scalars["String"]>;
-  libraries: Scalars["String"];
-  oncotreeCode?: Maybe<Scalars["String"]>;
-  preservation?: Maybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
-  qcReports: Scalars["String"];
-  sampleClass?: Maybe<Scalars["String"]>;
-  sampleName?: Maybe<Scalars["String"]>;
-  sampleOrigin?: Maybe<Scalars["String"]>;
-  sampleType?: Maybe<Scalars["String"]>;
+  igoComplete?: Maybe<Scalars["Boolean"]["output"]>;
+  igoRequestId?: Maybe<Scalars["String"]["output"]>;
+  importDate: Scalars["BigInt"]["output"];
+  investigatorSampleId?: Maybe<Scalars["String"]["output"]>;
+  libraries: Scalars["String"]["output"];
+  oncotreeCode?: Maybe<Scalars["String"]["output"]>;
+  preservation?: Maybe<Scalars["String"]["output"]>;
+  primaryId: Scalars["String"]["output"];
+  qcReports: Scalars["String"]["output"];
+  sampleClass?: Maybe<Scalars["String"]["output"]>;
+  sampleName?: Maybe<Scalars["String"]["output"]>;
+  sampleOrigin?: Maybe<Scalars["String"]["output"]>;
+  sampleType?: Maybe<Scalars["String"]["output"]>;
   samplesHasMetadata: Array<Sample>;
   samplesHasMetadataAggregate?: Maybe<SampleMetadataSampleSamplesHasMetadataAggregationSelection>;
   samplesHasMetadataConnection: SampleMetadataSamplesHasMetadataConnection;
-  sex?: Maybe<Scalars["String"]>;
-  species?: Maybe<Scalars["String"]>;
-  tissueLocation?: Maybe<Scalars["String"]>;
-  tubeId?: Maybe<Scalars["String"]>;
-  tumorOrNormal?: Maybe<Scalars["String"]>;
+  sex?: Maybe<Scalars["String"]["output"]>;
+  species?: Maybe<Scalars["String"]["output"]>;
+  tissueLocation?: Maybe<Scalars["String"]["output"]>;
+  tubeId?: Maybe<Scalars["String"]["output"]>;
+  tumorOrNormal?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type SampleMetadataHasStatusStatusesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<StatusOptions>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type SampleMetadataHasStatusStatusesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<StatusWhere>;
 };
 
 export type SampleMetadataHasStatusStatusesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleMetadataHasStatusStatusesConnectionSort>>;
   where?: InputMaybe<SampleMetadataHasStatusStatusesConnectionWhere>;
 };
 
 export type SampleMetadataSamplesHasMetadataArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleMetadataSamplesHasMetadataAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type SampleMetadataSamplesHasMetadataConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<SampleMetadataSamplesHasMetadataConnectionSort>>;
   where?: InputMaybe<SampleMetadataSamplesHasMetadataConnectionWhere>;
 };
@@ -7812,7 +8132,7 @@ export type SampleMetadataAggregateSelection = {
   cmoSampleIdFields: StringAggregateSelection;
   cmoSampleName: StringAggregateSelection;
   collectionYear: StringAggregateSelection;
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   genePanel: StringAggregateSelection;
   igoRequestId: StringAggregateSelection;
   importDate: BigIntAggregateSelection;
@@ -7850,39 +8170,39 @@ export type SampleMetadataConnection = {
   __typename?: "SampleMetadataConnection";
   edges: Array<SampleMetadataEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleMetadataCreateInput = {
-  additionalProperties: Scalars["String"];
-  baitSet?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields: Scalars["String"];
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  genePanel: Scalars["String"];
+  additionalProperties: Scalars["String"]["input"];
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields: Scalars["String"]["input"];
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel: Scalars["String"]["input"];
   hasStatusStatuses?: InputMaybe<SampleMetadataHasStatusStatusesFieldInput>;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  importDate: Scalars["BigInt"];
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  libraries: Scalars["String"];
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
-  qcReports: Scalars["String"];
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleName?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  importDate: Scalars["BigInt"]["input"];
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  libraries: Scalars["String"]["input"];
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId: Scalars["String"]["input"];
+  qcReports: Scalars["String"]["input"];
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasMetadata?: InputMaybe<SampleMetadataSamplesHasMetadataFieldInput>;
-  sex?: InputMaybe<Scalars["String"]>;
-  species?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tubeId?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleMetadataDeleteInput = {
@@ -7905,7 +8225,7 @@ export type SampleMetadataDisconnectInput = {
 
 export type SampleMetadataEdge = {
   __typename?: "SampleMetadataEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleMetadata;
 };
 
@@ -7913,18 +8233,18 @@ export type SampleMetadataHasStatusStatusesAggregateInput = {
   AND?: InputMaybe<Array<SampleMetadataHasStatusStatusesAggregateInput>>;
   NOT?: InputMaybe<SampleMetadataHasStatusStatusesAggregateInput>;
   OR?: InputMaybe<Array<SampleMetadataHasStatusStatusesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleMetadataHasStatusStatusesNodeAggregationWhereInput>;
 };
 
 export type SampleMetadataHasStatusStatusesConnectFieldInput = {
   connect?: InputMaybe<Array<StatusConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<StatusConnectWhere>;
 };
 
@@ -7932,7 +8252,7 @@ export type SampleMetadataHasStatusStatusesConnection = {
   __typename?: "SampleMetadataHasStatusStatusesConnection";
   edges: Array<SampleMetadataHasStatusStatusesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleMetadataHasStatusStatusesConnectionSort = {
@@ -7973,26 +8293,26 @@ export type SampleMetadataHasStatusStatusesNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<SampleMetadataHasStatusStatusesNodeAggregationWhereInput>
   >;
-  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  validationReport_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  validationReport_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  validationReport_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleMetadataHasStatusStatusesRelationship = {
   __typename?: "SampleMetadataHasStatusStatusesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Status;
 };
 
@@ -8012,8 +8332,8 @@ export type SampleMetadataHasStatusStatusesUpdateFieldInput = {
 };
 
 export type SampleMetadataOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more SampleMetadataSort objects to sort SampleMetadata by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<SampleMetadataSort>>;
 };
@@ -8029,7 +8349,7 @@ export type SampleMetadataRelationInput = {
 
 export type SampleMetadataSampleSamplesHasMetadataAggregationSelection = {
   __typename?: "SampleMetadataSampleSamplesHasMetadataAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleMetadataSampleSamplesHasMetadataNodeAggregateSelection>;
 };
 
@@ -8045,18 +8365,18 @@ export type SampleMetadataSamplesHasMetadataAggregateInput = {
   AND?: InputMaybe<Array<SampleMetadataSamplesHasMetadataAggregateInput>>;
   NOT?: InputMaybe<SampleMetadataSamplesHasMetadataAggregateInput>;
   OR?: InputMaybe<Array<SampleMetadataSamplesHasMetadataAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleMetadataSamplesHasMetadataNodeAggregationWhereInput>;
 };
 
 export type SampleMetadataSamplesHasMetadataConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -8064,7 +8384,7 @@ export type SampleMetadataSamplesHasMetadataConnection = {
   __typename?: "SampleMetadataSamplesHasMetadataConnection";
   edges: Array<SampleMetadataSamplesHasMetadataRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleMetadataSamplesHasMetadataConnectionSort = {
@@ -8107,71 +8427,71 @@ export type SampleMetadataSamplesHasMetadataNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<SampleMetadataSamplesHasMetadataNodeAggregationWhereInput>
   >;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleMetadataSamplesHasMetadataRelationship = {
   __typename?: "SampleMetadataSamplesHasMetadataRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -8225,7 +8545,7 @@ export type SampleMetadataSort = {
 
 export type SampleMetadataStatusHasStatusStatusesAggregationSelection = {
   __typename?: "SampleMetadataStatusHasStatusStatusesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleMetadataStatusHasStatusStatusesNodeAggregateSelection>;
 };
 
@@ -8235,101 +8555,101 @@ export type SampleMetadataStatusHasStatusStatusesNodeAggregateSelection = {
 };
 
 export type SampleMetadataUpdateInput = {
-  additionalProperties?: InputMaybe<Scalars["String"]>;
-  baitSet?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields?: InputMaybe<Scalars["String"]>;
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
+  additionalProperties?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
   hasStatusStatuses?: InputMaybe<
     Array<SampleMetadataHasStatusStatusesUpdateFieldInput>
   >;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  libraries?: InputMaybe<Scalars["String"]>;
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
-  qcReports?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleName?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_DECREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_INCREMENT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  libraries?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasMetadata?: InputMaybe<
     Array<SampleMetadataSamplesHasMetadataUpdateFieldInput>
   >;
-  sex?: InputMaybe<Scalars["String"]>;
-  species?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tubeId?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleMetadataWhere = {
   AND?: InputMaybe<Array<SampleMetadataWhere>>;
   NOT?: InputMaybe<SampleMetadataWhere>;
   OR?: InputMaybe<Array<SampleMetadataWhere>>;
-  additionalProperties?: InputMaybe<Scalars["String"]>;
-  additionalProperties_CONTAINS?: InputMaybe<Scalars["String"]>;
-  additionalProperties_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  additionalProperties_IN?: InputMaybe<Array<Scalars["String"]>>;
-  additionalProperties_MATCHES?: InputMaybe<Scalars["String"]>;
-  additionalProperties_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  baitSet?: InputMaybe<Scalars["String"]>;
-  baitSet_CONTAINS?: InputMaybe<Scalars["String"]>;
-  baitSet_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  baitSet_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  baitSet_MATCHES?: InputMaybe<Scalars["String"]>;
-  baitSet_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cfDNA2dBarcode_MATCHES?: InputMaybe<Scalars["String"]>;
-  cfDNA2dBarcode_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoInfoIgoId_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoInfoIgoId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoPatientId?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoPatientId_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_IN?: InputMaybe<Array<Scalars["String"]>>;
-  cmoSampleIdFields_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoSampleIdFields_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleName?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  cmoSampleName_MATCHES?: InputMaybe<Scalars["String"]>;
-  cmoSampleName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  collectionYear?: InputMaybe<Scalars["String"]>;
-  collectionYear_CONTAINS?: InputMaybe<Scalars["String"]>;
-  collectionYear_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  collectionYear_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  collectionYear_MATCHES?: InputMaybe<Scalars["String"]>;
-  collectionYear_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel?: InputMaybe<Scalars["String"]>;
-  genePanel_CONTAINS?: InputMaybe<Scalars["String"]>;
-  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  genePanel_IN?: InputMaybe<Array<Scalars["String"]>>;
-  genePanel_MATCHES?: InputMaybe<Scalars["String"]>;
-  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  additionalProperties?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  additionalProperties_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  additionalProperties_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  baitSet_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  baitSet_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cfDNA2dBarcode_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cfDNA2dBarcode_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cmoInfoIgoId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoInfoIgoId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cmoPatientId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoPatientId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  cmoSampleIdFields_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleIdFields_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  cmoSampleName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  cmoSampleName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  collectionYear_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  collectionYear_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  genePanel_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  genePanel_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasStatusStatusesAggregate?: InputMaybe<SampleMetadataHasStatusStatusesAggregateInput>;
   /** Return SampleMetadata where all of the related SampleMetadataHasStatusStatusesConnections match this filter */
   hasStatusStatusesConnection_ALL?: InputMaybe<SampleMetadataHasStatusStatusesConnectionWhere>;
@@ -8347,79 +8667,81 @@ export type SampleMetadataWhere = {
   hasStatusStatuses_SINGLE?: InputMaybe<StatusWhere>;
   /** Return SampleMetadata where some of the related Statuses match this filter */
   hasStatusStatuses_SOME?: InputMaybe<StatusWhere>;
-  igoComplete?: InputMaybe<Scalars["Boolean"]>;
-  igoRequestId?: InputMaybe<Scalars["String"]>;
-  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  igoRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]>;
-  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  importDate?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]>>;
-  importDate_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_LTE?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  investigatorSampleId_MATCHES?: InputMaybe<Scalars["String"]>;
-  investigatorSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  libraries?: InputMaybe<Scalars["String"]>;
-  libraries_CONTAINS?: InputMaybe<Scalars["String"]>;
-  libraries_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  libraries_IN?: InputMaybe<Array<Scalars["String"]>>;
-  libraries_MATCHES?: InputMaybe<Scalars["String"]>;
-  libraries_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  oncotreeCode?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_CONTAINS?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  oncotreeCode_MATCHES?: InputMaybe<Scalars["String"]>;
-  oncotreeCode_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  preservation?: InputMaybe<Scalars["String"]>;
-  preservation_CONTAINS?: InputMaybe<Scalars["String"]>;
-  preservation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  preservation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  preservation_MATCHES?: InputMaybe<Scalars["String"]>;
-  preservation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  primaryId?: InputMaybe<Scalars["String"]>;
-  primaryId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  primaryId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  primaryId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  primaryId_MATCHES?: InputMaybe<Scalars["String"]>;
-  primaryId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  qcReports?: InputMaybe<Scalars["String"]>;
-  qcReports_CONTAINS?: InputMaybe<Scalars["String"]>;
-  qcReports_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  qcReports_IN?: InputMaybe<Array<Scalars["String"]>>;
-  qcReports_MATCHES?: InputMaybe<Scalars["String"]>;
-  qcReports_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleClass_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleName?: InputMaybe<Scalars["String"]>;
-  sampleName_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleName_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleName_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleName_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleOrigin?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleOrigin_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleOrigin_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleType?: InputMaybe<Scalars["String"]>;
-  sampleType_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleType_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleType_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleType_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  igoComplete?: InputMaybe<Scalars["Boolean"]["input"]>;
+  igoRequestId?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  igoRequestId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  igoRequestId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  importDate?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_IN?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  importDate_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  investigatorSampleId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  investigatorSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraries?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  libraries_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  libraries_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  oncotreeCode_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  oncotreeCode_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  preservation?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  preservation_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  preservation_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  primaryId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  qcReports_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  qcReports_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleClass_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleName_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleName_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleOrigin_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleOrigin_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleType_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleType_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasMetadataAggregate?: InputMaybe<SampleMetadataSamplesHasMetadataAggregateInput>;
   /** Return SampleMetadata where all of the related SampleMetadataSamplesHasMetadataConnections match this filter */
   samplesHasMetadataConnection_ALL?: InputMaybe<SampleMetadataSamplesHasMetadataConnectionWhere>;
@@ -8437,48 +8759,48 @@ export type SampleMetadataWhere = {
   samplesHasMetadata_SINGLE?: InputMaybe<SampleWhere>;
   /** Return SampleMetadata where some of the related Samples match this filter */
   samplesHasMetadata_SOME?: InputMaybe<SampleWhere>;
-  sex?: InputMaybe<Scalars["String"]>;
-  sex_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sex_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sex_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sex_MATCHES?: InputMaybe<Scalars["String"]>;
-  sex_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  species?: InputMaybe<Scalars["String"]>;
-  species_CONTAINS?: InputMaybe<Scalars["String"]>;
-  species_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  species_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  species_MATCHES?: InputMaybe<Scalars["String"]>;
-  species_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  tissueLocation?: InputMaybe<Scalars["String"]>;
-  tissueLocation_CONTAINS?: InputMaybe<Scalars["String"]>;
-  tissueLocation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  tissueLocation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  tissueLocation_MATCHES?: InputMaybe<Scalars["String"]>;
-  tissueLocation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  tubeId?: InputMaybe<Scalars["String"]>;
-  tubeId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  tubeId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  tubeId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  tubeId_MATCHES?: InputMaybe<Scalars["String"]>;
-  tubeId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_CONTAINS?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  tumorOrNormal_MATCHES?: InputMaybe<Scalars["String"]>;
-  tumorOrNormal_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  sex?: InputMaybe<Scalars["String"]["input"]>;
+  sex_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sex_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sex_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sex_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sex_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  species?: InputMaybe<Scalars["String"]["input"]>;
+  species_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  species_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  species_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  species_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  species_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  tissueLocation_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  tissueLocation_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  tubeId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  tubeId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  tumorOrNormal_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  tumorOrNormal_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more SampleSort objects to sort Samples by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<SampleSort>>;
 };
 
 export type SamplePatientPatientsHasSampleAggregationSelection = {
   __typename?: "SamplePatientPatientsHasSampleAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SamplePatientPatientsHasSampleNodeAggregateSelection>;
 };
 
@@ -8491,18 +8813,18 @@ export type SamplePatientsHasSampleAggregateInput = {
   AND?: InputMaybe<Array<SamplePatientsHasSampleAggregateInput>>;
   NOT?: InputMaybe<SamplePatientsHasSampleAggregateInput>;
   OR?: InputMaybe<Array<SamplePatientsHasSampleAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SamplePatientsHasSampleNodeAggregationWhereInput>;
 };
 
 export type SamplePatientsHasSampleConnectFieldInput = {
   connect?: InputMaybe<Array<PatientConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<PatientConnectWhere>;
 };
 
@@ -8510,7 +8832,7 @@ export type SamplePatientsHasSampleConnection = {
   __typename?: "SamplePatientsHasSampleConnection";
   edges: Array<SamplePatientsHasSampleRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SamplePatientsHasSampleConnectionSort = {
@@ -8547,26 +8869,26 @@ export type SamplePatientsHasSampleNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SamplePatientsHasSampleNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SamplePatientsHasSampleNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SamplePatientsHasSampleNodeAggregationWhereInput>>;
-  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  smilePatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smilePatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SamplePatientsHasSampleRelationship = {
   __typename?: "SamplePatientsHasSampleRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Patient;
 };
 
@@ -8605,7 +8927,7 @@ export type SampleRelationInput = {
 
 export type SampleRequestRequestsHasSampleAggregationSelection = {
   __typename?: "SampleRequestRequestsHasSampleAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleRequestRequestsHasSampleNodeAggregateSelection>;
 };
 
@@ -8638,18 +8960,18 @@ export type SampleRequestsHasSampleAggregateInput = {
   AND?: InputMaybe<Array<SampleRequestsHasSampleAggregateInput>>;
   NOT?: InputMaybe<SampleRequestsHasSampleAggregateInput>;
   OR?: InputMaybe<Array<SampleRequestsHasSampleAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleRequestsHasSampleNodeAggregationWhereInput>;
 };
 
 export type SampleRequestsHasSampleConnectFieldInput = {
   connect?: InputMaybe<Array<RequestConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestConnectWhere>;
 };
 
@@ -8657,7 +8979,7 @@ export type SampleRequestsHasSampleConnection = {
   __typename?: "SampleRequestsHasSampleConnection";
   edges: Array<SampleRequestsHasSampleRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleRequestsHasSampleConnectionSort = {
@@ -8694,331 +9016,341 @@ export type SampleRequestsHasSampleNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleRequestsHasSampleNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleRequestsHasSampleNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleRequestsHasSampleNodeAggregationWhereInput>>;
-  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  dataAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  dataAnalystName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoDeliveryDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoDeliveryDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoProjectId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  ilabRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  investigatorName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  labHeadName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  labHeadName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraryType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraryType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  otherContactEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  otherContactEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  otherContactEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  piEmail_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  piEmail_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  projectManagerName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  projectManagerName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  projectManagerName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcAccessEmails_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  requestJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  strand_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  strand_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleRequestsHasSampleRelationship = {
   __typename?: "SampleRequestsHasSampleRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Request;
 };
 
@@ -9037,7 +9369,7 @@ export type SampleRequestsHasSampleUpdateFieldInput = {
 
 export type SampleSampleAliasSampleAliasesIsAliasAggregationSelection = {
   __typename?: "SampleSampleAliasSampleAliasesIsAliasAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleSampleAliasSampleAliasesIsAliasNodeAggregateSelection>;
 };
 
@@ -9051,18 +9383,18 @@ export type SampleSampleAliasesIsAliasAggregateInput = {
   AND?: InputMaybe<Array<SampleSampleAliasesIsAliasAggregateInput>>;
   NOT?: InputMaybe<SampleSampleAliasesIsAliasAggregateInput>;
   OR?: InputMaybe<Array<SampleSampleAliasesIsAliasAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<SampleSampleAliasesIsAliasNodeAggregationWhereInput>;
 };
 
 export type SampleSampleAliasesIsAliasConnectFieldInput = {
   connect?: InputMaybe<Array<SampleAliasConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleAliasConnectWhere>;
 };
 
@@ -9070,7 +9402,7 @@ export type SampleSampleAliasesIsAliasConnection = {
   __typename?: "SampleSampleAliasesIsAliasConnection";
   edges: Array<SampleSampleAliasesIsAliasRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SampleSampleAliasesIsAliasConnectionSort = {
@@ -9107,41 +9439,41 @@ export type SampleSampleAliasesIsAliasNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<SampleSampleAliasesIsAliasNodeAggregationWhereInput>>;
   NOT?: InputMaybe<SampleSampleAliasesIsAliasNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<SampleSampleAliasesIsAliasNodeAggregationWhereInput>>;
-  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  namespace_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  namespace_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  namespace_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  value_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  value_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  value_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type SampleSampleAliasesIsAliasRelationship = {
   __typename?: "SampleSampleAliasesIsAliasRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleAlias;
 };
 
@@ -9163,7 +9495,7 @@ export type SampleSampleAliasesIsAliasUpdateFieldInput = {
 export type SampleSampleMetadataHasMetadataSampleMetadataAggregationSelection =
   {
     __typename?: "SampleSampleMetadataHasMetadataSampleMetadataAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<SampleSampleMetadataHasMetadataSampleMetadataNodeAggregateSelection>;
   };
 
@@ -9209,7 +9541,7 @@ export type SampleSort = {
 
 export type SampleTempoHasTempoTemposAggregationSelection = {
   __typename?: "SampleTempoHasTempoTemposAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<SampleTempoHasTempoTemposNodeAggregateSelection>;
 };
 
@@ -9228,7 +9560,7 @@ export type SampleUpdateInput = {
   cohortsHasCohortSample?: InputMaybe<
     Array<SampleCohortsHasCohortSampleUpdateFieldInput>
   >;
-  datasource?: InputMaybe<Scalars["String"]>;
+  datasource?: InputMaybe<Scalars["String"]["input"]>;
   hasDbgapDbGaps?: InputMaybe<Array<SampleHasDbgapDbGapsUpdateFieldInput>>;
   hasMetadataSampleMetadata?: InputMaybe<
     Array<SampleHasMetadataSampleMetadataUpdateFieldInput>
@@ -9240,13 +9572,13 @@ export type SampleUpdateInput = {
   requestsHasSample?: InputMaybe<
     Array<SampleRequestsHasSampleUpdateFieldInput>
   >;
-  revisable?: InputMaybe<Scalars["Boolean"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
   sampleAliasesIsAlias?: InputMaybe<
     Array<SampleSampleAliasesIsAliasUpdateFieldInput>
   >;
-  sampleCategory?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  smileSampleId?: InputMaybe<Scalars["String"]>;
+  sampleCategory?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SampleWhere = {
@@ -9270,12 +9602,12 @@ export type SampleWhere = {
   cohortsHasCohortSample_SINGLE?: InputMaybe<CohortWhere>;
   /** Return Samples where some of the related Cohorts match this filter */
   cohortsHasCohortSample_SOME?: InputMaybe<CohortWhere>;
-  datasource?: InputMaybe<Scalars["String"]>;
-  datasource_CONTAINS?: InputMaybe<Scalars["String"]>;
-  datasource_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  datasource_IN?: InputMaybe<Array<Scalars["String"]>>;
-  datasource_MATCHES?: InputMaybe<Scalars["String"]>;
-  datasource_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  datasource?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  datasource_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  datasource_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasDbgapDbGapsAggregate?: InputMaybe<SampleHasDbgapDbGapsAggregateInput>;
   /** Return Samples where all of the related SampleHasDbgapDbGapsConnections match this filter */
   hasDbgapDbGapsConnection_ALL?: InputMaybe<SampleHasDbgapDbGapsConnectionWhere>;
@@ -9361,7 +9693,7 @@ export type SampleWhere = {
   requestsHasSample_SINGLE?: InputMaybe<RequestWhere>;
   /** Return Samples where some of the related Requests match this filter */
   requestsHasSample_SOME?: InputMaybe<RequestWhere>;
-  revisable?: InputMaybe<Scalars["Boolean"]>;
+  revisable?: InputMaybe<Scalars["Boolean"]["input"]>;
   sampleAliasesIsAliasAggregate?: InputMaybe<SampleSampleAliasesIsAliasAggregateInput>;
   /** Return Samples where all of the related SampleSampleAliasesIsAliasConnections match this filter */
   sampleAliasesIsAliasConnection_ALL?: InputMaybe<SampleSampleAliasesIsAliasConnectionWhere>;
@@ -9379,38 +9711,38 @@ export type SampleWhere = {
   sampleAliasesIsAlias_SINGLE?: InputMaybe<SampleAliasWhere>;
   /** Return Samples where some of the related SampleAliases match this filter */
   sampleAliasesIsAlias_SOME?: InputMaybe<SampleAliasWhere>;
-  sampleCategory?: InputMaybe<Scalars["String"]>;
-  sampleCategory_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleCategory_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleCategory_IN?: InputMaybe<Array<Scalars["String"]>>;
-  sampleCategory_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleCategory_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass?: InputMaybe<Scalars["String"]>;
-  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]>;
-  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  sampleClass_MATCHES?: InputMaybe<Scalars["String"]>;
-  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  smileSampleId?: InputMaybe<Scalars["String"]>;
-  smileSampleId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileSampleId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileSampleId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  sampleCategory?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  sampleCategory_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleCategory_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  sampleClass_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  sampleClass_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileSampleId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileSampleId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SamplesConnection = {
   __typename?: "SamplesConnection";
   edges: Array<SampleEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type SeqDateAccessionBySampleId = {
   __typename?: "SeqDateAccessionBySampleId";
-  DMP_SAMPLE_ID: Scalars["String"];
-  MOLECULAR_ACCESSION_NUMBER?: Maybe<Scalars["String"]>;
-  SEQUENCING_DATE: Scalars["String"];
+  DMP_SAMPLE_ID: Scalars["String"]["output"];
+  MOLECULAR_ACCESSION_NUMBER?: Maybe<Scalars["String"]["output"]>;
+  SEQUENCING_DATE: Scalars["String"]["output"];
 };
 
 /** An enum for sorting in either ascending or descending order. */
@@ -9429,51 +9761,51 @@ export type Status = {
   sampleMetadataHasStatus: Array<SampleMetadata>;
   sampleMetadataHasStatusAggregate?: Maybe<StatusSampleMetadataSampleMetadataHasStatusAggregationSelection>;
   sampleMetadataHasStatusConnection: StatusSampleMetadataHasStatusConnection;
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type StatusRequestMetadataHasStatusArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<RequestMetadataOptions>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type StatusRequestMetadataHasStatusAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<RequestMetadataWhere>;
 };
 
 export type StatusRequestMetadataHasStatusConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<StatusRequestMetadataHasStatusConnectionSort>>;
   where?: InputMaybe<StatusRequestMetadataHasStatusConnectionWhere>;
 };
 
 export type StatusSampleMetadataHasStatusArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleMetadataOptions>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type StatusSampleMetadataHasStatusAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleMetadataWhere>;
 };
 
 export type StatusSampleMetadataHasStatusConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<StatusSampleMetadataHasStatusConnectionSort>>;
   where?: InputMaybe<StatusSampleMetadataHasStatusConnectionWhere>;
 };
 
 export type StatusAggregateSelection = {
   __typename?: "StatusAggregateSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   validationReport: StringAggregateSelection;
 };
 
@@ -9493,8 +9825,8 @@ export type StatusConnectWhere = {
 export type StatusCreateInput = {
   requestMetadataHasStatus?: InputMaybe<StatusRequestMetadataHasStatusFieldInput>;
   sampleMetadataHasStatus?: InputMaybe<StatusSampleMetadataHasStatusFieldInput>;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type StatusDeleteInput = {
@@ -9517,13 +9849,13 @@ export type StatusDisconnectInput = {
 
 export type StatusEdge = {
   __typename?: "StatusEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Status;
 };
 
 export type StatusOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more StatusSort objects to sort Statuses by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<StatusSort>>;
 };
@@ -9541,18 +9873,18 @@ export type StatusRequestMetadataHasStatusAggregateInput = {
   AND?: InputMaybe<Array<StatusRequestMetadataHasStatusAggregateInput>>;
   NOT?: InputMaybe<StatusRequestMetadataHasStatusAggregateInput>;
   OR?: InputMaybe<Array<StatusRequestMetadataHasStatusAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<StatusRequestMetadataHasStatusNodeAggregationWhereInput>;
 };
 
 export type StatusRequestMetadataHasStatusConnectFieldInput = {
   connect?: InputMaybe<Array<RequestMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<RequestMetadataConnectWhere>;
 };
 
@@ -9560,7 +9892,7 @@ export type StatusRequestMetadataHasStatusConnection = {
   __typename?: "StatusRequestMetadataHasStatusConnection";
   edges: Array<StatusRequestMetadataHasStatusRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type StatusRequestMetadataHasStatusConnectionSort = {
@@ -9601,61 +9933,71 @@ export type StatusRequestMetadataHasStatusNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<StatusRequestMetadataHasStatusNodeAggregationWhereInput>
   >;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  requestMetadataJson_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  requestMetadataJson_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  requestMetadataJson_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type StatusRequestMetadataHasStatusRelationship = {
   __typename?: "StatusRequestMetadataHasStatusRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: RequestMetadata;
 };
 
@@ -9677,7 +10019,7 @@ export type StatusRequestMetadataHasStatusUpdateFieldInput = {
 export type StatusRequestMetadataRequestMetadataHasStatusAggregationSelection =
   {
     __typename?: "StatusRequestMetadataRequestMetadataHasStatusAggregationSelection";
-    count: Scalars["Int"];
+    count: Scalars["Int"]["output"];
     node?: Maybe<StatusRequestMetadataRequestMetadataHasStatusNodeAggregateSelection>;
   };
 
@@ -9693,18 +10035,18 @@ export type StatusSampleMetadataHasStatusAggregateInput = {
   AND?: InputMaybe<Array<StatusSampleMetadataHasStatusAggregateInput>>;
   NOT?: InputMaybe<StatusSampleMetadataHasStatusAggregateInput>;
   OR?: InputMaybe<Array<StatusSampleMetadataHasStatusAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<StatusSampleMetadataHasStatusNodeAggregationWhereInput>;
 };
 
 export type StatusSampleMetadataHasStatusConnectFieldInput = {
   connect?: InputMaybe<Array<SampleMetadataConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleMetadataConnectWhere>;
 };
 
@@ -9712,7 +10054,7 @@ export type StatusSampleMetadataHasStatusConnection = {
   __typename?: "StatusSampleMetadataHasStatusConnection";
   edges: Array<StatusSampleMetadataHasStatusRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type StatusSampleMetadataHasStatusConnectionSort = {
@@ -9753,406 +10095,444 @@ export type StatusSampleMetadataHasStatusNodeAggregationWhereInput = {
   OR?: InputMaybe<
     Array<StatusSampleMetadataHasStatusNodeAggregationWhereInput>
   >;
-  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]>;
-  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]>;
-  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  additionalProperties_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  additionalProperties_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  additionalProperties_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  baitSet_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  baitSet_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  baitSet_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cfDNA2dBarcode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoInfoIgoId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoPatientId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  cmoSampleIdFields_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleIdFields_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  cmoSampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  collectionYear_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  collectionYear_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  genePanel_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  genePanel_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  igoRequestId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  importDate_AVERAGE_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_AVERAGE_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MAX_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_MIN_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_EQUAL?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_GTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LT?: InputMaybe<Scalars["BigInt"]["input"]>;
+  importDate_SUM_LTE?: InputMaybe<Scalars["BigInt"]["input"]>;
+  investigatorSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LT?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<
+    Scalars["Float"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  investigatorSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  investigatorSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<
+    Scalars["Int"]["input"]
+  >;
+  libraries_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  libraries_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  libraries_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  oncotreeCode_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  preservation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  preservation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  primaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  primaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  qcReports_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  qcReports_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleName_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleName_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleOrigin_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleType_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleType_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sex_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sex_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  species_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  species_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  species_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tissueLocation_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tubeId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tubeId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  tumorOrNormal_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type StatusSampleMetadataHasStatusRelationship = {
   __typename?: "StatusSampleMetadataHasStatusRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: SampleMetadata;
 };
 
@@ -10173,7 +10553,7 @@ export type StatusSampleMetadataHasStatusUpdateFieldInput = {
 
 export type StatusSampleMetadataSampleMetadataHasStatusAggregationSelection = {
   __typename?: "StatusSampleMetadataSampleMetadataHasStatusAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<StatusSampleMetadataSampleMetadataHasStatusNodeAggregateSelection>;
 };
 
@@ -10221,8 +10601,8 @@ export type StatusUpdateInput = {
   sampleMetadataHasStatus?: InputMaybe<
     Array<StatusSampleMetadataHasStatusUpdateFieldInput>
   >;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type StatusWhere = {
@@ -10263,36 +10643,38 @@ export type StatusWhere = {
   sampleMetadataHasStatus_SINGLE?: InputMaybe<SampleMetadataWhere>;
   /** Return Statuses where some of the related SampleMetadata match this filter */
   sampleMetadataHasStatus_SOME?: InputMaybe<SampleMetadataWhere>;
-  validationReport?: InputMaybe<Scalars["String"]>;
-  validationReport_CONTAINS?: InputMaybe<Scalars["String"]>;
-  validationReport_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  validationReport_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  validationReport_MATCHES?: InputMaybe<Scalars["String"]>;
-  validationReport_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  validationStatus?: InputMaybe<Scalars["Boolean"]>;
+  validationReport?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  validationReport_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  validationReport_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  validationStatus?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type StatusesConnection = {
   __typename?: "StatusesConnection";
   edges: Array<StatusEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type StringAggregateSelection = {
   __typename?: "StringAggregateSelection";
-  longest?: Maybe<Scalars["String"]>;
-  shortest?: Maybe<Scalars["String"]>;
+  longest?: Maybe<Scalars["String"]["output"]>;
+  shortest?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type Tempo = {
   __typename?: "Tempo";
-  accessLevel?: Maybe<Scalars["String"]>;
-  billed?: Maybe<Scalars["Boolean"]>;
-  billedBy?: Maybe<Scalars["String"]>;
-  costCenter?: Maybe<Scalars["String"]>;
-  custodianInformation?: Maybe<Scalars["String"]>;
-  embargoDate?: Maybe<Scalars["String"]>;
+  accessLevel?: Maybe<Scalars["String"]["output"]>;
+  billed?: Maybe<Scalars["Boolean"]["output"]>;
+  billedBy?: Maybe<Scalars["String"]["output"]>;
+  costCenter?: Maybe<Scalars["String"]["output"]>;
+  custodianInformation?: Maybe<Scalars["String"]["output"]>;
+  embargoDate?: Maybe<Scalars["String"]["output"]>;
   hasEventBamCompletes: Array<BamComplete>;
   hasEventBamCompletesAggregate?: Maybe<TempoBamCompleteHasEventBamCompletesAggregationSelection>;
   hasEventBamCompletesConnection: TempoHasEventBamCompletesConnection;
@@ -10302,85 +10684,85 @@ export type Tempo = {
   hasEventQcCompletes: Array<QcComplete>;
   hasEventQcCompletesAggregate?: Maybe<TempoQcCompleteHasEventQcCompletesAggregationSelection>;
   hasEventQcCompletesConnection: TempoHasEventQcCompletesConnection;
-  initialPipelineRunDate?: Maybe<Scalars["String"]>;
+  initialPipelineRunDate?: Maybe<Scalars["String"]["output"]>;
   samplesHasTempo: Array<Sample>;
   samplesHasTempoAggregate?: Maybe<TempoSampleSamplesHasTempoAggregationSelection>;
   samplesHasTempoConnection: TempoSamplesHasTempoConnection;
-  smileTempoId: Scalars["String"];
+  smileTempoId: Scalars["String"]["output"];
 };
 
 export type TempoHasEventBamCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<BamCompleteOptions>;
   where?: InputMaybe<BamCompleteWhere>;
 };
 
 export type TempoHasEventBamCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<BamCompleteWhere>;
 };
 
 export type TempoHasEventBamCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoHasEventBamCompletesConnectionSort>>;
   where?: InputMaybe<TempoHasEventBamCompletesConnectionWhere>;
 };
 
 export type TempoHasEventMafCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<MafCompleteOptions>;
   where?: InputMaybe<MafCompleteWhere>;
 };
 
 export type TempoHasEventMafCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<MafCompleteWhere>;
 };
 
 export type TempoHasEventMafCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoHasEventMafCompletesConnectionSort>>;
   where?: InputMaybe<TempoHasEventMafCompletesConnectionWhere>;
 };
 
 export type TempoHasEventQcCompletesArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<QcCompleteOptions>;
   where?: InputMaybe<QcCompleteWhere>;
 };
 
 export type TempoHasEventQcCompletesAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<QcCompleteWhere>;
 };
 
 export type TempoHasEventQcCompletesConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoHasEventQcCompletesConnectionSort>>;
   where?: InputMaybe<TempoHasEventQcCompletesConnectionWhere>;
 };
 
 export type TempoSamplesHasTempoArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   options?: InputMaybe<SampleOptions>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type TempoSamplesHasTempoAggregateArgs = {
-  directed?: InputMaybe<Scalars["Boolean"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<SampleWhere>;
 };
 
 export type TempoSamplesHasTempoConnectionArgs = {
-  after?: InputMaybe<Scalars["String"]>;
-  directed?: InputMaybe<Scalars["Boolean"]>;
-  first?: InputMaybe<Scalars["Int"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  directed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<TempoSamplesHasTempoConnectionSort>>;
   where?: InputMaybe<TempoSamplesHasTempoConnectionWhere>;
 };
@@ -10390,7 +10772,7 @@ export type TempoAggregateSelection = {
   accessLevel: StringAggregateSelection;
   billedBy: StringAggregateSelection;
   costCenter: StringAggregateSelection;
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   custodianInformation: StringAggregateSelection;
   embargoDate: StringAggregateSelection;
   initialPipelineRunDate: StringAggregateSelection;
@@ -10399,7 +10781,7 @@ export type TempoAggregateSelection = {
 
 export type TempoBamCompleteHasEventBamCompletesAggregationSelection = {
   __typename?: "TempoBamCompleteHasEventBamCompletesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoBamCompleteHasEventBamCompletesNodeAggregateSelection>;
 };
 
@@ -10411,36 +10793,36 @@ export type TempoBamCompleteHasEventBamCompletesNodeAggregateSelection = {
 
 export type TempoCohortRequest = {
   __typename?: "TempoCohortRequest";
-  cohortId: Scalars["String"];
-  endUsers: Scalars["String"];
-  pmUsers: Scalars["String"];
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
+  cohortId: Scalars["String"]["output"];
+  endUsers: Scalars["String"]["output"];
+  pmUsers: Scalars["String"]["output"];
+  projectSubtitle: Scalars["String"]["output"];
+  projectTitle: Scalars["String"]["output"];
   samples: Array<TempoCohortSample>;
-  type: Scalars["String"];
+  type: Scalars["String"]["output"];
 };
 
 export type TempoCohortRequestInput = {
-  cohortId: Scalars["String"];
-  endUsers: Array<Scalars["String"]>;
-  pmUsers: Array<Scalars["String"]>;
-  projectSubtitle: Scalars["String"];
-  projectTitle: Scalars["String"];
+  cohortId: Scalars["String"]["input"];
+  endUsers: Array<Scalars["String"]["input"]>;
+  pmUsers: Array<Scalars["String"]["input"]>;
+  projectSubtitle: Scalars["String"]["input"];
+  projectTitle: Scalars["String"]["input"];
   samples: Array<TempoCohortSampleInput>;
-  type: Scalars["String"];
+  type: Scalars["String"]["input"];
 };
 
 export type TempoCohortSample = {
   __typename?: "TempoCohortSample";
-  cmoId?: Maybe<Scalars["String"]>;
-  embargoDate?: Maybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
+  cmoId?: Maybe<Scalars["String"]["output"]>;
+  embargoDate?: Maybe<Scalars["String"]["output"]>;
+  primaryId: Scalars["String"]["output"];
 };
 
 export type TempoCohortSampleInput = {
-  cmoId?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
-  primaryId: Scalars["String"];
+  cmoId?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
+  primaryId: Scalars["String"]["input"];
 };
 
 export type TempoConnectInput = {
@@ -10461,18 +10843,18 @@ export type TempoConnectWhere = {
 };
 
 export type TempoCreateInput = {
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
   hasEventBamCompletes?: InputMaybe<TempoHasEventBamCompletesFieldInput>;
   hasEventMafCompletes?: InputMaybe<TempoHasEventMafCompletesFieldInput>;
   hasEventQcCompletes?: InputMaybe<TempoHasEventQcCompletesFieldInput>;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasTempo?: InputMaybe<TempoSamplesHasTempoFieldInput>;
-  smileTempoId: Scalars["String"];
+  smileTempoId: Scalars["String"]["input"];
 };
 
 export type TempoDeleteInput = {
@@ -10503,7 +10885,7 @@ export type TempoDisconnectInput = {
 
 export type TempoEdge = {
   __typename?: "TempoEdge";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Tempo;
 };
 
@@ -10511,18 +10893,18 @@ export type TempoHasEventBamCompletesAggregateInput = {
   AND?: InputMaybe<Array<TempoHasEventBamCompletesAggregateInput>>;
   NOT?: InputMaybe<TempoHasEventBamCompletesAggregateInput>;
   OR?: InputMaybe<Array<TempoHasEventBamCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoHasEventBamCompletesNodeAggregationWhereInput>;
 };
 
 export type TempoHasEventBamCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<BamCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<BamCompleteConnectWhere>;
 };
 
@@ -10530,7 +10912,7 @@ export type TempoHasEventBamCompletesConnection = {
   __typename?: "TempoHasEventBamCompletesConnection";
   edges: Array<TempoHasEventBamCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoHasEventBamCompletesConnectionSort = {
@@ -10567,41 +10949,41 @@ export type TempoHasEventBamCompletesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoHasEventBamCompletesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoHasEventBamCompletesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoHasEventBamCompletesNodeAggregationWhereInput>>;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoHasEventBamCompletesRelationship = {
   __typename?: "TempoHasEventBamCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: BamComplete;
 };
 
@@ -10622,18 +11004,18 @@ export type TempoHasEventMafCompletesAggregateInput = {
   AND?: InputMaybe<Array<TempoHasEventMafCompletesAggregateInput>>;
   NOT?: InputMaybe<TempoHasEventMafCompletesAggregateInput>;
   OR?: InputMaybe<Array<TempoHasEventMafCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoHasEventMafCompletesNodeAggregationWhereInput>;
 };
 
 export type TempoHasEventMafCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<MafCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<MafCompleteConnectWhere>;
 };
 
@@ -10641,7 +11023,7 @@ export type TempoHasEventMafCompletesConnection = {
   __typename?: "TempoHasEventMafCompletesConnection";
   edges: Array<TempoHasEventMafCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoHasEventMafCompletesConnectionSort = {
@@ -10678,56 +11060,56 @@ export type TempoHasEventMafCompletesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoHasEventMafCompletesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoHasEventMafCompletesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoHasEventMafCompletesNodeAggregationWhereInput>>;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  normalPrimaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  normalPrimaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  normalPrimaryId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoHasEventMafCompletesRelationship = {
   __typename?: "TempoHasEventMafCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: MafComplete;
 };
 
@@ -10748,18 +11130,18 @@ export type TempoHasEventQcCompletesAggregateInput = {
   AND?: InputMaybe<Array<TempoHasEventQcCompletesAggregateInput>>;
   NOT?: InputMaybe<TempoHasEventQcCompletesAggregateInput>;
   OR?: InputMaybe<Array<TempoHasEventQcCompletesAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoHasEventQcCompletesNodeAggregationWhereInput>;
 };
 
 export type TempoHasEventQcCompletesConnectFieldInput = {
   connect?: InputMaybe<Array<QcCompleteConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<QcCompleteConnectWhere>;
 };
 
@@ -10767,7 +11149,7 @@ export type TempoHasEventQcCompletesConnection = {
   __typename?: "TempoHasEventQcCompletesConnection";
   edges: Array<TempoHasEventQcCompletesRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoHasEventQcCompletesConnectionSort = {
@@ -10804,71 +11186,71 @@ export type TempoHasEventQcCompletesNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoHasEventQcCompletesNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoHasEventQcCompletesNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoHasEventQcCompletesNodeAggregationWhereInput>>;
-  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  reason_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  reason_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  reason_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  reason_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  reason_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  result_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  result_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  result_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  result_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  result_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  date_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  date_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  date_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  date_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  reason_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  reason_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  result_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  result_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  result_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  status_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  status_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  status_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoHasEventQcCompletesRelationship = {
   __typename?: "TempoHasEventQcCompletesRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: QcComplete;
 };
 
@@ -10887,7 +11269,7 @@ export type TempoHasEventQcCompletesUpdateFieldInput = {
 
 export type TempoMafCompleteHasEventMafCompletesAggregationSelection = {
   __typename?: "TempoMafCompleteHasEventMafCompletesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoMafCompleteHasEventMafCompletesNodeAggregateSelection>;
 };
 
@@ -10899,15 +11281,15 @@ export type TempoMafCompleteHasEventMafCompletesNodeAggregateSelection = {
 };
 
 export type TempoOptions = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
   /** Specify one or more TempoSort objects to sort Tempos by. The sorts will be applied in the order in which they are arranged in the array. */
   sort?: InputMaybe<Array<TempoSort>>;
 };
 
 export type TempoQcCompleteHasEventQcCompletesAggregationSelection = {
   __typename?: "TempoQcCompleteHasEventQcCompletesAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoQcCompleteHasEventQcCompletesNodeAggregateSelection>;
 };
 
@@ -10934,7 +11316,7 @@ export type TempoRelationInput = {
 
 export type TempoSampleSamplesHasTempoAggregationSelection = {
   __typename?: "TempoSampleSamplesHasTempoAggregationSelection";
-  count: Scalars["Int"];
+  count: Scalars["Int"]["output"];
   node?: Maybe<TempoSampleSamplesHasTempoNodeAggregateSelection>;
 };
 
@@ -10950,18 +11332,18 @@ export type TempoSamplesHasTempoAggregateInput = {
   AND?: InputMaybe<Array<TempoSamplesHasTempoAggregateInput>>;
   NOT?: InputMaybe<TempoSamplesHasTempoAggregateInput>;
   OR?: InputMaybe<Array<TempoSamplesHasTempoAggregateInput>>;
-  count?: InputMaybe<Scalars["Int"]>;
-  count_GT?: InputMaybe<Scalars["Int"]>;
-  count_GTE?: InputMaybe<Scalars["Int"]>;
-  count_LT?: InputMaybe<Scalars["Int"]>;
-  count_LTE?: InputMaybe<Scalars["Int"]>;
+  count?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  count_LTE?: InputMaybe<Scalars["Int"]["input"]>;
   node?: InputMaybe<TempoSamplesHasTempoNodeAggregationWhereInput>;
 };
 
 export type TempoSamplesHasTempoConnectFieldInput = {
   connect?: InputMaybe<Array<SampleConnectInput>>;
   /** Whether or not to overwrite any matching relationship with the new properties. */
-  overwrite?: Scalars["Boolean"];
+  overwrite?: Scalars["Boolean"]["input"];
   where?: InputMaybe<SampleConnectWhere>;
 };
 
@@ -10969,7 +11351,7 @@ export type TempoSamplesHasTempoConnection = {
   __typename?: "TempoSamplesHasTempoConnection";
   edges: Array<TempoSamplesHasTempoRelationship>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type TempoSamplesHasTempoConnectionSort = {
@@ -11006,71 +11388,71 @@ export type TempoSamplesHasTempoNodeAggregationWhereInput = {
   AND?: InputMaybe<Array<TempoSamplesHasTempoNodeAggregationWhereInput>>;
   NOT?: InputMaybe<TempoSamplesHasTempoNodeAggregationWhereInput>;
   OR?: InputMaybe<Array<TempoSamplesHasTempoNodeAggregationWhereInput>>;
-  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]>;
-  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]>;
-  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]>;
+  datasource_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  datasource_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  datasource_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleCategory_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  sampleClass_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  sampleClass_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LT?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars["Float"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_LONGEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars["Int"]["input"]>;
+  smileSampleId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type TempoSamplesHasTempoRelationship = {
   __typename?: "TempoSamplesHasTempoRelationship";
-  cursor: Scalars["String"];
+  cursor: Scalars["String"]["output"];
   node: Sample;
 };
 
@@ -11100,12 +11482,12 @@ export type TempoSort = {
 };
 
 export type TempoUpdateInput = {
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
   hasEventBamCompletes?: InputMaybe<
     Array<TempoHasEventBamCompletesUpdateFieldInput>
   >;
@@ -11115,46 +11497,48 @@ export type TempoUpdateInput = {
   hasEventQcCompletes?: InputMaybe<
     Array<TempoHasEventQcCompletesUpdateFieldInput>
   >;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasTempo?: InputMaybe<Array<TempoSamplesHasTempoUpdateFieldInput>>;
-  smileTempoId?: InputMaybe<Scalars["String"]>;
+  smileTempoId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type TempoWhere = {
   AND?: InputMaybe<Array<TempoWhere>>;
   NOT?: InputMaybe<TempoWhere>;
   OR?: InputMaybe<Array<TempoWhere>>;
-  accessLevel?: InputMaybe<Scalars["String"]>;
-  accessLevel_CONTAINS?: InputMaybe<Scalars["String"]>;
-  accessLevel_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  accessLevel_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  accessLevel_MATCHES?: InputMaybe<Scalars["String"]>;
-  accessLevel_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  billed?: InputMaybe<Scalars["Boolean"]>;
-  billedBy?: InputMaybe<Scalars["String"]>;
-  billedBy_CONTAINS?: InputMaybe<Scalars["String"]>;
-  billedBy_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  billedBy_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  billedBy_MATCHES?: InputMaybe<Scalars["String"]>;
-  billedBy_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  costCenter?: InputMaybe<Scalars["String"]>;
-  costCenter_CONTAINS?: InputMaybe<Scalars["String"]>;
-  costCenter_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  costCenter_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  costCenter_MATCHES?: InputMaybe<Scalars["String"]>;
-  costCenter_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  custodianInformation?: InputMaybe<Scalars["String"]>;
-  custodianInformation_CONTAINS?: InputMaybe<Scalars["String"]>;
-  custodianInformation_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  custodianInformation_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  custodianInformation_MATCHES?: InputMaybe<Scalars["String"]>;
-  custodianInformation_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  embargoDate?: InputMaybe<Scalars["String"]>;
-  embargoDate_CONTAINS?: InputMaybe<Scalars["String"]>;
-  embargoDate_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  embargoDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  embargoDate_MATCHES?: InputMaybe<Scalars["String"]>;
-  embargoDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  accessLevel?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  accessLevel_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  accessLevel_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  billed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billedBy?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  billedBy_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  billedBy_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  costCenter_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  costCenter_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  custodianInformation_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  custodianInformation_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  embargoDate_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  embargoDate_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   hasEventBamCompletesAggregate?: InputMaybe<TempoHasEventBamCompletesAggregateInput>;
   /** Return Tempos where all of the related TempoHasEventBamCompletesConnections match this filter */
   hasEventBamCompletesConnection_ALL?: InputMaybe<TempoHasEventBamCompletesConnectionWhere>;
@@ -11206,12 +11590,14 @@ export type TempoWhere = {
   hasEventQcCompletes_SINGLE?: InputMaybe<QcCompleteWhere>;
   /** Return Tempos where some of the related QcCompletes match this filter */
   hasEventQcCompletes_SOME?: InputMaybe<QcCompleteWhere>;
-  initialPipelineRunDate?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_CONTAINS?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  initialPipelineRunDate_MATCHES?: InputMaybe<Scalars["String"]>;
-  initialPipelineRunDate_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  initialPipelineRunDate?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_IN?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  initialPipelineRunDate_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  initialPipelineRunDate_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
   samplesHasTempoAggregate?: InputMaybe<TempoSamplesHasTempoAggregateInput>;
   /** Return Tempos where all of the related TempoSamplesHasTempoConnections match this filter */
   samplesHasTempoConnection_ALL?: InputMaybe<TempoSamplesHasTempoConnectionWhere>;
@@ -11229,26 +11615,26 @@ export type TempoWhere = {
   samplesHasTempo_SINGLE?: InputMaybe<SampleWhere>;
   /** Return Tempos where some of the related Samples match this filter */
   samplesHasTempo_SOME?: InputMaybe<SampleWhere>;
-  smileTempoId?: InputMaybe<Scalars["String"]>;
-  smileTempoId_CONTAINS?: InputMaybe<Scalars["String"]>;
-  smileTempoId_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  smileTempoId_IN?: InputMaybe<Array<Scalars["String"]>>;
-  smileTempoId_MATCHES?: InputMaybe<Scalars["String"]>;
-  smileTempoId_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  smileTempoId?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_CONTAINS?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_ENDS_WITH?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_IN?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  smileTempoId_MATCHES?: InputMaybe<Scalars["String"]["input"]>;
+  smileTempoId_STARTS_WITH?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type TemposConnection = {
   __typename?: "TemposConnection";
   edges: Array<TempoEdge>;
   pageInfo: PageInfo;
-  totalCount: Scalars["Int"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type ToleratedSampleValidationError = {
   __typename?: "ToleratedSampleValidationError";
-  primaryId: Scalars["String"];
-  validationReport?: Maybe<Scalars["String"]>;
-  validationStatus?: Maybe<Scalars["Boolean"]>;
+  primaryId: Scalars["String"]["output"];
+  validationReport?: Maybe<Scalars["String"]["output"]>;
+  validationStatus?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type UpdateBamCompletesMutationResponse = {
@@ -11279,11 +11665,11 @@ export type UpdateDbGapsMutationResponse = {
 export type UpdateInfo = {
   __typename?: "UpdateInfo";
   /** @deprecated This field has been deprecated because bookmarks are now handled by the driver. */
-  bookmark?: Maybe<Scalars["String"]>;
-  nodesCreated: Scalars["Int"];
-  nodesDeleted: Scalars["Int"];
-  relationshipsCreated: Scalars["Int"];
-  relationshipsDeleted: Scalars["Int"];
+  bookmark?: Maybe<Scalars["String"]["output"]>;
+  nodesCreated: Scalars["Int"]["output"];
+  nodesDeleted: Scalars["Int"]["output"];
+  relationshipsCreated: Scalars["Int"]["output"];
+  relationshipsDeleted: Scalars["Int"]["output"];
 };
 
 export type UpdateMafCompletesMutationResponse = {
@@ -11359,13 +11745,15 @@ export type UpdateTemposMutationResponse = {
 };
 
 export type DashboardRequestsQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
 }>;
 
 export type DashboardRequestsQuery = {
@@ -11405,14 +11793,16 @@ export type DashboardRequestsQuery = {
 };
 
 export type DashboardPatientsQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
 export type DashboardPatientsQuery = {
@@ -11436,13 +11826,15 @@ export type DashboardPatientsQuery = {
 };
 
 export type DashboardCohortsQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
 }>;
 
 export type DashboardCohortsQuery = {
@@ -11450,6 +11842,7 @@ export type DashboardCohortsQuery = {
   dashboardCohorts: Array<{
     __typename?: "DashboardCohort";
     cohortId: string;
+    cohortStatus?: string | null;
     totalSampleCount?: number | null;
     billed?: string | null;
     initialCohortDeliveryDate?: string | null;
@@ -11468,7 +11861,9 @@ export type DashboardCohortsQuery = {
 };
 
 export type DashboardSamplesQueryVariables = Exact<{
-  searchVals?: InputMaybe<Array<Scalars["String"]> | Scalars["String"]>;
+  searchVals?: InputMaybe<
+    Array<Scalars["String"]["input"]> | Scalars["String"]["input"]
+  >;
   recordContexts?: InputMaybe<
     | Array<InputMaybe<DashboardRecordContext>>
     | InputMaybe<DashboardRecordContext>
@@ -11477,10 +11872,10 @@ export type DashboardSamplesQueryVariables = Exact<{
   columnFilters?: InputMaybe<
     Array<DashboardRecordColumnFilter> | DashboardRecordColumnFilter
   >;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
-  includeDemographics?: InputMaybe<Scalars["Boolean"]>;
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  includeDemographics?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
 export type DashboardSamplesQuery = {
@@ -11559,10 +11954,10 @@ export type DashboardSamplesQuery = {
 };
 
 export type DashboardSampleHistoryQueryVariables = Exact<{
-  searchVals: Array<Scalars["String"]> | Scalars["String"];
+  searchVals: Array<Scalars["String"]["input"]> | Scalars["String"]["input"];
   sort: DashboardRecordSort;
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars["Int"]["input"];
+  offset: Scalars["Int"]["input"];
 }>;
 
 export type DashboardSampleHistoryQuery = {
@@ -11824,7 +12219,7 @@ export type AllBlockedCohortIdsQuery = {
 };
 
 export type AllAnchorSeqDateDataQueryVariables = Exact<{
-  phiEnabled?: InputMaybe<Scalars["Boolean"]>;
+  phiEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
 export type AllAnchorSeqDateDataQuery = {
@@ -12101,6 +12496,7 @@ export const DashboardCohortsDocument = gql`
       offset: $offset
     ) {
       cohortId
+      cohortStatus
       totalSampleCount
       billed
       initialCohortDeliveryDate

--- a/graphql-server/src/schemas/queries/cohorts.ts
+++ b/graphql-server/src/schemas/queries/cohorts.ts
@@ -24,6 +24,7 @@ const FIELDS_TO_SEARCH = [
   "type",
   "searchableSampleIds", // hidden searchable field,
   "pipelineVersion",
+  "cohortStatus",
 ];
 
 export function buildCohortsQueryBody({
@@ -127,7 +128,8 @@ export function buildCohortsQueryBody({
       totalSampleCount: totalSampleCount,
       searchableSampleIds: apoc.text.join(searchableSampleIds, ","),
       billed: billed,
-      initialCohortDeliveryDate: initialCohortDeliveryDate
+      initialCohortDeliveryDate: initialCohortDeliveryDate,
+      cohortStatus: c.cohortStatus
     }) as tempNode,
     COLLECT {
       MATCH (c)-[:HAS_COHORT_COMPLETE]->(cc: CohortComplete)

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -172,6 +172,7 @@ const QUERY_RESULT_TYPEDEFS = gql`
 
   type DashboardCohort {
     cohortId: String!
+    cohortStatus: String
     totalSampleCount: Int
     billed: String
     initialCohortDeliveryDate: String
@@ -299,6 +300,7 @@ const MUTATION_TYPEDEFS = gql`
   input DashboardCohortInput {
     changedFieldNames: [String!]!
     cohortId: String!
+    cohortStatus: String
     totalSampleCount: Int
     billed: String
     initialCohortDeliveryDate: String

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1,10 +1,12 @@
 {
   "__schema": {
     "queryType": {
-      "name": "Query"
+      "name": "Query",
+      "kind": "OBJECT"
     },
     "mutationType": {
-      "name": "Mutation"
+      "name": "Mutation",
+      "kind": "OBJECT"
     },
     "subscriptionType": null,
     "types": [
@@ -12,6 +14,7 @@
         "kind": "ENUM",
         "name": "AgGridSortDirection",
         "description": null,
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -35,6 +38,7 @@
         "kind": "OBJECT",
         "name": "AnchorSeqDateData",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "ANCHOR_ONCOTREE_CODE",
@@ -44,8 +48,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -60,8 +64,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -76,8 +80,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -92,8 +96,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -110,6 +114,7 @@
         "kind": "OBJECT",
         "name": "BamComplete",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -119,8 +124,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -135,8 +140,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -188,14 +193,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Tempo",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -288,11 +293,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "BamCompleteTemposHasEventConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -318,8 +323,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BamCompleteTemposHasEventConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -336,6 +341,7 @@
         "kind": "OBJECT",
         "name": "BamCompleteAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -345,8 +351,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -361,8 +367,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -377,8 +383,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -395,6 +401,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -404,11 +411,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -426,6 +433,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -435,8 +443,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "BamCompleteWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -453,6 +461,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -462,8 +471,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -478,8 +487,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -508,6 +517,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -517,11 +527,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -539,6 +549,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -548,11 +559,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -570,6 +581,7 @@
         "kind": "OBJECT",
         "name": "BamCompleteEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -579,8 +591,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -595,8 +607,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BamComplete",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -613,6 +625,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -646,11 +659,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -668,6 +681,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -677,11 +691,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -699,6 +713,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteSort",
         "description": "Fields to sort BamCompletes by. The order in which sorts are applied is not guaranteed when specifying many fields in one BamCompleteSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -734,6 +749,7 @@
         "kind": "OBJECT",
         "name": "BamCompleteTempoTemposHasEventAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -743,8 +759,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -773,6 +789,7 @@
         "kind": "OBJECT",
         "name": "BamCompleteTempoTemposHasEventNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "accessLevel",
@@ -782,8 +799,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -798,8 +815,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -814,8 +831,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -830,8 +847,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -846,8 +863,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -862,8 +879,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -878,8 +895,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -896,6 +913,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -905,11 +923,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -937,11 +955,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -1031,6 +1049,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1040,11 +1059,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -1060,8 +1079,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -1090,6 +1109,7 @@
         "kind": "OBJECT",
         "name": "BamCompleteTemposHasEventConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -1099,14 +1119,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "BamCompleteTemposHasEventRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -1123,8 +1143,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -1139,8 +1159,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -1157,6 +1177,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1180,6 +1201,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1189,11 +1211,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -1221,11 +1243,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -1255,6 +1277,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1264,8 +1287,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "TempoCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -1282,6 +1305,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1317,6 +1341,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1352,6 +1377,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1361,11 +1387,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -1381,11 +1407,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -1403,6 +1429,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -1412,11 +1439,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -1444,11 +1471,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -2726,6 +2753,7 @@
         "kind": "OBJECT",
         "name": "BamCompleteTemposHasEventRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -2735,8 +2763,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -2751,8 +2779,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Tempo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -2769,6 +2797,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -2792,6 +2821,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteTemposHasEventUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -2801,11 +2831,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -2821,11 +2851,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -2841,11 +2871,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -2861,11 +2891,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -2907,6 +2937,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -2940,11 +2971,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteTemposHasEventUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -2962,6 +2993,7 @@
         "kind": "INPUT_OBJECT",
         "name": "BamCompleteWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -2971,11 +3003,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -3003,11 +3035,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -3059,11 +3091,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -3139,11 +3171,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -3293,6 +3325,7 @@
         "kind": "OBJECT",
         "name": "BamCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -3302,14 +3335,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "BamCompleteEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -3326,8 +3359,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -3342,8 +3375,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -3360,6 +3393,7 @@
         "kind": "SCALAR",
         "name": "BigInt",
         "description": "A BigInt value up to 64 bits in size, which can be a number or a string if used inline, or a string only if used as a variable. Always returned as a string.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -3370,6 +3404,7 @@
         "kind": "OBJECT",
         "name": "BigIntAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "average",
@@ -3429,6 +3464,7 @@
         "kind": "SCALAR",
         "name": "Boolean",
         "description": "The `Boolean` scalar type represents `true` or `false`.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -3439,6 +3475,7 @@
         "kind": "OBJECT",
         "name": "Cohort",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortId",
@@ -3448,8 +3485,24 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -3501,14 +3554,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "CohortComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -3601,11 +3654,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "CohortHasCohortCompleteCohortCompletesConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -3631,8 +3684,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CohortHasCohortCompleteCohortCompletesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -3684,14 +3737,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Sample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -3784,11 +3837,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "CohortHasCohortSampleSamplesConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -3814,8 +3867,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CohortHasCohortSampleSamplesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -3832,6 +3885,7 @@
         "kind": "OBJECT",
         "name": "CohortAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortId",
@@ -3841,8 +3895,24 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -3857,8 +3927,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -3875,6 +3945,7 @@
         "kind": "OBJECT",
         "name": "CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -3884,8 +3955,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -3914,6 +3985,7 @@
         "kind": "OBJECT",
         "name": "CohortCohortCompleteHasCohortCompleteCohortCompletesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -3923,8 +3995,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -3939,8 +4011,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -3955,8 +4027,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BigIntAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -3971,8 +4043,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -3987,8 +4059,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4003,8 +4075,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4019,8 +4091,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4035,8 +4107,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4051,8 +4123,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4069,6 +4141,7 @@
         "kind": "OBJECT",
         "name": "CohortComplete",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortsHasCohortComplete",
@@ -4115,14 +4188,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Cohort",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -4215,11 +4288,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "CohortCompleteCohortsHasCohortCompleteConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -4245,8 +4318,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CohortCompleteCohortsHasCohortCompleteConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4258,13 +4331,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4277,8 +4346,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -4293,8 +4362,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "BigInt",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -4321,8 +4390,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -4337,8 +4406,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -4353,8 +4422,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -4366,13 +4435,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4385,8 +4450,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -4403,6 +4468,7 @@
         "kind": "OBJECT",
         "name": "CohortCompleteAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -4412,8 +4478,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -4428,8 +4494,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4444,8 +4510,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4460,8 +4526,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BigIntAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4476,8 +4542,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4492,8 +4558,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4508,8 +4574,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4524,8 +4590,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4540,8 +4606,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4556,8 +4622,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4574,6 +4640,7 @@
         "kind": "OBJECT",
         "name": "CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -4583,8 +4650,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -4613,6 +4680,7 @@
         "kind": "OBJECT",
         "name": "CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortId",
@@ -4622,8 +4690,24 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4640,6 +4724,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -4649,11 +4734,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -4681,11 +4766,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -4775,6 +4860,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -4784,11 +4870,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -4804,8 +4890,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -4834,6 +4920,7 @@
         "kind": "OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -4843,14 +4930,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "CohortCompleteCohortsHasCohortCompleteRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -4867,8 +4954,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -4883,8 +4970,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -4901,6 +4988,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -4924,6 +5012,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -4933,11 +5022,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -4965,11 +5054,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -4999,6 +5088,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5008,8 +5098,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "CohortCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -5026,6 +5116,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5061,6 +5152,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5096,6 +5188,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5105,11 +5198,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5125,11 +5218,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5147,6 +5240,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5156,11 +5250,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5188,11 +5282,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5380,6 +5474,186 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -5390,6 +5664,7 @@
         "kind": "OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -5399,8 +5674,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -5415,8 +5690,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Cohort",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -5433,6 +5708,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5456,6 +5732,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCohortsHasCohortCompleteUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5465,11 +5742,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5485,11 +5762,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5505,11 +5782,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5525,11 +5802,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5571,6 +5848,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5580,11 +5858,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5602,6 +5880,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5611,8 +5890,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "CohortCompleteWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -5629,6 +5908,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5647,13 +5927,9 @@
             "name": "date",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -5666,8 +5942,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -5682,8 +5958,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "BigInt",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -5710,8 +5986,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -5726,8 +6002,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -5742,8 +6018,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -5755,13 +6031,9 @@
             "name": "status",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -5774,8 +6046,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -5792,6 +6064,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5801,11 +6074,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5823,6 +6096,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5832,11 +6106,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5854,6 +6128,7 @@
         "kind": "OBJECT",
         "name": "CohortCompleteEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -5863,8 +6138,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -5879,8 +6154,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CohortComplete",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -5897,6 +6172,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5930,11 +6206,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5952,6 +6228,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -5961,11 +6238,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -5983,6 +6260,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteSort",
         "description": "Fields to sort CohortCompletes by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortCompleteSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -6102,6 +6380,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -6111,11 +6390,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteCohortsHasCohortCompleteUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -6265,6 +6544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCompleteWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -6274,11 +6554,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -6306,11 +6586,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -6470,13 +6750,9 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "name": "String",
+                "kind": "SCALAR",
+                "ofType": null
               }
             },
             "defaultValue": null,
@@ -6550,11 +6826,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -6630,11 +6906,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "BigInt",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -6710,8 +6986,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -6786,11 +7062,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -6866,11 +7142,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -6946,11 +7222,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -7026,13 +7302,9 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "name": "String",
+                "kind": "SCALAR",
+                "ofType": null
               }
             },
             "defaultValue": null,
@@ -7106,11 +7378,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -7152,6 +7424,7 @@
         "kind": "OBJECT",
         "name": "CohortCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -7161,14 +7434,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "CohortCompleteEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -7185,8 +7458,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -7201,8 +7474,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -7219,6 +7492,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7228,11 +7502,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -7248,11 +7522,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -7270,6 +7544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7279,8 +7554,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "CohortWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -7297,6 +7572,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7306,8 +7582,24 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -7348,6 +7640,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7357,11 +7650,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -7377,11 +7670,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -7399,6 +7692,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7408,11 +7702,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -7428,11 +7722,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -7450,6 +7744,7 @@
         "kind": "OBJECT",
         "name": "CohortEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -7459,8 +7754,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -7475,8 +7770,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Cohort",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -7493,6 +7788,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7502,11 +7798,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -7534,11 +7830,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -7628,6 +7924,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7637,11 +7934,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortCompleteConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -7657,8 +7954,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -7687,6 +7984,7 @@
         "kind": "OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -7696,14 +7994,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "CohortHasCohortCompleteCohortCompletesRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -7720,8 +8018,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -7736,8 +8034,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -7754,6 +8052,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7777,6 +8076,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7786,11 +8086,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -7818,11 +8118,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -7852,6 +8152,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7861,8 +8162,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "CohortCompleteCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -7879,6 +8180,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7914,6 +8216,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7949,6 +8252,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -7958,11 +8262,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -7978,11 +8282,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -8000,6 +8304,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -8009,11 +8314,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -8041,11 +8346,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -9743,6 +10048,7 @@
         "kind": "OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -9752,8 +10058,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -9768,8 +10074,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CohortComplete",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -9786,6 +10092,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -9809,6 +10116,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortCompleteCohortCompletesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -9818,11 +10126,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -9838,11 +10146,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -9858,11 +10166,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -9878,11 +10186,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -9924,6 +10232,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -9933,11 +10242,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -9965,11 +10274,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -10059,6 +10368,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10068,11 +10378,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -10088,8 +10398,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -10118,6 +10428,7 @@
         "kind": "OBJECT",
         "name": "CohortHasCohortSampleSamplesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -10127,14 +10438,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "CohortHasCohortSampleSamplesRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -10151,8 +10462,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -10167,8 +10478,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -10185,6 +10496,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10208,6 +10520,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10217,11 +10530,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -10249,11 +10562,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -10283,6 +10596,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10292,8 +10606,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -10310,6 +10624,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10345,6 +10660,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10380,6 +10696,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10389,11 +10706,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -10409,11 +10726,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -10431,6 +10748,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -10440,11 +10758,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -10472,11 +10790,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -11214,6 +11532,7 @@
         "kind": "OBJECT",
         "name": "CohortHasCohortSampleSamplesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -11223,8 +11542,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -11239,8 +11558,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Sample",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -11257,6 +11576,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -11280,6 +11600,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortHasCohortSampleSamplesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -11289,11 +11610,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -11309,11 +11630,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -11329,11 +11650,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -11349,11 +11670,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -11395,6 +11716,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -11428,11 +11750,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -11450,6 +11772,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -11459,11 +11782,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -11479,11 +11802,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -11501,6 +11824,7 @@
         "kind": "OBJECT",
         "name": "CohortSampleHasCohortSampleSamplesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -11510,8 +11834,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -11540,6 +11864,7 @@
         "kind": "OBJECT",
         "name": "CohortSampleHasCohortSampleSamplesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -11549,8 +11874,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -11565,8 +11890,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -11581,8 +11906,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -11597,8 +11922,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -11615,10 +11940,23 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortSort",
         "description": "Fields to sort Cohorts by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
             "name": "cohortId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -11638,10 +11976,23 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
             "name": "cohortId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -11659,11 +12010,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortCompleteCohortCompletesUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -11679,11 +12030,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortHasCohortSampleSamplesUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -11701,6 +12052,7 @@
         "kind": "INPUT_OBJECT",
         "name": "CohortWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -11710,11 +12062,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -11742,11 +12094,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -11798,11 +12150,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -11825,6 +12177,86 @@
           },
           {
             "name": "cohortId_STARTS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_CONTAINS",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_ENDS_WITH",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_IN",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "name": null,
+                "kind": "NON_NULL",
+                "ofType": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_MATCHES",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_STARTS_WITH",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -12060,6 +12492,7 @@
         "kind": "OBJECT",
         "name": "CohortsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -12069,14 +12502,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "CohortEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12093,8 +12526,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12109,8 +12542,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -12127,6 +12560,7 @@
         "kind": "OBJECT",
         "name": "CreateBamCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "bamCompletes",
@@ -12136,14 +12570,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "BamComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12160,8 +12594,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12178,6 +12612,7 @@
         "kind": "OBJECT",
         "name": "CreateCohortCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortCompletes",
@@ -12187,14 +12622,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "CohortComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12211,8 +12646,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12229,6 +12664,7 @@
         "kind": "OBJECT",
         "name": "CreateCohortsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohorts",
@@ -12238,14 +12674,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Cohort",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12262,8 +12698,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12280,6 +12716,7 @@
         "kind": "OBJECT",
         "name": "CreateDbGapsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dbGaps",
@@ -12289,14 +12726,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "DbGap",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12313,8 +12750,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12331,6 +12768,7 @@
         "kind": "OBJECT",
         "name": "CreateInfo",
         "description": "Information about the number of nodes and relationships created during a create mutation",
+        "isOneOf": null,
         "fields": [
           {
             "name": "bookmark",
@@ -12352,8 +12790,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -12368,8 +12806,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -12386,6 +12824,7 @@
         "kind": "OBJECT",
         "name": "CreateMafCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12395,8 +12834,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12411,14 +12850,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "MafComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12437,6 +12876,7 @@
         "kind": "OBJECT",
         "name": "CreatePatientAliasesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12446,8 +12886,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12462,14 +12902,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "PatientAlias",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12488,6 +12928,7 @@
         "kind": "OBJECT",
         "name": "CreatePatientsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12497,8 +12938,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12513,14 +12954,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Patient",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12539,6 +12980,7 @@
         "kind": "OBJECT",
         "name": "CreateProjectsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12548,8 +12990,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12564,14 +13006,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Project",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12590,6 +13032,7 @@
         "kind": "OBJECT",
         "name": "CreateQcCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12599,8 +13042,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12615,14 +13058,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "QcComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12641,6 +13084,7 @@
         "kind": "OBJECT",
         "name": "CreateRequestMetadataMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12650,8 +13094,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12666,14 +13110,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "RequestMetadata",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12692,6 +13136,7 @@
         "kind": "OBJECT",
         "name": "CreateRequestsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12701,8 +13146,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12717,14 +13162,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Request",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12743,6 +13188,7 @@
         "kind": "OBJECT",
         "name": "CreateSampleAliasesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12752,8 +13198,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12768,14 +13214,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleAlias",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12794,6 +13240,7 @@
         "kind": "OBJECT",
         "name": "CreateSampleMetadataMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12803,8 +13250,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12819,14 +13266,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleMetadata",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12845,6 +13292,7 @@
         "kind": "OBJECT",
         "name": "CreateSamplesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12854,8 +13302,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12870,14 +13318,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Sample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12896,6 +13344,7 @@
         "kind": "OBJECT",
         "name": "CreateStatusesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12905,8 +13354,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12921,14 +13370,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Status",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12947,6 +13396,7 @@
         "kind": "OBJECT",
         "name": "CreateTemposMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -12956,8 +13406,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -12972,14 +13422,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Tempo",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -12998,6 +13448,7 @@
         "kind": "OBJECT",
         "name": "DashboardCohort",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "_total",
@@ -13043,10 +13494,22 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -13193,6 +13656,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DashboardCohortInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -13238,14 +13702,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "String",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 }
@@ -13274,10 +13738,22 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -13424,6 +13900,7 @@
         "kind": "OBJECT",
         "name": "DashboardPatient",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "_total",
@@ -13565,8 +14042,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -13595,6 +14072,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DashboardRecordColumnFilter",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -13604,8 +14082,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -13620,8 +14098,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -13638,6 +14116,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DashboardRecordContext",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -13659,14 +14138,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "String",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 }
@@ -13685,6 +14164,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DashboardRecordSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -13694,8 +14174,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -13710,8 +14190,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "ENUM",
                 "name": "AgGridSortDirection",
+                "kind": "ENUM",
                 "ofType": null
               }
             },
@@ -13728,6 +14208,7 @@
         "kind": "OBJECT",
         "name": "DashboardRequest",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "_total",
@@ -13833,8 +14314,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -13981,8 +14462,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "ToleratedSampleValidationError",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -14035,6 +14516,7 @@
         "kind": "OBJECT",
         "name": "DashboardSample",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "_total",
@@ -14356,8 +14838,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "IgoQcReport",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -14612,8 +15094,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -14640,8 +15122,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -14728,8 +15210,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -14806,6 +15288,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DashboardSampleInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -14959,14 +15442,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "String",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 }
@@ -15391,8 +15874,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -15419,8 +15902,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -15507,8 +15990,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -15585,6 +16068,7 @@
         "kind": "OBJECT",
         "name": "DbGap",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dbGapStudy",
@@ -15594,8 +16078,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -15647,14 +16131,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Sample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -15747,11 +16231,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "DbGapSamplesHasDbgapConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -15777,8 +16261,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DbGapSamplesHasDbgapConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -15793,8 +16277,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -15811,6 +16295,7 @@
         "kind": "OBJECT",
         "name": "DbGapAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -15820,8 +16305,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -15836,8 +16321,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -15852,8 +16337,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -15870,6 +16355,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -15879,11 +16365,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -15901,6 +16387,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -15910,8 +16397,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "DbGapWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -15928,6 +16415,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -15937,8 +16425,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -15965,8 +16453,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -15983,6 +16471,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -15992,11 +16481,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -16014,6 +16503,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16023,11 +16513,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -16045,6 +16535,7 @@
         "kind": "OBJECT",
         "name": "DbGapEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -16054,8 +16545,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -16070,8 +16561,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DbGap",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -16088,6 +16579,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16121,11 +16613,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -16143,6 +16635,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16152,11 +16645,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -16174,6 +16667,7 @@
         "kind": "OBJECT",
         "name": "DbGapSampleSamplesHasDbgapAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -16183,8 +16677,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -16213,6 +16707,7 @@
         "kind": "OBJECT",
         "name": "DbGapSampleSamplesHasDbgapNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -16222,8 +16717,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -16238,8 +16733,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -16254,8 +16749,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -16270,8 +16765,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -16288,6 +16783,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16297,11 +16793,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -16329,11 +16825,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -16423,6 +16919,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16432,11 +16929,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -16452,8 +16949,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -16482,6 +16979,7 @@
         "kind": "OBJECT",
         "name": "DbGapSamplesHasDbgapConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -16491,14 +16989,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "DbGapSamplesHasDbgapRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -16515,8 +17013,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -16531,8 +17029,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -16549,6 +17047,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16572,6 +17071,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16581,11 +17081,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -16613,11 +17113,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -16647,6 +17147,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16656,8 +17157,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -16674,6 +17175,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16709,6 +17211,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16744,6 +17247,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16753,11 +17257,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -16773,11 +17277,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -16795,6 +17299,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -16804,11 +17309,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -16836,11 +17341,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -17578,6 +18083,7 @@
         "kind": "OBJECT",
         "name": "DbGapSamplesHasDbgapRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -17587,8 +18093,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -17603,8 +18109,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Sample",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -17621,6 +18127,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -17644,6 +18151,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSamplesHasDbgapUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -17653,11 +18161,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -17673,11 +18181,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -17693,11 +18201,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -17713,11 +18221,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -17759,6 +18267,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapSort",
         "description": "Fields to sort DbGaps by. The order in which sorts are applied is not guaranteed when specifying many fields in one DbGapSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -17794,6 +18303,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -17815,11 +18325,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapSamplesHasDbgapUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -17849,6 +18359,7 @@
         "kind": "INPUT_OBJECT",
         "name": "DbGapWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -17858,11 +18369,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -17890,11 +18401,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -17946,11 +18457,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -18134,11 +18645,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -18180,6 +18691,7 @@
         "kind": "OBJECT",
         "name": "DbGapsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -18189,14 +18701,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "DbGapEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -18213,8 +18725,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -18229,8 +18741,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -18247,6 +18759,7 @@
         "kind": "OBJECT",
         "name": "DeleteInfo",
         "description": "Information about the number of nodes and relationships deleted during a delete mutation",
+        "isOneOf": null,
         "fields": [
           {
             "name": "bookmark",
@@ -18268,8 +18781,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -18284,8 +18797,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -18302,6 +18815,7 @@
         "kind": "SCALAR",
         "name": "Float",
         "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -18312,6 +18826,7 @@
         "kind": "OBJECT",
         "name": "IgoQcReport",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "IGORecommendation",
@@ -18371,6 +18886,7 @@
         "kind": "SCALAR",
         "name": "Int",
         "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -18381,6 +18897,7 @@
         "kind": "OBJECT",
         "name": "MafComplete",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -18390,8 +18907,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -18406,8 +18923,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -18422,8 +18939,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -18475,14 +18992,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Tempo",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -18575,11 +19092,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "MafCompleteTemposHasEventConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -18605,8 +19122,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "MafCompleteTemposHasEventConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -18623,6 +19140,7 @@
         "kind": "OBJECT",
         "name": "MafCompleteAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -18632,8 +19150,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -18648,8 +19166,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -18664,8 +19182,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -18680,8 +19198,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -18698,6 +19216,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18707,11 +19226,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -18729,6 +19248,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18738,8 +19258,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "MafCompleteWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -18756,6 +19276,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18765,8 +19286,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -18781,8 +19302,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -18797,8 +19318,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -18827,6 +19348,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18836,11 +19358,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -18858,6 +19380,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18867,11 +19390,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -18889,6 +19412,7 @@
         "kind": "OBJECT",
         "name": "MafCompleteEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -18898,8 +19422,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -18914,8 +19438,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "MafComplete",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -18932,6 +19456,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18965,11 +19490,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -18987,6 +19512,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -18996,11 +19522,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -19018,6 +19544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteSort",
         "description": "Fields to sort MafCompletes by. The order in which sorts are applied is not guaranteed when specifying many fields in one MafCompleteSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19065,6 +19592,7 @@
         "kind": "OBJECT",
         "name": "MafCompleteTempoTemposHasEventAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -19074,8 +19602,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -19104,6 +19632,7 @@
         "kind": "OBJECT",
         "name": "MafCompleteTempoTemposHasEventNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "accessLevel",
@@ -19113,8 +19642,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -19129,8 +19658,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -19145,8 +19674,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -19161,8 +19690,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -19177,8 +19706,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -19193,8 +19722,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -19209,8 +19738,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -19227,6 +19756,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19236,11 +19766,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -19268,11 +19798,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -19362,6 +19892,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19371,11 +19902,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -19391,8 +19922,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -19421,6 +19952,7 @@
         "kind": "OBJECT",
         "name": "MafCompleteTemposHasEventConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -19430,14 +19962,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "MafCompleteTemposHasEventRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -19454,8 +19986,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -19470,8 +20002,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -19488,6 +20020,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19511,6 +20044,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19520,11 +20054,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -19552,11 +20086,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -19586,6 +20120,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19595,8 +20130,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "TempoCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -19613,6 +20148,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19648,6 +20184,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19683,6 +20220,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19692,11 +20230,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -19712,11 +20250,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -19734,6 +20272,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -19743,11 +20282,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -19775,11 +20314,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -21057,6 +21596,7 @@
         "kind": "OBJECT",
         "name": "MafCompleteTemposHasEventRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -21066,8 +21606,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -21082,8 +21622,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Tempo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -21100,6 +21640,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -21123,6 +21664,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteTemposHasEventUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -21132,11 +21674,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -21152,11 +21694,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -21172,11 +21714,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -21192,11 +21734,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -21238,6 +21780,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -21283,11 +21826,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteTemposHasEventUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -21305,6 +21848,7 @@
         "kind": "INPUT_OBJECT",
         "name": "MafCompleteWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -21314,11 +21858,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -21346,11 +21890,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -21402,11 +21946,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -21482,11 +22026,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -21562,11 +22106,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -21716,6 +22260,7 @@
         "kind": "OBJECT",
         "name": "MafCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -21725,14 +22270,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "MafCompleteEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -21749,8 +22294,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -21765,8 +22310,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -21783,6 +22328,7 @@
         "kind": "OBJECT",
         "name": "Mutation",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "createBamCompletes",
@@ -21795,14 +22341,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "BamCompleteCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -21817,8 +22363,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateBamCompletesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -21836,14 +22382,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "CohortCompleteCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -21858,8 +22404,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateCohortCompletesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -21877,14 +22423,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "CohortCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -21899,8 +22445,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateCohortsMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -21918,14 +22464,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "DbGapCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -21940,8 +22486,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateDbGapsMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -21959,14 +22505,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "MafCompleteCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -21981,8 +22527,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateMafCompletesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22000,14 +22546,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "PatientAliasCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -22022,8 +22568,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreatePatientAliasesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22041,14 +22587,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "PatientCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -22063,8 +22609,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreatePatientsMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22082,14 +22628,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "ProjectCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -22104,8 +22650,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateProjectsMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22123,14 +22669,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "QcCompleteCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -22145,8 +22691,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateQcCompletesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22164,14 +22710,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "RequestMetadataCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -22186,8 +22732,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateRequestMetadataMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22205,14 +22751,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "RequestCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -22227,8 +22773,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateRequestsMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22246,14 +22792,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "SampleAliasCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -22268,8 +22814,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateSampleAliasesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22287,14 +22833,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "SampleMetadataCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -22309,8 +22855,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateSampleMetadataMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22328,14 +22874,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "SampleCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -22350,8 +22896,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateSamplesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22369,14 +22915,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "StatusCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -22391,8 +22937,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateStatusesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22410,14 +22956,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
                         "name": "TempoCreateInput",
+                        "kind": "INPUT_OBJECT",
                         "ofType": null
                       }
                     }
@@ -22432,8 +22978,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CreateTemposMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22473,8 +23019,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22514,8 +23060,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22555,8 +23101,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22596,8 +23142,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22637,8 +23183,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22678,8 +23224,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22719,8 +23265,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22760,8 +23306,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22801,8 +23347,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22842,8 +23388,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22883,8 +23429,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22924,8 +23470,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -22965,8 +23511,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23006,8 +23552,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23047,8 +23593,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23088,8 +23634,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DeleteInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23154,8 +23700,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateBamCompletesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23195,8 +23741,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateCohortCompletesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23236,8 +23782,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateCohortsMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23255,8 +23801,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "DashboardSampleInput",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -23269,8 +23815,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DashboardSample",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23310,8 +23856,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateDbGapsMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23351,8 +23897,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateMafCompletesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23392,8 +23938,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdatePatientAliasesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23433,8 +23979,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdatePatientsMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23474,8 +24020,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateProjectsMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23515,8 +24061,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateQcCompletesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23556,8 +24102,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateRequestMetadataMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23597,8 +24143,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateRequestsMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23638,8 +24184,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateSampleAliasesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23679,8 +24225,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateSampleMetadataMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23720,8 +24266,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateSamplesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23761,8 +24307,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateStatusesMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23827,8 +24373,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateTemposMutationResponse",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -23845,6 +24391,7 @@
         "kind": "OBJECT",
         "name": "PageInfo",
         "description": "Pagination information (Relay)",
+        "isOneOf": null,
         "fields": [
           {
             "name": "endCursor",
@@ -23866,8 +24413,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -23882,8 +24429,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -23912,6 +24459,7 @@
         "kind": "OBJECT",
         "name": "Patient",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "hasSampleSamples",
@@ -23958,14 +24506,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Sample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -24058,11 +24606,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "PatientHasSampleSamplesConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -24088,8 +24636,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PatientHasSampleSamplesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -24141,14 +24689,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "PatientAlias",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -24241,11 +24789,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "PatientPatientAliasesIsAliasConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -24271,8 +24819,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PatientPatientAliasesIsAliasConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -24287,8 +24835,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -24305,6 +24853,7 @@
         "kind": "OBJECT",
         "name": "PatientAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -24314,8 +24863,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -24330,8 +24879,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -24348,6 +24897,7 @@
         "kind": "OBJECT",
         "name": "PatientAlias",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "isAliasPatients",
@@ -24394,14 +24944,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Patient",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -24494,11 +25044,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "PatientAliasIsAliasPatientsConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -24524,8 +25074,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PatientAliasIsAliasPatientsConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -24540,8 +25090,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -24556,8 +25106,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -24574,6 +25124,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -24583,8 +25134,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -24599,8 +25150,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -24615,8 +25166,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -24633,6 +25184,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24642,11 +25194,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -24664,6 +25216,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24673,8 +25226,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "PatientAliasWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -24691,6 +25244,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24712,8 +25266,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -24728,8 +25282,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -24746,6 +25300,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24755,11 +25310,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -24777,6 +25332,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24786,11 +25342,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -24808,6 +25364,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -24817,8 +25374,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -24833,8 +25390,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PatientAlias",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -24851,6 +25408,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24860,11 +25418,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -24892,11 +25450,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -24986,6 +25544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -24995,11 +25554,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25015,8 +25574,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -25045,6 +25604,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasIsAliasPatientsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -25054,14 +25614,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "PatientAliasIsAliasPatientsRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -25078,8 +25638,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -25094,8 +25654,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -25112,6 +25672,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25135,6 +25696,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25144,11 +25706,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25176,11 +25738,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25210,6 +25772,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25219,8 +25782,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "PatientCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -25237,6 +25800,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25272,6 +25836,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25307,6 +25872,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25316,11 +25882,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25336,11 +25902,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25358,6 +25924,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25367,11 +25934,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25399,11 +25966,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25601,6 +26168,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasIsAliasPatientsRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -25610,8 +26178,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -25626,8 +26194,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Patient",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -25644,6 +26212,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25667,6 +26236,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasIsAliasPatientsUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25676,11 +26246,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25696,11 +26266,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25716,11 +26286,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25736,11 +26306,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25782,6 +26352,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25815,11 +26386,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25837,6 +26408,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasPatientIsAliasPatientsAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -25846,8 +26418,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -25876,6 +26448,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasPatientIsAliasPatientsNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "smilePatientId",
@@ -25885,8 +26458,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -25903,6 +26476,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25912,11 +26486,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -25934,6 +26508,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasSort",
         "description": "Fields to sort PatientAliases by. The order in which sorts are applied is not guaranteed when specifying many fields in one PatientAliasSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25969,6 +26544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -25978,11 +26554,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasIsAliasPatientsUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -26024,6 +26600,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientAliasWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26033,11 +26610,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -26065,11 +26642,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -26229,11 +26806,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -26309,11 +26886,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -26355,6 +26932,7 @@
         "kind": "OBJECT",
         "name": "PatientAliasesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -26364,14 +26942,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "PatientAliasEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -26388,8 +26966,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -26404,8 +26982,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -26422,6 +27000,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26431,11 +27010,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -26451,11 +27030,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -26473,6 +27052,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26482,8 +27062,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "PatientWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -26500,6 +27080,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26533,8 +27114,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -26551,6 +27132,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26560,11 +27142,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -26580,11 +27162,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -26602,6 +27184,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26611,11 +27194,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -26631,11 +27214,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -26653,6 +27236,7 @@
         "kind": "OBJECT",
         "name": "PatientEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -26662,8 +27246,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -26678,8 +27262,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Patient",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -26696,6 +27280,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26705,11 +27290,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -26737,11 +27322,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -26831,6 +27416,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26840,11 +27426,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -26860,8 +27446,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -26890,6 +27476,7 @@
         "kind": "OBJECT",
         "name": "PatientHasSampleSamplesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -26899,14 +27486,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "PatientHasSampleSamplesRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -26923,8 +27510,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -26939,8 +27526,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -26957,6 +27544,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26980,6 +27568,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -26989,11 +27578,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -27021,11 +27610,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -27055,6 +27644,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -27064,8 +27654,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -27082,6 +27672,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -27117,6 +27708,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -27152,6 +27744,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -27161,11 +27754,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -27181,11 +27774,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -27203,6 +27796,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -27212,11 +27806,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -27244,11 +27838,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -27986,6 +28580,7 @@
         "kind": "OBJECT",
         "name": "PatientHasSampleSamplesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -27995,8 +28590,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -28011,8 +28606,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Sample",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -28029,6 +28624,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28052,6 +28648,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientHasSampleSamplesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28061,11 +28658,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28081,11 +28678,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28101,11 +28698,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28121,11 +28718,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28167,6 +28764,7 @@
         "kind": "OBJECT",
         "name": "PatientIdsTriplet",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "CMO_PATIENT_ID",
@@ -28176,8 +28774,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -28204,8 +28802,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -28234,6 +28832,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28267,11 +28866,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28289,6 +28888,7 @@
         "kind": "OBJECT",
         "name": "PatientPatientAliasPatientAliasesIsAliasAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -28298,8 +28898,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -28328,6 +28928,7 @@
         "kind": "OBJECT",
         "name": "PatientPatientAliasPatientAliasesIsAliasNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "namespace",
@@ -28337,8 +28938,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -28353,8 +28954,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -28371,6 +28972,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28380,11 +28982,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28412,11 +29014,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28506,6 +29108,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28515,11 +29118,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientAliasConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28535,8 +29138,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -28565,6 +29168,7 @@
         "kind": "OBJECT",
         "name": "PatientPatientAliasesIsAliasConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -28574,14 +29178,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "PatientPatientAliasesIsAliasRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -28598,8 +29202,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -28614,8 +29218,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -28632,6 +29236,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28655,6 +29260,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28664,11 +29270,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28696,11 +29302,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28730,6 +29336,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28739,8 +29346,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "PatientAliasCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -28757,6 +29364,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28792,6 +29400,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28827,6 +29436,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28836,11 +29446,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28856,11 +29466,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28878,6 +29488,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -28887,11 +29498,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -28919,11 +29530,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -29301,6 +29912,7 @@
         "kind": "OBJECT",
         "name": "PatientPatientAliasesIsAliasRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -29310,8 +29922,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -29326,8 +29938,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PatientAlias",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -29344,6 +29956,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -29367,6 +29980,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientPatientAliasesIsAliasUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -29376,11 +29990,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -29396,11 +30010,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -29416,11 +30030,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -29436,11 +30050,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -29482,6 +30096,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -29491,11 +30106,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -29511,11 +30126,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -29533,6 +30148,7 @@
         "kind": "OBJECT",
         "name": "PatientSampleHasSampleSamplesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -29542,8 +30158,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -29572,6 +30188,7 @@
         "kind": "OBJECT",
         "name": "PatientSampleHasSampleSamplesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -29581,8 +30198,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -29597,8 +30214,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -29613,8 +30230,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -29629,8 +30246,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -29647,6 +30264,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientSort",
         "description": "Fields to sort Patients by. The order in which sorts are applied is not guaranteed when specifying many fields in one PatientSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -29670,6 +30288,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -29679,11 +30298,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientHasSampleSamplesUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -29699,11 +30318,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientPatientAliasesIsAliasUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -29733,6 +30352,7 @@
         "kind": "INPUT_OBJECT",
         "name": "PatientWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -29742,11 +30362,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -29774,11 +30394,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -30046,11 +30666,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -30092,6 +30712,7 @@
         "kind": "OBJECT",
         "name": "PatientsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -30101,14 +30722,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "PatientEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -30125,8 +30746,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -30141,8 +30762,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -30159,6 +30780,7 @@
         "kind": "OBJECT",
         "name": "Project",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "hasRequestRequests",
@@ -30205,14 +30827,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Request",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -30305,11 +30927,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "ProjectHasRequestRequestsConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -30335,8 +30957,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "ProjectHasRequestRequestsConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -30351,8 +30973,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -30367,8 +30989,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -30385,6 +31007,7 @@
         "kind": "OBJECT",
         "name": "ProjectAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -30394,8 +31017,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -30410,8 +31033,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -30426,8 +31049,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -30444,6 +31067,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30453,11 +31077,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -30475,6 +31099,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30484,8 +31109,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "ProjectWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -30502,6 +31127,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30523,8 +31149,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -30539,8 +31165,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -30557,6 +31183,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30566,11 +31193,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -30588,6 +31215,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30597,11 +31225,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -30619,6 +31247,7 @@
         "kind": "OBJECT",
         "name": "ProjectEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -30628,8 +31257,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -30644,8 +31273,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Project",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -30662,6 +31291,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30671,11 +31301,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -30703,11 +31333,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -30797,6 +31427,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30806,11 +31437,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -30826,8 +31457,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -30856,6 +31487,7 @@
         "kind": "OBJECT",
         "name": "ProjectHasRequestRequestsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -30865,14 +31497,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "ProjectHasRequestRequestsRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -30889,8 +31521,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -30905,8 +31537,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -30923,6 +31555,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30946,6 +31579,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -30955,11 +31589,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -30987,11 +31621,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -31021,6 +31655,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -31030,8 +31665,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "RequestCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -31048,6 +31683,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -31083,6 +31719,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -31118,6 +31755,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -31127,11 +31765,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -31147,11 +31785,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -31169,6 +31807,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -31178,11 +31817,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -31210,11 +31849,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -35072,6 +35711,7 @@
         "kind": "OBJECT",
         "name": "ProjectHasRequestRequestsRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -35081,8 +35721,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -35097,8 +35737,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Request",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35115,6 +35755,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35138,6 +35779,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectHasRequestRequestsUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35147,11 +35789,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -35167,11 +35809,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -35187,11 +35829,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -35207,11 +35849,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -35253,6 +35895,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35286,11 +35929,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -35308,6 +35951,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35317,11 +35961,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -35339,6 +35983,7 @@
         "kind": "OBJECT",
         "name": "ProjectRequestHasRequestRequestsAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -35348,8 +35993,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -35378,6 +36023,7 @@
         "kind": "OBJECT",
         "name": "ProjectRequestHasRequestRequestsNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dataAccessEmails",
@@ -35387,8 +36033,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35403,8 +36049,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35419,8 +36065,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35435,8 +36081,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35451,8 +36097,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BigIntAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35467,8 +36113,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35483,8 +36129,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35499,8 +36145,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35515,8 +36161,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35531,8 +36177,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35547,8 +36193,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35563,8 +36209,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35579,8 +36225,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35595,8 +36241,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35611,8 +36257,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35627,8 +36273,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35643,8 +36289,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35659,8 +36305,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35675,8 +36321,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35691,8 +36337,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35707,8 +36353,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -35725,6 +36371,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectSort",
         "description": "Fields to sort Projects by. The order in which sorts are applied is not guaranteed when specifying many fields in one ProjectSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35760,6 +36407,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35769,11 +36417,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectHasRequestRequestsUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -35815,6 +36463,7 @@
         "kind": "INPUT_OBJECT",
         "name": "ProjectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -35824,11 +36473,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -35856,11 +36505,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -36020,11 +36669,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -36100,11 +36749,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -36146,6 +36795,7 @@
         "kind": "OBJECT",
         "name": "ProjectsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -36155,14 +36805,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "ProjectEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -36179,8 +36829,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -36195,8 +36845,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -36213,6 +36863,7 @@
         "kind": "OBJECT",
         "name": "QcComplete",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -36222,8 +36873,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -36238,8 +36889,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -36254,8 +36905,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -36270,8 +36921,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -36323,14 +36974,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Tempo",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -36423,11 +37074,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "QcCompleteTemposHasEventConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -36453,8 +37104,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "QcCompleteTemposHasEventConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -36471,6 +37122,7 @@
         "kind": "OBJECT",
         "name": "QcCompleteAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -36480,8 +37132,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -36496,8 +37148,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -36512,8 +37164,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -36528,8 +37180,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -36544,8 +37196,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -36562,6 +37214,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36571,11 +37224,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -36593,6 +37246,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36602,8 +37256,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "QcCompleteWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -36620,6 +37274,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36629,8 +37284,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -36645,8 +37300,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -36661,8 +37316,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -36677,8 +37332,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -36707,6 +37362,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36716,11 +37372,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -36738,6 +37394,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36747,11 +37404,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -36769,6 +37426,7 @@
         "kind": "OBJECT",
         "name": "QcCompleteEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -36778,8 +37436,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -36794,8 +37452,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "QcComplete",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -36812,6 +37470,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36845,11 +37504,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -36867,6 +37526,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36876,11 +37536,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -36898,6 +37558,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteSort",
         "description": "Fields to sort QcCompletes by. The order in which sorts are applied is not guaranteed when specifying many fields in one QcCompleteSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -36957,6 +37618,7 @@
         "kind": "OBJECT",
         "name": "QcCompleteTempoTemposHasEventAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -36966,8 +37628,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -36996,6 +37658,7 @@
         "kind": "OBJECT",
         "name": "QcCompleteTempoTemposHasEventNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "accessLevel",
@@ -37005,8 +37668,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -37021,8 +37684,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -37037,8 +37700,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -37053,8 +37716,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -37069,8 +37732,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -37085,8 +37748,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -37101,8 +37764,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -37119,6 +37782,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37128,11 +37792,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -37160,11 +37824,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -37254,6 +37918,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37263,11 +37928,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -37283,8 +37948,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -37313,6 +37978,7 @@
         "kind": "OBJECT",
         "name": "QcCompleteTemposHasEventConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -37322,14 +37988,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "QcCompleteTemposHasEventRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -37346,8 +38012,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -37362,8 +38028,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -37380,6 +38046,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37403,6 +38070,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37412,11 +38080,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -37444,11 +38112,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -37478,6 +38146,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37487,8 +38156,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "TempoCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -37505,6 +38174,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37540,6 +38210,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37575,6 +38246,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37584,11 +38256,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -37604,11 +38276,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -37626,6 +38298,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -37635,11 +38308,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -37667,11 +38340,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -38949,6 +39622,7 @@
         "kind": "OBJECT",
         "name": "QcCompleteTemposHasEventRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -38958,8 +39632,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -38974,8 +39648,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Tempo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -38992,6 +39666,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -39015,6 +39690,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteTemposHasEventUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -39024,11 +39700,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -39044,11 +39720,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -39064,11 +39740,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -39084,11 +39760,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -39130,6 +39806,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -39187,11 +39864,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteTemposHasEventUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -39209,6 +39886,7 @@
         "kind": "INPUT_OBJECT",
         "name": "QcCompleteWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -39218,11 +39896,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -39250,11 +39928,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -39306,11 +39984,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -39386,11 +40064,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -39466,11 +40144,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -39546,11 +40224,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -39700,6 +40378,7 @@
         "kind": "OBJECT",
         "name": "QcCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -39709,14 +40388,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "QcCompleteEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -39733,8 +40412,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -39749,8 +40428,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -39767,6 +40446,7 @@
         "kind": "OBJECT",
         "name": "Query",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "allAnchorSeqDateData",
@@ -39789,14 +40469,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "AnchorSeqDateData",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -39813,14 +40493,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "String",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 }
@@ -39862,14 +40542,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "BamComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -39899,8 +40579,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BamCompleteAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -39942,8 +40622,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "BamCompleteSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -39968,8 +40648,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BamCompletesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -40009,14 +40689,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "CohortComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -40046,8 +40726,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CohortCompleteAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -40089,8 +40769,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "CohortCompleteSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -40115,8 +40795,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CohortCompletesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -40156,14 +40836,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Cohort",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -40193,8 +40873,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CohortAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -40236,8 +40916,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "CohortSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -40262,8 +40942,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "CohortsConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -40281,11 +40961,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "DashboardRecordColumnFilter",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -40301,8 +40981,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "Int",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 },
@@ -40317,8 +40997,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "Int",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 },
@@ -40333,11 +41013,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "SCALAR",
                       "name": "String",
+                      "kind": "SCALAR",
                       "ofType": null
                     }
                   }
@@ -40353,8 +41033,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "DashboardRecordSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -40367,14 +41047,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "DashboardCohort",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -40394,11 +41074,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "DashboardRecordColumnFilter",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -40414,8 +41094,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "Int",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 },
@@ -40430,8 +41110,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "Int",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 },
@@ -40458,11 +41138,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "SCALAR",
                       "name": "String",
+                      "kind": "SCALAR",
                       "ofType": null
                     }
                   }
@@ -40478,8 +41158,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "DashboardRecordSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -40492,14 +41172,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "DashboardPatient",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -40519,11 +41199,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "DashboardRecordColumnFilter",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -40539,8 +41219,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "Int",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 },
@@ -40555,8 +41235,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "Int",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 },
@@ -40571,11 +41251,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "SCALAR",
                       "name": "String",
+                      "kind": "SCALAR",
                       "ofType": null
                     }
                   }
@@ -40591,8 +41271,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "DashboardRecordSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -40605,14 +41285,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "DashboardRequest",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -40632,8 +41312,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "Int",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 },
@@ -40648,8 +41328,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "Int",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 },
@@ -40664,14 +41344,14 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
                     "name": null,
+                    "kind": "LIST",
                     "ofType": {
-                      "kind": "NON_NULL",
                       "name": null,
+                      "kind": "NON_NULL",
                       "ofType": {
-                        "kind": "SCALAR",
                         "name": "String",
+                        "kind": "SCALAR",
                         "ofType": null
                       }
                     }
@@ -40688,8 +41368,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "DashboardRecordSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -40702,14 +41382,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "DashboardSample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -40729,11 +41409,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "DashboardRecordColumnFilter",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -40749,8 +41429,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "Boolean",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 },
@@ -40765,8 +41445,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "Int",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 },
@@ -40781,8 +41461,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "Int",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 },
@@ -40809,8 +41489,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "DashboardRecordContext",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -40825,11 +41505,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "SCALAR",
                       "name": "String",
+                      "kind": "SCALAR",
                       "ofType": null
                     }
                   }
@@ -40845,8 +41525,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "DashboardRecordSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -40859,14 +41539,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "DashboardSample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -40908,14 +41588,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "DbGap",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -40945,8 +41625,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DbGapAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -40988,8 +41668,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "DbGapSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -41014,8 +41694,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DbGapsConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41055,14 +41735,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "MafComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -41092,8 +41772,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "MafCompleteAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41135,8 +41815,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "MafCompleteSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -41161,8 +41841,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "MafCompletesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41202,14 +41882,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "PatientAlias",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -41239,8 +41919,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PatientAliasAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41282,8 +41962,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "PatientAliasSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -41308,8 +41988,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PatientAliasesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41349,14 +42029,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Patient",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -41386,8 +42066,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PatientAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41429,8 +42109,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "PatientSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -41455,8 +42135,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PatientsConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41496,14 +42176,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Project",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -41533,8 +42213,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "ProjectAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41576,8 +42256,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "ProjectSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -41602,8 +42282,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "ProjectsConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41643,14 +42323,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "QcComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -41680,8 +42360,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "QcCompleteAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41723,8 +42403,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "QcCompleteSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -41749,8 +42429,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "QcCompletesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41790,14 +42470,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "RequestMetadata",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -41827,8 +42507,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "RequestMetadataAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41870,8 +42550,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "RequestMetadataSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -41896,8 +42576,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "RequestMetadataConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -41937,14 +42617,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Request",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -41974,8 +42654,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "RequestAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -42017,8 +42697,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "RequestSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -42043,8 +42723,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "RequestsConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -42084,14 +42764,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleAlias",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -42121,8 +42801,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleAliasAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -42164,8 +42844,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "SampleAliasSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -42190,8 +42870,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleAliasesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -42231,14 +42911,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleMetadata",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -42268,8 +42948,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleMetadataAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -42311,8 +42991,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "SampleMetadataSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -42337,8 +43017,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleMetadataConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -42378,14 +43058,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Sample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -42415,8 +43095,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -42458,8 +43138,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "SampleSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -42484,8 +43164,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SamplesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -42525,14 +43205,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Status",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -42562,8 +43242,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StatusAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -42605,8 +43285,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "StatusSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -42631,8 +43311,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StatusesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -42672,14 +43352,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Tempo",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -42709,8 +43389,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "TempoAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -42752,8 +43432,8 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "TempoSort",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 },
@@ -42778,8 +43458,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "TemposConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -42796,6 +43476,7 @@
         "kind": "OBJECT",
         "name": "Request",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "bicAnalysis",
@@ -42805,8 +43486,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -42821,8 +43502,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -42837,8 +43518,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -42853,8 +43534,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -42869,8 +43550,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -42922,14 +43603,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "RequestMetadata",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -43022,11 +43703,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "RequestHasMetadataRequestMetadataConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -43052,8 +43733,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "RequestHasMetadataRequestMetadataConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43105,14 +43786,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Sample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -43205,11 +43886,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "RequestHasSampleSamplesConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -43235,8 +43916,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "RequestHasSampleSamplesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43263,8 +43944,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43279,8 +43960,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43307,8 +43988,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43323,8 +44004,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43339,8 +44020,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43355,8 +44036,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43371,8 +44052,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43399,8 +44080,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43415,8 +44096,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43431,8 +44112,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43447,8 +44128,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43463,8 +44144,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43516,14 +44197,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Project",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -43616,11 +44297,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "RequestProjectsHasRequestConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -43646,8 +44327,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "RequestProjectsHasRequestConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43662,8 +44343,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43678,8 +44359,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43694,8 +44375,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43724,6 +44405,7 @@
         "kind": "OBJECT",
         "name": "RequestAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -43733,8 +44415,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -43749,8 +44431,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43765,8 +44447,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43781,8 +44463,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43797,8 +44479,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43813,8 +44495,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BigIntAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43829,8 +44511,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43845,8 +44527,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43861,8 +44543,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43877,8 +44559,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43893,8 +44575,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43909,8 +44591,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43925,8 +44607,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43941,8 +44623,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43957,8 +44639,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43973,8 +44655,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -43989,8 +44671,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -44005,8 +44687,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -44021,8 +44703,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -44037,8 +44719,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -44053,8 +44735,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -44069,8 +44751,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -44087,6 +44769,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44096,11 +44779,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -44116,11 +44799,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -44136,11 +44819,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -44158,6 +44841,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44167,8 +44851,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "RequestWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -44185,6 +44869,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44194,8 +44879,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44210,8 +44895,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44226,8 +44911,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44242,8 +44927,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44258,8 +44943,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44310,8 +44995,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44326,8 +45011,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44354,8 +45039,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44370,8 +45055,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44386,8 +45071,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44402,8 +45087,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44418,8 +45103,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44446,8 +45131,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44462,8 +45147,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44478,8 +45163,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44494,8 +45179,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44510,8 +45195,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44538,8 +45223,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44554,8 +45239,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44570,8 +45255,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44600,6 +45285,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44609,11 +45295,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -44629,11 +45315,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -44649,11 +45335,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -44671,6 +45357,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44680,11 +45367,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -44700,11 +45387,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -44720,11 +45407,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -44742,6 +45429,7 @@
         "kind": "OBJECT",
         "name": "RequestEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -44751,8 +45439,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44767,8 +45455,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Request",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -44785,6 +45473,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44794,11 +45483,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -44826,11 +45515,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -44920,6 +45609,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -44929,11 +45619,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -44949,8 +45639,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -44979,6 +45669,7 @@
         "kind": "OBJECT",
         "name": "RequestHasMetadataRequestMetadataConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -44988,14 +45679,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "RequestHasMetadataRequestMetadataRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -45012,8 +45703,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -45028,8 +45719,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -45046,6 +45737,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45069,6 +45761,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45078,11 +45771,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -45110,11 +45803,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -45144,6 +45837,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45153,8 +45847,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "RequestMetadataCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -45171,6 +45865,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45206,6 +45901,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45241,6 +45937,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45250,11 +45947,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -45270,11 +45967,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -45292,6 +45989,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -45301,11 +45999,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -45333,11 +46031,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -45955,6 +46653,7 @@
         "kind": "OBJECT",
         "name": "RequestHasMetadataRequestMetadataRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -45964,8 +46663,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -45980,8 +46679,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "RequestMetadata",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -45998,6 +46697,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46021,6 +46721,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasMetadataRequestMetadataUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46030,11 +46731,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -46050,11 +46751,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -46070,11 +46771,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -46090,11 +46791,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -46136,6 +46837,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46145,11 +46847,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -46177,11 +46879,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -46271,6 +46973,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46280,11 +46983,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -46300,8 +47003,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -46330,6 +47033,7 @@
         "kind": "OBJECT",
         "name": "RequestHasSampleSamplesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -46339,14 +47043,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "RequestHasSampleSamplesRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -46363,8 +47067,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -46379,8 +47083,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -46397,6 +47101,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46420,6 +47125,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46429,11 +47135,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -46461,11 +47167,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -46495,6 +47201,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46504,8 +47211,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -46522,6 +47229,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46557,6 +47265,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46592,6 +47301,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46601,11 +47311,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -46621,11 +47331,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -46643,6 +47353,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -46652,11 +47363,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -46684,11 +47395,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -47426,6 +48137,7 @@
         "kind": "OBJECT",
         "name": "RequestHasSampleSamplesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -47435,8 +48147,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -47451,8 +48163,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Sample",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -47469,6 +48181,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -47492,6 +48205,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestHasSampleSamplesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -47501,11 +48215,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -47521,11 +48235,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -47541,11 +48255,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -47561,11 +48275,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -47607,6 +48321,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadata",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "hasStatusStatuses",
@@ -47653,14 +48368,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Status",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -47753,11 +48468,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "RequestMetadataHasStatusStatusesConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -47783,8 +48498,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "RequestMetadataHasStatusStatusesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -47799,8 +48514,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -47815,8 +48530,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "BigInt",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -47831,8 +48546,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -47884,14 +48599,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Request",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -47984,11 +48699,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "RequestMetadataRequestsHasMetadataConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -48014,8 +48729,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "RequestMetadataRequestsHasMetadataConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -48032,6 +48747,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -48041,8 +48757,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -48057,8 +48773,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -48073,8 +48789,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BigIntAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -48089,8 +48805,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -48107,6 +48823,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48116,11 +48833,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48136,11 +48853,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48158,6 +48875,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48167,8 +48885,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "RequestMetadataWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -48185,6 +48903,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -48194,14 +48913,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "RequestMetadataEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -48218,8 +48937,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -48234,8 +48953,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -48252,6 +48971,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48273,8 +48993,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -48289,8 +49009,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "BigInt",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -48305,8 +49025,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -48335,6 +49055,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48344,11 +49065,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48364,11 +49085,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48386,6 +49107,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48395,11 +49117,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48415,11 +49137,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48437,6 +49159,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -48446,8 +49169,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -48462,8 +49185,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "RequestMetadata",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -48480,6 +49203,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48489,11 +49213,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48521,11 +49245,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48615,6 +49339,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48624,11 +49349,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48644,8 +49369,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -48674,6 +49399,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataHasStatusStatusesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -48683,14 +49409,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "RequestMetadataHasStatusStatusesRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -48707,8 +49433,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -48723,8 +49449,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -48741,6 +49467,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48764,6 +49491,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48773,11 +49501,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48805,11 +49533,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48839,6 +49567,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48848,8 +49577,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "StatusCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -48866,6 +49595,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48901,6 +49631,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48936,6 +49667,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48945,11 +49677,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48965,11 +49697,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -48987,6 +49719,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -48996,11 +49729,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -49028,11 +49761,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -49230,6 +49963,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataHasStatusStatusesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -49239,8 +49973,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -49255,8 +49989,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Status",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49273,6 +50007,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -49296,6 +50031,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataHasStatusStatusesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -49305,11 +50041,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -49325,11 +50061,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -49345,11 +50081,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -49365,11 +50101,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -49411,6 +50147,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -49444,11 +50181,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -49466,6 +50203,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -49475,11 +50213,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -49495,11 +50233,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -49517,6 +50255,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataRequestRequestsHasMetadataAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -49526,8 +50265,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -49556,6 +50295,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataRequestRequestsHasMetadataNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dataAccessEmails",
@@ -49565,8 +50305,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49581,8 +50321,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49597,8 +50337,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49613,8 +50353,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49629,8 +50369,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BigIntAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49645,8 +50385,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49661,8 +50401,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49677,8 +50417,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49693,8 +50433,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49709,8 +50449,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49725,8 +50465,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49741,8 +50481,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49757,8 +50497,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49773,8 +50513,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49789,8 +50529,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49805,8 +50545,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49821,8 +50561,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49837,8 +50577,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49853,8 +50593,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49869,8 +50609,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49885,8 +50625,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -49903,6 +50643,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -49912,11 +50653,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -49944,11 +50685,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -50038,6 +50779,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50047,11 +50789,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -50067,8 +50809,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -50097,6 +50839,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataRequestsHasMetadataConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -50106,14 +50849,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "RequestMetadataRequestsHasMetadataRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -50130,8 +50873,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -50146,8 +50889,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -50164,6 +50907,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50187,6 +50931,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50196,11 +50941,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -50228,11 +50973,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -50262,6 +51007,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50271,8 +51017,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "RequestCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -50289,6 +51035,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50324,6 +51071,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50359,6 +51107,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50368,11 +51117,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -50388,11 +51137,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -50410,6 +51159,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -50419,11 +51169,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -50451,11 +51201,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -54313,6 +55063,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataRequestsHasMetadataRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -54322,8 +55073,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -54338,8 +55089,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Request",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -54356,6 +55107,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -54379,6 +55131,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataRequestsHasMetadataUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -54388,11 +55141,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -54408,11 +55161,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -54428,11 +55181,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -54448,11 +55201,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -54494,6 +55247,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataSort",
         "description": "Fields to sort RequestMetadata by. The order in which sorts are applied is not guaranteed when specifying many fields in one RequestMetadataSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -54541,6 +55295,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataStatusHasStatusStatusesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -54550,8 +55305,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -54580,6 +55335,7 @@
         "kind": "OBJECT",
         "name": "RequestMetadataStatusHasStatusStatusesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "validationReport",
@@ -54589,8 +55345,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -54607,6 +55363,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -54616,11 +55373,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataHasStatusStatusesUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -54696,11 +55453,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataRequestsHasMetadataUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -54718,6 +55475,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestMetadataWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -54727,11 +55485,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -54759,11 +55517,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -54923,11 +55681,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -55003,11 +55761,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "BigInt",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -55083,11 +55841,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -55237,6 +55995,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55270,11 +56029,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -55292,6 +56051,7 @@
         "kind": "OBJECT",
         "name": "RequestProjectProjectsHasRequestAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -55301,8 +56061,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -55331,6 +56091,7 @@
         "kind": "OBJECT",
         "name": "RequestProjectProjectsHasRequestNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "igoProjectId",
@@ -55340,8 +56101,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -55356,8 +56117,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -55374,6 +56135,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55383,11 +56145,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -55415,11 +56177,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -55509,6 +56271,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55518,11 +56281,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "ProjectConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -55538,8 +56301,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -55568,6 +56331,7 @@
         "kind": "OBJECT",
         "name": "RequestProjectsHasRequestConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -55577,14 +56341,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "RequestProjectsHasRequestRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -55601,8 +56365,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -55617,8 +56381,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -55635,6 +56399,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55658,6 +56423,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55667,11 +56433,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -55699,11 +56465,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -55733,6 +56499,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55742,8 +56509,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "ProjectCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -55760,6 +56527,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55795,6 +56563,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55830,6 +56599,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55839,11 +56609,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -55859,11 +56629,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -55881,6 +56651,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -55890,11 +56661,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -55922,11 +56693,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -56304,6 +57075,7 @@
         "kind": "OBJECT",
         "name": "RequestProjectsHasRequestRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -56313,8 +57085,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -56329,8 +57101,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Project",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -56347,6 +57119,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -56370,6 +57143,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestProjectsHasRequestUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -56379,11 +57153,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -56399,11 +57173,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -56419,11 +57193,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -56439,11 +57213,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -56485,6 +57259,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -56494,11 +57269,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -56514,11 +57289,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -56534,11 +57309,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -56556,6 +57331,7 @@
         "kind": "OBJECT",
         "name": "RequestRequestMetadataHasMetadataRequestMetadataAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -56565,8 +57341,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -56595,6 +57371,7 @@
         "kind": "OBJECT",
         "name": "RequestRequestMetadataHasMetadataRequestMetadataNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "igoRequestId",
@@ -56604,8 +57381,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -56620,8 +57397,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BigIntAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -56636,8 +57413,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -56654,6 +57431,7 @@
         "kind": "OBJECT",
         "name": "RequestSampleHasSampleSamplesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -56663,8 +57441,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -56693,6 +57471,7 @@
         "kind": "OBJECT",
         "name": "RequestSampleHasSampleSamplesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -56702,8 +57481,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -56718,8 +57497,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -56734,8 +57513,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -56750,8 +57529,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -56768,6 +57547,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestSort",
         "description": "Fields to sort Requests by. The order in which sorts are applied is not guaranteed when specifying many fields in one RequestSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -57055,6 +57835,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -57124,11 +57905,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasMetadataRequestMetadataUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -57144,11 +57925,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestHasSampleSamplesUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -57344,8 +58125,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -57372,8 +58153,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -57400,11 +58181,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestProjectsHasRequestUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -57470,6 +58251,7 @@
         "kind": "INPUT_OBJECT",
         "name": "RequestWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -57479,11 +58261,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -57511,11 +58293,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -57579,11 +58361,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -57659,11 +58441,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -57739,11 +58521,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -57819,11 +58601,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -58115,8 +58897,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "BigInt",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -58191,11 +58973,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -58271,11 +59053,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -58351,8 +59133,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -58427,11 +59209,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -58507,11 +59289,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -58599,11 +59381,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -58679,11 +59461,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -58759,8 +59541,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -58835,11 +59617,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -58915,11 +59697,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -58995,11 +59777,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -59039,8 +59821,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -59103,11 +59885,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -59291,11 +60073,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -59371,11 +60153,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -59451,11 +60233,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -59531,8 +60313,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -59573,6 +60355,7 @@
         "kind": "OBJECT",
         "name": "RequestsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -59582,14 +60365,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "RequestEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -59606,8 +60389,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -59622,8 +60405,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -59640,6 +60423,7 @@
         "kind": "OBJECT",
         "name": "Sample",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortsHasCohortSample",
@@ -59686,14 +60470,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Cohort",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -59786,11 +60570,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "SampleCohortsHasCohortSampleConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -59816,8 +60600,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleCohortsHasCohortSampleConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -59832,8 +60616,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -59885,14 +60669,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "DbGap",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -59985,11 +60769,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "SampleHasDbgapDbGapsConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -60015,8 +60799,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleHasDbgapDbGapsConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -60068,14 +60852,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleMetadata",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -60168,11 +60952,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "SampleHasMetadataSampleMetadataConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -60198,8 +60982,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleHasMetadataSampleMetadataConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -60251,14 +61035,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Tempo",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -60351,11 +61135,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "SampleHasTempoTemposConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -60381,8 +61165,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleHasTempoTemposConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -60434,14 +61218,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Patient",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -60534,11 +61318,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "SamplePatientsHasSampleConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -60564,8 +61348,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SamplePatientsHasSampleConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -60617,14 +61401,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Request",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -60717,11 +61501,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "SampleRequestsHasSampleConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -60747,8 +61531,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleRequestsHasSampleConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -60812,14 +61596,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleAlias",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -60912,11 +61696,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "SampleSampleAliasesIsAliasConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -60942,8 +61726,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleSampleAliasesIsAliasConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -60958,8 +61742,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -60986,8 +61770,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -61004,6 +61788,7 @@
         "kind": "OBJECT",
         "name": "SampleAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -61013,8 +61798,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -61029,8 +61814,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -61045,8 +61830,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -61061,8 +61846,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -61077,8 +61862,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -61095,6 +61880,7 @@
         "kind": "OBJECT",
         "name": "SampleAlias",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "isAliasSamples",
@@ -61141,14 +61927,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Sample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -61241,11 +62027,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "SampleAliasIsAliasSamplesConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -61271,8 +62057,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleAliasIsAliasSamplesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -61287,8 +62073,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -61303,8 +62089,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -61321,6 +62107,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -61330,8 +62117,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -61346,8 +62133,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -61362,8 +62149,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -61380,6 +62167,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61389,11 +62177,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -61411,6 +62199,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61420,8 +62209,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleAliasWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -61438,6 +62227,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61459,8 +62249,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -61475,8 +62265,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -61493,6 +62283,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61502,11 +62293,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -61524,6 +62315,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61533,11 +62325,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -61555,6 +62347,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -61564,8 +62357,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -61580,8 +62373,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleAlias",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -61598,6 +62391,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61607,11 +62401,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -61639,11 +62433,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -61733,6 +62527,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61742,11 +62537,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -61762,8 +62557,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -61792,6 +62587,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasIsAliasSamplesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -61801,14 +62597,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleAliasIsAliasSamplesRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -61825,8 +62621,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -61841,8 +62637,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -61859,6 +62655,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61882,6 +62679,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61891,11 +62689,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -61923,11 +62721,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -61957,6 +62755,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -61966,8 +62765,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -61984,6 +62783,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -62019,6 +62819,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -62054,6 +62855,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -62063,11 +62865,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -62083,11 +62885,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -62105,6 +62907,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -62114,11 +62917,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -62146,11 +62949,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -62888,6 +63691,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasIsAliasSamplesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -62897,8 +63701,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -62913,8 +63717,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Sample",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -62931,6 +63735,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -62954,6 +63759,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasIsAliasSamplesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -62963,11 +63769,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -62983,11 +63789,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -63003,11 +63809,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -63023,11 +63829,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -63069,6 +63875,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63102,11 +63909,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -63124,6 +63931,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63133,11 +63941,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -63155,6 +63963,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasSampleIsAliasSamplesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -63164,8 +63973,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -63194,6 +64003,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasSampleIsAliasSamplesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -63203,8 +64013,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -63219,8 +64029,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -63235,8 +64045,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -63251,8 +64061,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -63269,6 +64079,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasSort",
         "description": "Fields to sort SampleAliases by. The order in which sorts are applied is not guaranteed when specifying many fields in one SampleAliasSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63304,6 +64115,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63313,11 +64125,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasIsAliasSamplesUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -63359,6 +64171,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleAliasWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63368,11 +64181,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -63400,11 +64213,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -63564,11 +64377,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -63644,11 +64457,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -63690,6 +64503,7 @@
         "kind": "OBJECT",
         "name": "SampleAliasesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -63699,14 +64513,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleAliasEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -63723,8 +64537,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -63739,8 +64553,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -63757,6 +64571,7 @@
         "kind": "OBJECT",
         "name": "SampleCohortCohortsHasCohortSampleAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -63766,8 +64581,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -63796,6 +64611,7 @@
         "kind": "OBJECT",
         "name": "SampleCohortCohortsHasCohortSampleNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortId",
@@ -63805,8 +64621,24 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -63823,6 +64655,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63832,11 +64665,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -63864,11 +64697,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -63958,6 +64791,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -63967,11 +64801,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "CohortConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -63987,8 +64821,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -64017,6 +64851,7 @@
         "kind": "OBJECT",
         "name": "SampleCohortsHasCohortSampleConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -64026,14 +64861,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleCohortsHasCohortSampleRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -64050,8 +64885,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -64066,8 +64901,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -64084,6 +64919,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64107,6 +64943,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64116,11 +64953,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64148,11 +64985,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64182,6 +65019,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64191,8 +65029,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "CohortCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -64209,6 +65047,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64244,6 +65083,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64279,6 +65119,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64288,11 +65129,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64308,11 +65149,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64330,6 +65171,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64339,11 +65181,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64371,11 +65213,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64563,6 +65405,186 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_AVERAGE_LENGTH_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_LONGEST_LENGTH_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_EQUAL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_GT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_GTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_LT",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cohortStatus_SHORTEST_LENGTH_LTE",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -64573,6 +65595,7 @@
         "kind": "OBJECT",
         "name": "SampleCohortsHasCohortSampleRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -64582,8 +65605,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -64598,8 +65621,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Cohort",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -64616,6 +65639,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64639,6 +65663,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCohortsHasCohortSampleUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64648,11 +65673,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64668,11 +65693,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64688,11 +65713,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64708,11 +65733,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64754,6 +65779,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64763,11 +65789,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64783,11 +65809,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64803,11 +65829,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64823,11 +65849,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64843,11 +65869,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64863,11 +65889,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64883,11 +65909,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -64905,6 +65931,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64914,8 +65941,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -64932,6 +65959,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -64953,8 +65981,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -65053,8 +66081,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -65081,8 +66109,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -65099,6 +66127,7 @@
         "kind": "OBJECT",
         "name": "SampleDbGapHasDbgapDbGapsAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -65108,8 +66137,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -65138,6 +66167,7 @@
         "kind": "OBJECT",
         "name": "SampleDbGapHasDbgapDbGapsNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dbGapStudy",
@@ -65147,8 +66177,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -65163,8 +66193,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -65181,6 +66211,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65190,11 +66221,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65210,11 +66241,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65230,11 +66261,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65250,11 +66281,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65270,11 +66301,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65290,11 +66321,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65310,11 +66341,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65332,6 +66363,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65341,11 +66373,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65361,11 +66393,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65381,11 +66413,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65401,11 +66433,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65421,11 +66453,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65441,11 +66473,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65461,11 +66493,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65483,6 +66515,7 @@
         "kind": "OBJECT",
         "name": "SampleEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -65492,8 +66525,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -65508,8 +66541,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Sample",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -65526,6 +66559,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65535,11 +66569,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65567,11 +66601,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65661,6 +66695,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65670,11 +66705,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "DbGapConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65690,8 +66725,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -65720,6 +66755,7 @@
         "kind": "OBJECT",
         "name": "SampleHasDbgapDbGapsConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -65729,14 +66765,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleHasDbgapDbGapsRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -65753,8 +66789,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -65769,8 +66805,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -65787,6 +66823,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65810,6 +66847,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65819,11 +66857,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65851,11 +66889,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -65885,6 +66923,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65894,8 +66933,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "DbGapCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -65912,6 +66951,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65947,6 +66987,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65982,6 +67023,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -65991,11 +67033,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66011,11 +67053,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66033,6 +67075,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66042,11 +67085,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66074,11 +67117,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66456,6 +67499,7 @@
         "kind": "OBJECT",
         "name": "SampleHasDbgapDbGapsRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -66465,8 +67509,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -66481,8 +67525,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "DbGap",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -66499,6 +67543,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66522,6 +67567,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasDbgapDbGapsUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66531,11 +67577,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66551,11 +67597,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66571,11 +67617,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66591,11 +67637,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66637,6 +67683,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66646,11 +67693,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66678,11 +67725,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66772,6 +67819,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66781,11 +67829,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66801,8 +67849,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -66831,6 +67879,7 @@
         "kind": "OBJECT",
         "name": "SampleHasMetadataSampleMetadataConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -66840,14 +67889,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleHasMetadataSampleMetadataRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -66864,8 +67913,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -66880,8 +67929,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -66898,6 +67947,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66921,6 +67971,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -66930,11 +67981,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66962,11 +68013,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -66996,6 +68047,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -67005,8 +68057,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleMetadataCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -67023,6 +68075,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -67058,6 +68111,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -67093,6 +68147,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -67102,11 +68157,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -67122,11 +68177,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -67144,6 +68199,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -67153,11 +68209,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -67185,11 +68241,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -71947,6 +73003,7 @@
         "kind": "OBJECT",
         "name": "SampleHasMetadataSampleMetadataRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -71956,8 +73013,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -71972,8 +73029,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleMetadata",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -71990,6 +73047,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72013,6 +73071,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasMetadataSampleMetadataUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72022,11 +73081,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -72042,11 +73101,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -72062,11 +73121,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -72082,11 +73141,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -72128,6 +73187,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72137,11 +73197,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -72169,11 +73229,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -72263,6 +73323,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72272,11 +73333,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -72292,8 +73353,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -72322,6 +73383,7 @@
         "kind": "OBJECT",
         "name": "SampleHasTempoTemposConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -72331,14 +73393,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleHasTempoTemposRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -72355,8 +73417,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -72371,8 +73433,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -72389,6 +73451,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72412,6 +73475,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72421,11 +73485,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -72453,11 +73517,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -72487,6 +73551,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72496,8 +73561,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "TempoCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -72514,6 +73579,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72549,6 +73615,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72584,6 +73651,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72593,11 +73661,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -72613,11 +73681,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -72635,6 +73703,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -72644,11 +73713,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -72676,11 +73745,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -73958,6 +75027,7 @@
         "kind": "OBJECT",
         "name": "SampleHasTempoTemposRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -73967,8 +75037,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -73983,8 +75053,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Tempo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -74001,6 +75071,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -74024,6 +75095,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleHasTempoTemposUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -74033,11 +75105,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -74053,11 +75125,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -74073,11 +75145,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -74093,11 +75165,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -74139,6 +75211,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadata",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "additionalProperties",
@@ -74148,8 +75221,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -74212,8 +75285,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -74252,8 +75325,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -74305,14 +75378,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Status",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -74405,11 +75478,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "SampleMetadataHasStatusStatusesConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -74435,8 +75508,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleMetadataHasStatusStatusesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -74475,8 +75548,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "BigInt",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -74503,8 +75576,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -74543,8 +75616,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -74559,8 +75632,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -74660,14 +75733,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Sample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -74760,11 +75833,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "SampleMetadataSamplesHasMetadataConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -74790,8 +75863,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleMetadataSamplesHasMetadataConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -74868,6 +75941,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "additionalProperties",
@@ -74877,8 +75951,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -74893,8 +75967,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -74909,8 +75983,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -74925,8 +75999,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -74941,8 +76015,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -74957,8 +76031,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -74973,8 +76047,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -74989,8 +76063,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75005,8 +76079,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -75021,8 +76095,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75037,8 +76111,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75053,8 +76127,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BigIntAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75069,8 +76143,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75085,8 +76159,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75101,8 +76175,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75117,8 +76191,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75133,8 +76207,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75149,8 +76223,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75165,8 +76239,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75181,8 +76255,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75197,8 +76271,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75213,8 +76287,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75229,8 +76303,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75245,8 +76319,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75261,8 +76335,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75277,8 +76351,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75293,8 +76367,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75311,6 +76385,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -75320,11 +76395,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -75340,11 +76415,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -75362,6 +76437,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -75371,8 +76447,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleMetadataWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -75389,6 +76465,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -75398,14 +76475,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleMetadataEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -75422,8 +76499,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75438,8 +76515,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -75456,6 +76533,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -75465,8 +76543,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -75529,8 +76607,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -75569,8 +76647,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -75621,8 +76699,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "BigInt",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -75649,8 +76727,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -75689,8 +76767,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -75705,8 +76783,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -75843,6 +76921,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -75852,11 +76931,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -75872,11 +76951,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -75894,6 +76973,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -75903,11 +76983,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -75923,11 +77003,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -75945,6 +77025,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -75954,8 +77035,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -75970,8 +77051,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleMetadata",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -75988,6 +77069,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -75997,11 +77079,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76029,11 +77111,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76123,6 +77205,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76132,11 +77215,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76152,8 +77235,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -76182,6 +77265,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataHasStatusStatusesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -76191,14 +77275,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleMetadataHasStatusStatusesRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -76215,8 +77299,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -76231,8 +77315,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -76249,6 +77333,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76272,6 +77357,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76281,11 +77367,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76313,11 +77399,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76347,6 +77433,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76356,8 +77443,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "StatusCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -76374,6 +77461,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76409,6 +77497,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76444,6 +77533,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76453,11 +77543,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76473,11 +77563,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76495,6 +77585,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76504,11 +77595,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76536,11 +77627,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76738,6 +77829,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataHasStatusStatusesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -76747,8 +77839,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -76763,8 +77855,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Status",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -76781,6 +77873,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76804,6 +77897,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataHasStatusStatusesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76813,11 +77907,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76833,11 +77927,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76853,11 +77947,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76873,11 +77967,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76919,6 +78013,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76952,11 +78047,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -76974,6 +78069,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -76983,11 +78079,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -77003,11 +78099,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -77025,6 +78121,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataSampleSamplesHasMetadataAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -77034,8 +78131,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -77064,6 +78161,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataSampleSamplesHasMetadataNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -77073,8 +78171,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -77089,8 +78187,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -77105,8 +78203,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -77121,8 +78219,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -77139,6 +78237,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77148,11 +78247,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -77180,11 +78279,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -77274,6 +78373,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77283,11 +78383,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -77303,8 +78403,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -77333,6 +78433,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataSamplesHasMetadataConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -77342,14 +78443,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleMetadataSamplesHasMetadataRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -77366,8 +78467,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -77382,8 +78483,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -77400,6 +78501,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77423,6 +78525,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77432,11 +78535,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -77464,11 +78567,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -77498,6 +78601,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77507,8 +78611,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -77525,6 +78629,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77560,6 +78665,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77595,6 +78701,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77604,11 +78711,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -77624,11 +78731,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -77646,6 +78753,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -77655,11 +78763,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -77687,11 +78795,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -78429,6 +79537,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataSamplesHasMetadataRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -78438,8 +79547,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -78454,8 +79563,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Sample",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -78472,6 +79581,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -78495,6 +79605,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSamplesHasMetadataUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -78504,11 +79615,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -78524,11 +79635,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -78544,11 +79655,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -78564,11 +79675,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -78610,6 +79721,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataSort",
         "description": "Fields to sort SampleMetadata by. The order in which sorts are applied is not guaranteed when specifying many fields in one SampleMetadataSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -78945,6 +80057,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataStatusHasStatusStatusesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -78954,8 +80067,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -78984,6 +80097,7 @@
         "kind": "OBJECT",
         "name": "SampleMetadataStatusHasStatusStatusesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "validationReport",
@@ -78993,8 +80107,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -79011,6 +80125,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -79128,11 +80243,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataHasStatusStatusesUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -79328,11 +80443,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataSamplesHasMetadataUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -79410,6 +80525,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleMetadataWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -79419,11 +80535,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -79451,11 +80567,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -79507,11 +80623,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -79587,8 +80703,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -79663,8 +80779,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -79739,8 +80855,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -79815,8 +80931,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -79891,11 +81007,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -79971,8 +81087,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -80047,8 +81163,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -80123,11 +81239,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -80323,8 +81439,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -80399,11 +81515,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "BigInt",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -80479,8 +81595,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -80555,11 +81671,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -80635,8 +81751,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -80711,8 +81827,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -80787,11 +81903,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -80867,11 +81983,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -80947,8 +82063,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -81023,8 +82139,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -81099,8 +82215,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -81175,8 +82291,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -81359,8 +82475,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -81435,8 +82551,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -81511,8 +82627,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -81587,8 +82703,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -81663,8 +82779,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -81705,6 +82821,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -81738,11 +82855,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -81760,6 +82877,7 @@
         "kind": "OBJECT",
         "name": "SamplePatientPatientsHasSampleAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -81769,8 +82887,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -81799,6 +82917,7 @@
         "kind": "OBJECT",
         "name": "SamplePatientPatientsHasSampleNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "smilePatientId",
@@ -81808,8 +82927,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -81826,6 +82945,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -81835,11 +82955,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -81867,11 +82987,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -81961,6 +83081,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -81970,11 +83091,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "PatientConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -81990,8 +83111,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -82020,6 +83141,7 @@
         "kind": "OBJECT",
         "name": "SamplePatientsHasSampleConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -82029,14 +83151,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SamplePatientsHasSampleRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -82053,8 +83175,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -82069,8 +83191,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -82087,6 +83209,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82110,6 +83233,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82119,11 +83243,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82151,11 +83275,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82185,6 +83309,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82194,8 +83319,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "PatientCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -82212,6 +83337,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82247,6 +83373,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82282,6 +83409,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82291,11 +83419,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82311,11 +83439,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82333,6 +83461,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82342,11 +83471,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82374,11 +83503,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82576,6 +83705,7 @@
         "kind": "OBJECT",
         "name": "SamplePatientsHasSampleRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -82585,8 +83715,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -82601,8 +83731,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Patient",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -82619,6 +83749,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82642,6 +83773,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SamplePatientsHasSampleUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82651,11 +83783,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82671,11 +83803,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82691,11 +83823,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82711,11 +83843,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82757,6 +83889,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -82766,11 +83899,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82786,11 +83919,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82806,11 +83939,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82826,11 +83959,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82846,11 +83979,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82866,11 +83999,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82886,11 +84019,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -82908,6 +84041,7 @@
         "kind": "OBJECT",
         "name": "SampleRequestRequestsHasSampleAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -82917,8 +84051,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -82947,6 +84081,7 @@
         "kind": "OBJECT",
         "name": "SampleRequestRequestsHasSampleNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dataAccessEmails",
@@ -82956,8 +84091,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -82972,8 +84107,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -82988,8 +84123,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83004,8 +84139,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83020,8 +84155,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BigIntAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83036,8 +84171,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83052,8 +84187,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83068,8 +84203,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83084,8 +84219,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83100,8 +84235,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83116,8 +84251,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83132,8 +84267,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83148,8 +84283,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83164,8 +84299,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83180,8 +84315,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83196,8 +84331,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83212,8 +84347,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83228,8 +84363,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83244,8 +84379,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83260,8 +84395,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83276,8 +84411,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83294,6 +84429,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83303,11 +84439,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -83335,11 +84471,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -83429,6 +84565,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83438,11 +84575,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -83458,8 +84595,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -83488,6 +84625,7 @@
         "kind": "OBJECT",
         "name": "SampleRequestsHasSampleConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -83497,14 +84635,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleRequestsHasSampleRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -83521,8 +84659,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -83537,8 +84675,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -83555,6 +84693,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83578,6 +84717,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83587,11 +84727,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -83619,11 +84759,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -83653,6 +84793,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83662,8 +84803,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "RequestCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -83680,6 +84821,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83715,6 +84857,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83750,6 +84893,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83759,11 +84903,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -83779,11 +84923,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -83801,6 +84945,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -83810,11 +84955,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -83842,11 +84987,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -87704,6 +88849,7 @@
         "kind": "OBJECT",
         "name": "SampleRequestsHasSampleRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -87713,8 +88859,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -87729,8 +88875,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Request",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -87747,6 +88893,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -87770,6 +88917,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleRequestsHasSampleUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -87779,11 +88927,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -87799,11 +88947,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -87819,11 +88967,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -87839,11 +88987,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -87885,6 +89033,7 @@
         "kind": "OBJECT",
         "name": "SampleSampleAliasSampleAliasesIsAliasAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -87894,8 +89043,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -87924,6 +89073,7 @@
         "kind": "OBJECT",
         "name": "SampleSampleAliasSampleAliasesIsAliasNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "namespace",
@@ -87933,8 +89083,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -87949,8 +89099,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -87967,6 +89117,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -87976,11 +89127,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -88008,11 +89159,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -88102,6 +89253,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88111,11 +89263,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleAliasConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -88131,8 +89283,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -88161,6 +89313,7 @@
         "kind": "OBJECT",
         "name": "SampleSampleAliasesIsAliasConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -88170,14 +89323,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleSampleAliasesIsAliasRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -88194,8 +89347,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -88210,8 +89363,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -88228,6 +89381,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88251,6 +89405,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88260,11 +89415,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -88292,11 +89447,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -88326,6 +89481,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88335,8 +89491,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleAliasCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -88353,6 +89509,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88388,6 +89545,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88423,6 +89581,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88432,11 +89591,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -88452,11 +89611,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -88474,6 +89633,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88483,11 +89643,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -88515,11 +89675,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -88897,6 +90057,7 @@
         "kind": "OBJECT",
         "name": "SampleSampleAliasesIsAliasRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -88906,8 +90067,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -88922,8 +90083,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleAlias",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -88940,6 +90101,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88963,6 +90125,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSampleAliasesIsAliasUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -88972,11 +90135,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -88992,11 +90155,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -89012,11 +90175,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -89032,11 +90195,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -89078,6 +90241,7 @@
         "kind": "OBJECT",
         "name": "SampleSampleMetadataHasMetadataSampleMetadataAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -89087,8 +90251,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -89117,6 +90281,7 @@
         "kind": "OBJECT",
         "name": "SampleSampleMetadataHasMetadataSampleMetadataNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "additionalProperties",
@@ -89126,8 +90291,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89142,8 +90307,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89158,8 +90323,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89174,8 +90339,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89190,8 +90355,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89206,8 +90371,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89222,8 +90387,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89238,8 +90403,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89254,8 +90419,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89270,8 +90435,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89286,8 +90451,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BigIntAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89302,8 +90467,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89318,8 +90483,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89334,8 +90499,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89350,8 +90515,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89366,8 +90531,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89382,8 +90547,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89398,8 +90563,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89414,8 +90579,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89430,8 +90595,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89446,8 +90611,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89462,8 +90627,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89478,8 +90643,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89494,8 +90659,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89510,8 +90675,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89526,8 +90691,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89544,6 +90709,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleSort",
         "description": "Fields to sort Samples by. The order in which sorts are applied is not guaranteed when specifying many fields in one SampleSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -89615,6 +90781,7 @@
         "kind": "OBJECT",
         "name": "SampleTempoHasTempoTemposAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -89624,8 +90791,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -89654,6 +90821,7 @@
         "kind": "OBJECT",
         "name": "SampleTempoHasTempoTemposNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "accessLevel",
@@ -89663,8 +90831,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89679,8 +90847,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89695,8 +90863,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89711,8 +90879,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89727,8 +90895,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89743,8 +90911,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89759,8 +90927,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -89777,6 +90945,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -89786,11 +90955,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleCohortsHasCohortSampleUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -89818,11 +90987,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasDbgapDbGapsUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -89838,11 +91007,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasMetadataSampleMetadataUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -89858,11 +91027,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleHasTempoTemposUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -89878,11 +91047,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SamplePatientsHasSampleUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -89898,11 +91067,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleRequestsHasSampleUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -89930,11 +91099,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleSampleAliasesIsAliasUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -89988,6 +91157,7 @@
         "kind": "INPUT_OBJECT",
         "name": "SampleWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -89997,11 +91167,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -90029,11 +91199,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -90193,11 +91363,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -90933,11 +92103,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -91013,8 +92183,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -91089,11 +92259,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -91135,6 +92305,7 @@
         "kind": "OBJECT",
         "name": "SamplesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -91144,14 +92315,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -91168,8 +92339,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -91184,8 +92355,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -91202,6 +92373,7 @@
         "kind": "OBJECT",
         "name": "SeqDateAccessionBySampleId",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "DMP_SAMPLE_ID",
@@ -91211,8 +92383,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -91239,8 +92411,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -91257,6 +92429,7 @@
         "kind": "ENUM",
         "name": "SortDirection",
         "description": "An enum for sorting in either ascending or descending order.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -91280,6 +92453,7 @@
         "kind": "OBJECT",
         "name": "Status",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "requestMetadataHasStatus",
@@ -91326,14 +92500,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "RequestMetadata",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -91426,11 +92600,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "StatusRequestMetadataHasStatusConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -91456,8 +92630,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StatusRequestMetadataHasStatusConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -91509,14 +92683,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleMetadata",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -91609,11 +92783,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "StatusSampleMetadataHasStatusConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -91639,8 +92813,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StatusSampleMetadataHasStatusConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -91681,6 +92855,7 @@
         "kind": "OBJECT",
         "name": "StatusAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -91690,8 +92865,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -91706,8 +92881,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -91724,6 +92899,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -91733,11 +92909,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -91753,11 +92929,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -91775,6 +92951,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -91784,8 +92961,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "StatusWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -91802,6 +92979,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -91861,6 +93039,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -91870,11 +93049,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -91890,11 +93069,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -91912,6 +93091,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -91921,11 +93101,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -91941,11 +93121,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -91963,6 +93143,7 @@
         "kind": "OBJECT",
         "name": "StatusEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -91972,8 +93153,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -91988,8 +93169,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Status",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -92006,6 +93187,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92039,11 +93221,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -92061,6 +93243,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92070,11 +93253,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -92090,11 +93273,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -92112,6 +93295,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92121,11 +93305,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -92153,11 +93337,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -92247,6 +93431,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92256,11 +93441,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "RequestMetadataConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -92276,8 +93461,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -92306,6 +93491,7 @@
         "kind": "OBJECT",
         "name": "StatusRequestMetadataHasStatusConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -92315,14 +93501,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "StatusRequestMetadataHasStatusRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -92339,8 +93525,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -92355,8 +93541,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -92373,6 +93559,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92396,6 +93583,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92405,11 +93593,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -92437,11 +93625,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -92471,6 +93659,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92480,8 +93669,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "RequestMetadataCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -92498,6 +93687,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92533,6 +93723,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92568,6 +93759,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92577,11 +93769,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -92597,11 +93789,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -92619,6 +93811,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -92628,11 +93821,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -92660,11 +93853,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -93282,6 +94475,7 @@
         "kind": "OBJECT",
         "name": "StatusRequestMetadataHasStatusRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -93291,8 +94485,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -93307,8 +94501,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "RequestMetadata",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -93325,6 +94519,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93348,6 +94543,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusRequestMetadataHasStatusUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93357,11 +94553,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -93377,11 +94573,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -93397,11 +94593,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -93417,11 +94613,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -93463,6 +94659,7 @@
         "kind": "OBJECT",
         "name": "StatusRequestMetadataRequestMetadataHasStatusAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -93472,8 +94669,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -93502,6 +94699,7 @@
         "kind": "OBJECT",
         "name": "StatusRequestMetadataRequestMetadataHasStatusNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "igoRequestId",
@@ -93511,8 +94709,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -93527,8 +94725,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BigIntAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -93543,8 +94741,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -93561,6 +94759,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93570,11 +94769,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -93602,11 +94801,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -93696,6 +94895,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93705,11 +94905,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleMetadataConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -93725,8 +94925,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -93755,6 +94955,7 @@
         "kind": "OBJECT",
         "name": "StatusSampleMetadataHasStatusConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -93764,14 +94965,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "StatusSampleMetadataHasStatusRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -93788,8 +94989,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -93804,8 +95005,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -93822,6 +95023,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93845,6 +95047,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93854,11 +95057,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -93886,11 +95089,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -93920,6 +95123,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93929,8 +95133,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleMetadataCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -93947,6 +95151,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -93982,6 +95187,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -94017,6 +95223,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -94026,11 +95233,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -94046,11 +95253,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -94068,6 +95275,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -94077,11 +95285,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -94109,11 +95317,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -98871,6 +100079,7 @@
         "kind": "OBJECT",
         "name": "StatusSampleMetadataHasStatusRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -98880,8 +100089,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -98896,8 +100105,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "SampleMetadata",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -98914,6 +100123,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -98937,6 +100147,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSampleMetadataHasStatusUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -98946,11 +100157,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -98966,11 +100177,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -98986,11 +100197,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -99006,11 +100217,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -99052,6 +100263,7 @@
         "kind": "OBJECT",
         "name": "StatusSampleMetadataSampleMetadataHasStatusAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -99061,8 +100273,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -99091,6 +100303,7 @@
         "kind": "OBJECT",
         "name": "StatusSampleMetadataSampleMetadataHasStatusNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "additionalProperties",
@@ -99100,8 +100313,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99116,8 +100329,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99132,8 +100345,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99148,8 +100361,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99164,8 +100377,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99180,8 +100393,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99196,8 +100409,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99212,8 +100425,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99228,8 +100441,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99244,8 +100457,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99260,8 +100473,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BigIntAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99276,8 +100489,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99292,8 +100505,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99308,8 +100521,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99324,8 +100537,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99340,8 +100553,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99356,8 +100569,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99372,8 +100585,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99388,8 +100601,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99404,8 +100617,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99420,8 +100633,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99436,8 +100649,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99452,8 +100665,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99468,8 +100681,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99484,8 +100697,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99500,8 +100713,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -99518,6 +100731,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusSort",
         "description": "Fields to sort Statuses by. The order in which sorts are applied is not guaranteed when specifying many fields in one StatusSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -99553,6 +100767,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -99562,11 +100777,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusRequestMetadataHasStatusUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -99582,11 +100797,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusSampleMetadataHasStatusUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -99628,6 +100843,7 @@
         "kind": "INPUT_OBJECT",
         "name": "StatusWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -99637,11 +100853,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -99669,11 +100885,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "StatusWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -99941,8 +101157,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -99995,6 +101211,7 @@
         "kind": "OBJECT",
         "name": "StatusesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -100004,14 +101221,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "StatusEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -100028,8 +101245,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -100044,8 +101261,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -100062,6 +101279,7 @@
         "kind": "SCALAR",
         "name": "String",
         "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -100072,6 +101290,7 @@
         "kind": "OBJECT",
         "name": "StringAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "longest",
@@ -100107,6 +101326,7 @@
         "kind": "OBJECT",
         "name": "Tempo",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "accessLevel",
@@ -100225,14 +101445,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "BamComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -100325,11 +101545,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "TempoHasEventBamCompletesConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -100355,8 +101575,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "TempoHasEventBamCompletesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -100408,14 +101628,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "MafComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -100508,11 +101728,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "TempoHasEventMafCompletesConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -100538,8 +101758,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "TempoHasEventMafCompletesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -100591,14 +101811,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "QcComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -100691,11 +101911,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "TempoHasEventQcCompletesConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -100721,8 +101941,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "TempoHasEventQcCompletesConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -100786,14 +102006,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Sample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -100886,11 +102106,11 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
                     "name": null,
+                    "kind": "NON_NULL",
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "TempoSamplesHasTempoConnectionSort",
+                      "kind": "INPUT_OBJECT",
                       "ofType": null
                     }
                   }
@@ -100916,8 +102136,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "TempoSamplesHasTempoConnection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -100932,8 +102152,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -100950,6 +102170,7 @@
         "kind": "OBJECT",
         "name": "TempoAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "accessLevel",
@@ -100959,8 +102180,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -100975,8 +102196,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -100991,8 +102212,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -101007,8 +102228,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101023,8 +102244,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -101039,8 +102260,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -101055,8 +102276,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -101071,8 +102292,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -101089,6 +102310,7 @@
         "kind": "OBJECT",
         "name": "TempoBamCompleteHasEventBamCompletesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -101098,8 +102320,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101128,6 +102350,7 @@
         "kind": "OBJECT",
         "name": "TempoBamCompleteHasEventBamCompletesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -101137,8 +102360,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -101153,8 +102376,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -101171,6 +102394,7 @@
         "kind": "OBJECT",
         "name": "TempoCohortRequest",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortId",
@@ -101180,8 +102404,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101196,8 +102420,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101212,8 +102436,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101228,8 +102452,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101244,8 +102468,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101260,14 +102484,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "TempoCohortSample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -101284,8 +102508,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101302,6 +102526,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoCohortRequestInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101311,8 +102536,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101327,14 +102552,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "String",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 }
@@ -101351,14 +102576,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "SCALAR",
                     "name": "String",
+                    "kind": "SCALAR",
                     "ofType": null
                   }
                 }
@@ -101375,8 +102600,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101391,8 +102616,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101407,14 +102632,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
                     "name": "TempoCohortSampleInput",
+                    "kind": "INPUT_OBJECT",
                     "ofType": null
                   }
                 }
@@ -101431,8 +102656,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101449,6 +102674,7 @@
         "kind": "OBJECT",
         "name": "TempoCohortSample",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cmoId",
@@ -101482,8 +102708,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101500,6 +102726,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoCohortSampleInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101533,8 +102760,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101551,6 +102778,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoConnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101560,11 +102788,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -101580,11 +102808,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -101600,11 +102828,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -101620,11 +102848,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -101642,6 +102870,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoConnectWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101651,8 +102880,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "TempoWhere",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -101669,6 +102898,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoCreateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101810,8 +103040,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -101828,6 +103058,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoDeleteInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101837,11 +103068,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -101857,11 +103088,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -101877,11 +103108,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -101897,11 +103128,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -101919,6 +103150,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoDisconnectInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -101928,11 +103160,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -101948,11 +103180,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -101968,11 +103200,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -101988,11 +103220,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -102010,6 +103242,7 @@
         "kind": "OBJECT",
         "name": "TempoEdge",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -102019,8 +103252,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -102035,8 +103268,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Tempo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -102053,6 +103286,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102062,11 +103296,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -102094,11 +103328,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -102188,6 +103422,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102197,11 +103432,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "BamCompleteConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -102217,8 +103452,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -102247,6 +103482,7 @@
         "kind": "OBJECT",
         "name": "TempoHasEventBamCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -102256,14 +103492,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "TempoHasEventBamCompletesRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -102280,8 +103516,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -102296,8 +103532,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -102314,6 +103550,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102337,6 +103574,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102346,11 +103584,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -102378,11 +103616,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -102412,6 +103650,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102421,8 +103660,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "BamCompleteCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -102439,6 +103678,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102474,6 +103714,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102509,6 +103750,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102518,11 +103760,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -102538,11 +103780,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -102560,6 +103802,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -102569,11 +103812,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -102601,11 +103844,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -102983,6 +104226,7 @@
         "kind": "OBJECT",
         "name": "TempoHasEventBamCompletesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -102992,8 +104236,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -103008,8 +104252,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "BamComplete",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -103026,6 +104270,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103049,6 +104294,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventBamCompletesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103058,11 +104304,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -103078,11 +104324,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -103098,11 +104344,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -103118,11 +104364,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -103164,6 +104410,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103173,11 +104420,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -103205,11 +104452,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -103299,6 +104546,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103308,11 +104556,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "MafCompleteConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -103328,8 +104576,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -103358,6 +104606,7 @@
         "kind": "OBJECT",
         "name": "TempoHasEventMafCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -103367,14 +104616,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "TempoHasEventMafCompletesRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -103391,8 +104640,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -103407,8 +104656,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -103425,6 +104674,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103448,6 +104698,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103457,11 +104708,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -103489,11 +104740,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -103523,6 +104774,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103532,8 +104784,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "MafCompleteCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -103550,6 +104802,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103585,6 +104838,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103620,6 +104874,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103629,11 +104884,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -103649,11 +104904,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -103671,6 +104926,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -103680,11 +104936,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -103712,11 +104968,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -104274,6 +105530,7 @@
         "kind": "OBJECT",
         "name": "TempoHasEventMafCompletesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -104283,8 +105540,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -104299,8 +105556,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "MafComplete",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -104317,6 +105574,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104340,6 +105598,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventMafCompletesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104349,11 +105608,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -104369,11 +105628,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -104389,11 +105648,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -104409,11 +105668,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -104455,6 +105714,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104464,11 +105724,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -104496,11 +105756,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -104590,6 +105850,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104599,11 +105860,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "QcCompleteConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -104619,8 +105880,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -104649,6 +105910,7 @@
         "kind": "OBJECT",
         "name": "TempoHasEventQcCompletesConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -104658,14 +105920,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "TempoHasEventQcCompletesRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -104682,8 +105944,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -104698,8 +105960,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -104716,6 +105978,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104739,6 +106002,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104748,11 +106012,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -104780,11 +106044,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -104814,6 +106078,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104823,8 +106088,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "QcCompleteCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -104841,6 +106106,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104876,6 +106142,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104911,6 +106178,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104920,11 +106188,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -104940,11 +106208,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -104962,6 +106230,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -104971,11 +106240,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -105003,11 +106272,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -105745,6 +107014,7 @@
         "kind": "OBJECT",
         "name": "TempoHasEventQcCompletesRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -105754,8 +107024,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -105770,8 +107040,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "QcComplete",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -105788,6 +107058,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -105811,6 +107082,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoHasEventQcCompletesUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -105820,11 +107092,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -105840,11 +107112,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -105860,11 +107132,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -105880,11 +107152,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -105926,6 +107198,7 @@
         "kind": "OBJECT",
         "name": "TempoMafCompleteHasEventMafCompletesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -105935,8 +107208,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -105965,6 +107238,7 @@
         "kind": "OBJECT",
         "name": "TempoMafCompleteHasEventMafCompletesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -105974,8 +107248,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -105990,8 +107264,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -106006,8 +107280,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -106024,6 +107298,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoOptions",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106057,11 +107332,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSort",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106079,6 +107354,7 @@
         "kind": "OBJECT",
         "name": "TempoQcCompleteHasEventQcCompletesAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -106088,8 +107364,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -106118,6 +107394,7 @@
         "kind": "OBJECT",
         "name": "TempoQcCompleteHasEventQcCompletesNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "date",
@@ -106127,8 +107404,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -106143,8 +107420,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -106159,8 +107436,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -106175,8 +107452,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -106193,6 +107470,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoRelationInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106202,11 +107480,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106222,11 +107500,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106242,11 +107520,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106262,11 +107540,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106284,6 +107562,7 @@
         "kind": "OBJECT",
         "name": "TempoSampleSamplesHasTempoAggregationSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "count",
@@ -106293,8 +107572,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -106323,6 +107602,7 @@
         "kind": "OBJECT",
         "name": "TempoSampleSamplesHasTempoNodeAggregateSelection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "datasource",
@@ -106332,8 +107612,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -106348,8 +107628,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -106364,8 +107644,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -106380,8 +107660,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "StringAggregateSelection",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -106398,6 +107678,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoAggregateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106407,11 +107688,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106439,11 +107720,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoAggregateInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106533,6 +107814,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoConnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106542,11 +107824,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "SampleConnectInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106562,8 +107844,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -106592,6 +107874,7 @@
         "kind": "OBJECT",
         "name": "TempoSamplesHasTempoConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -106601,14 +107884,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "TempoSamplesHasTempoRelationship",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -106625,8 +107908,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -106641,8 +107924,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -106659,6 +107942,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoConnectionSort",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106682,6 +107966,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoConnectionWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106691,11 +107976,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106723,11 +108008,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoConnectionWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106757,6 +108042,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoCreateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106766,8 +108052,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "INPUT_OBJECT",
                 "name": "SampleCreateInput",
+                "kind": "INPUT_OBJECT",
                 "ofType": null
               }
             },
@@ -106784,6 +108070,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoDeleteFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106819,6 +108106,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoDisconnectFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106854,6 +108142,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106863,11 +108152,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106883,11 +108172,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106905,6 +108194,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoNodeAggregationWhereInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -106914,11 +108204,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -106946,11 +108236,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoNodeAggregationWhereInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -107688,6 +108978,7 @@
         "kind": "OBJECT",
         "name": "TempoSamplesHasTempoRelationship",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cursor",
@@ -107697,8 +108988,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -107713,8 +109004,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "Sample",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -107731,6 +109022,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoUpdateConnectionInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -107754,6 +109046,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSamplesHasTempoUpdateFieldInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -107763,11 +109056,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoConnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -107783,11 +109076,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoCreateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -107803,11 +109096,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoDeleteFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -107823,11 +109116,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoDisconnectFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -107869,6 +109162,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoSort",
         "description": "Fields to sort Tempos by. The order in which sorts are applied is not guaranteed when specifying many fields in one TempoSort object.",
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -107976,6 +109270,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoUpdateInput",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -108057,11 +109352,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventBamCompletesUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -108077,11 +109372,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventMafCompletesUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -108097,11 +109392,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoHasEventQcCompletesUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -108129,11 +109424,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoSamplesHasTempoUpdateFieldInput",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -108163,6 +109458,7 @@
         "kind": "INPUT_OBJECT",
         "name": "TempoWhere",
         "description": null,
+        "isOneOf": false,
         "fields": null,
         "inputFields": [
           {
@@ -108172,11 +109468,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -108204,11 +109500,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
                   "name": "TempoWhere",
+                  "kind": "INPUT_OBJECT",
                   "ofType": null
                 }
               }
@@ -108260,8 +109556,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -108348,8 +109644,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -108424,8 +109720,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -108500,8 +109796,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -108576,8 +109872,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -108976,8 +110272,8 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -109160,11 +110456,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "SCALAR",
                   "name": "String",
+                  "kind": "SCALAR",
                   "ofType": null
                 }
               }
@@ -109206,6 +110502,7 @@
         "kind": "OBJECT",
         "name": "TemposConnection",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "edges",
@@ -109215,14 +110512,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "TempoEdge",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -109239,8 +110536,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "PageInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109255,8 +110552,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -109273,6 +110570,7 @@
         "kind": "OBJECT",
         "name": "ToleratedSampleValidationError",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "primaryId",
@@ -109282,8 +110580,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -109324,6 +110622,7 @@
         "kind": "OBJECT",
         "name": "UpdateBamCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "bamCompletes",
@@ -109333,14 +110632,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "BamComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -109357,8 +110656,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109375,6 +110674,7 @@
         "kind": "OBJECT",
         "name": "UpdateCohortCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohortCompletes",
@@ -109384,14 +110684,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "CohortComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -109408,8 +110708,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109426,6 +110726,7 @@
         "kind": "OBJECT",
         "name": "UpdateCohortsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "cohorts",
@@ -109435,14 +110736,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Cohort",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -109459,8 +110760,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109477,6 +110778,7 @@
         "kind": "OBJECT",
         "name": "UpdateDbGapsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "dbGaps",
@@ -109486,14 +110788,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "DbGap",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -109510,8 +110812,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109528,6 +110830,7 @@
         "kind": "OBJECT",
         "name": "UpdateInfo",
         "description": "Information about the number of nodes and relationships created and deleted during an update mutation",
+        "isOneOf": null,
         "fields": [
           {
             "name": "bookmark",
@@ -109549,8 +110852,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -109565,8 +110868,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -109581,8 +110884,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -109597,8 +110900,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Int",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -109615,6 +110918,7 @@
         "kind": "OBJECT",
         "name": "UpdateMafCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109624,8 +110928,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109640,14 +110944,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "MafComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -109666,6 +110970,7 @@
         "kind": "OBJECT",
         "name": "UpdatePatientAliasesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109675,8 +110980,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109691,14 +110996,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "PatientAlias",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -109717,6 +111022,7 @@
         "kind": "OBJECT",
         "name": "UpdatePatientsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109726,8 +111032,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109742,14 +111048,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Patient",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -109768,6 +111074,7 @@
         "kind": "OBJECT",
         "name": "UpdateProjectsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109777,8 +111084,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109793,14 +111100,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Project",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -109819,6 +111126,7 @@
         "kind": "OBJECT",
         "name": "UpdateQcCompletesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109828,8 +111136,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109844,14 +111152,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "QcComplete",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -109870,6 +111178,7 @@
         "kind": "OBJECT",
         "name": "UpdateRequestMetadataMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109879,8 +111188,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109895,14 +111204,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "RequestMetadata",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -109921,6 +111230,7 @@
         "kind": "OBJECT",
         "name": "UpdateRequestsMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109930,8 +111240,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109946,14 +111256,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Request",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -109972,6 +111282,7 @@
         "kind": "OBJECT",
         "name": "UpdateSampleAliasesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -109981,8 +111292,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -109997,14 +111308,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleAlias",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -110023,6 +111334,7 @@
         "kind": "OBJECT",
         "name": "UpdateSampleMetadataMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -110032,8 +111344,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -110048,14 +111360,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "SampleMetadata",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -110074,6 +111386,7 @@
         "kind": "OBJECT",
         "name": "UpdateSamplesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -110083,8 +111396,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -110099,14 +111412,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Sample",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -110125,6 +111438,7 @@
         "kind": "OBJECT",
         "name": "UpdateStatusesMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -110134,8 +111448,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -110150,14 +111464,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Status",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -110176,6 +111490,7 @@
         "kind": "OBJECT",
         "name": "UpdateTemposMutationResponse",
         "description": null,
+        "isOneOf": null,
         "fields": [
           {
             "name": "info",
@@ -110185,8 +111500,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "UpdateInfo",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -110201,14 +111516,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "Tempo",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -110227,6 +111542,7 @@
         "kind": "OBJECT",
         "name": "__Directive",
         "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+        "isOneOf": null,
         "fields": [
           {
             "name": "name",
@@ -110236,8 +111552,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -110264,8 +111580,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -110280,14 +111596,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "ENUM",
                     "name": "__DirectiveLocation",
+                    "kind": "ENUM",
                     "ofType": null
                   }
                 }
@@ -110317,18 +111633,46 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "__InputValue",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isDeprecated",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "Boolean",
+                "kind": "SCALAR",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deprecationReason",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -110343,6 +111687,7 @@
         "kind": "ENUM",
         "name": "__DirectiveLocation",
         "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -110460,6 +111805,12 @@
             "description": "Location adjacent to an input object field definition.",
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "DIRECTIVE_DEFINITION",
+            "description": "Location adjacent to a directive definition.",
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null
@@ -110468,6 +111819,7 @@
         "kind": "OBJECT",
         "name": "__EnumValue",
         "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+        "isOneOf": null,
         "fields": [
           {
             "name": "name",
@@ -110477,8 +111829,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -110505,8 +111857,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -110535,6 +111887,7 @@
         "kind": "OBJECT",
         "name": "__Field",
         "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+        "isOneOf": null,
         "fields": [
           {
             "name": "name",
@@ -110544,8 +111897,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -110585,14 +111938,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "__InputValue",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -110609,8 +111962,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "__Type",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -110625,8 +111978,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -110655,6 +112008,7 @@
         "kind": "OBJECT",
         "name": "__InputValue",
         "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+        "isOneOf": null,
         "fields": [
           {
             "name": "name",
@@ -110664,8 +112018,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -110692,8 +112046,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "__Type",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -110720,8 +112074,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -110750,6 +112104,7 @@
         "kind": "OBJECT",
         "name": "__Schema",
         "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+        "isOneOf": null,
         "fields": [
           {
             "name": "description",
@@ -110771,14 +112126,14 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "__Type",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -110795,8 +112150,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
                 "name": "__Type",
+                "kind": "OBJECT",
                 "ofType": null
               }
             },
@@ -110830,19 +112185,36 @@
           {
             "name": "directives",
             "description": "A list of all directives supported by this server.",
-            "args": [],
+            "args": [
+              {
+                "name": "includeDeprecated",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "name": "Boolean",
+                    "kind": "SCALAR",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "false",
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
                 "name": null,
+                "kind": "LIST",
                 "ofType": {
-                  "kind": "NON_NULL",
                   "name": null,
+                  "kind": "NON_NULL",
                   "ofType": {
-                    "kind": "OBJECT",
                     "name": "__Directive",
+                    "kind": "OBJECT",
                     "ofType": null
                   }
                 }
@@ -110861,6 +112233,7 @@
         "kind": "OBJECT",
         "name": "__Type",
         "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByURL`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+        "isOneOf": null,
         "fields": [
           {
             "name": "kind",
@@ -110870,8 +112243,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "ENUM",
                 "name": "__TypeKind",
+                "kind": "ENUM",
                 "ofType": null
               }
             },
@@ -110935,11 +112308,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "OBJECT",
                   "name": "__Field",
+                  "kind": "OBJECT",
                   "ofType": null
                 }
               }
@@ -110955,11 +112328,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "OBJECT",
                   "name": "__Type",
+                  "kind": "OBJECT",
                   "ofType": null
                 }
               }
@@ -110975,11 +112348,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "OBJECT",
                   "name": "__Type",
+                  "kind": "OBJECT",
                   "ofType": null
                 }
               }
@@ -111008,11 +112381,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "OBJECT",
                   "name": "__EnumValue",
+                  "kind": "OBJECT",
                   "ofType": null
                 }
               }
@@ -111041,11 +112414,11 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
                 "name": null,
+                "kind": "NON_NULL",
                 "ofType": {
-                  "kind": "OBJECT",
                   "name": "__InputValue",
+                  "kind": "OBJECT",
                   "ofType": null
                 }
               }
@@ -111064,6 +112437,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "isOneOf",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -111075,6 +112460,7 @@
         "kind": "ENUM",
         "name": "__TypeKind",
         "description": "An enum describing what kind of type a given `__Type` is.",
+        "isOneOf": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -111136,8 +112522,11 @@
         "name": "deprecated",
         "description": "Marks an element of a GraphQL schema as no longer supported.",
         "isRepeatable": false,
+        "isDeprecated": false,
+        "deprecationReason": null,
         "locations": [
           "ARGUMENT_DEFINITION",
+          "DIRECTIVE_DEFINITION",
           "ENUM_VALUE",
           "FIELD_DEFINITION",
           "INPUT_FIELD_DEFINITION"
@@ -111161,6 +112550,8 @@
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
         "isRepeatable": false,
+        "isDeprecated": false,
+        "deprecationReason": null,
         "locations": [
           "FIELD",
           "FRAGMENT_SPREAD",
@@ -111174,8 +112565,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -111186,9 +112577,22 @@
         ]
       },
       {
+        "name": "oneOf",
+        "description": "Indicates exactly one field must be supplied and this field must not be `null`.",
+        "isRepeatable": false,
+        "isDeprecated": false,
+        "deprecationReason": null,
+        "locations": [
+          "INPUT_OBJECT"
+        ],
+        "args": []
+      },
+      {
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
         "isRepeatable": false,
+        "isDeprecated": false,
+        "deprecationReason": null,
         "locations": [
           "FIELD",
           "FRAGMENT_SPREAD",
@@ -111202,8 +112606,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "Boolean",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },
@@ -111217,6 +112621,8 @@
         "name": "specifiedBy",
         "description": "Exposes a URL that specifies the behavior of this scalar.",
         "isRepeatable": false,
+        "isDeprecated": false,
+        "deprecationReason": null,
         "locations": [
           "SCALAR"
         ],
@@ -111228,8 +112634,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
                 "name": "String",
+                "kind": "SCALAR",
                 "ofType": null
               }
             },

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -90,6 +90,7 @@ query DashboardCohorts(
     offset: $offset
   ) {
     cohortId
+    cohortStatus
     totalSampleCount
     billed
     initialCohortDeliveryDate

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "apollo-link-http": "^1.5.17"
   },
   "devDependencies": {
-    "@graphql-codegen/cli": "^5.0.0"
+    "@graphql-codegen/cli": "^5.0.0",
+    "node-gyp": "9.4.1"
   },
   "resolutions": {
     "@whatwg-node/fetch": "0.9.16",
@@ -42,6 +43,8 @@
     "@graphql-tools/executor": "1.3.3",
     "inquirer": "8.2.6",
     "graphql-config": "5.1.5",
+    "@graphql-codegen/typescript-operations": "4.4.1",
+    "@graphql-codegen/typescript": "4.1.6",
     "@graphql-tools/apollo-engine-loader": "8.0.12",
     "@graphql-tools/github-loader": "8.0.12",
     "@neo4j/graphql": "5.12.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,10 +84,10 @@
     "@types/node" "^10.1.0"
     long "^4.0.0"
 
-"@apollo/protobufjs@1.2.7":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.7.tgz#3a8675512817e4a046a897e5f4f16415f16a7d8a"
-  integrity sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==
+"@apollo/protobufjs@1.2.8":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.8.tgz#c7156eccded1e843a5ac5b693798a0d0bc08a570"
+  integrity sha512-r7xNeUqZX+eBBEmyvaPw0/cSz6zgf5jdH8mjUz8ynKpNs/GU7vi2T7sNcZINk2ZID7wwjG91FCgdpCrQuJ8rzA==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -111,11 +111,11 @@
     "@apollo/federation-internals" "2.12.3"
 
 "@apollo/usage-reporting-protobuf@^4.0.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.1.tgz#407c3d18c7fbed7a264f3b9a3812620b93499de1"
-  integrity sha512-u40dIUePHaSKVshcedO7Wp+mPiZsaU6xjv9J+VyxpoU/zL6Jle+9zWeG98tr/+SZ0nZ4OXhrbb8SNr0rAPpIDA==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.2.tgz#e70e9d2ec00858900f93c4133ca49c9f710896a2"
+  integrity sha512-aTnAD41RYz0d5dawlyR5Iclkgzx0Xb0njUJmEfvZ6pS4f4HU8wCYyctPpWat/HWp2PmRwDfX5R1k4uVcDKZ4xA==
   dependencies:
-    "@apollo/protobufjs" "1.2.7"
+    "@apollo/protobufjs" "1.2.8"
 
 "@apollo/utils.dropunuseddefinitions@^1.1.0":
   version "1.1.0"
@@ -257,10 +257,10 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
-"@babel/compat-data@^7.20.5", "@babel/compat-data@^7.28.6", "@babel/compat-data@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.0.tgz#00d03e8c0ac24dd9be942c5370990cbe1f17d88d"
-  integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
+"@babel/compat-data@^7.20.5", "@babel/compat-data@^7.28.6", "@babel/compat-data@^7.29.3":
+  version "7.29.3"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.3.tgz#e3f5347f0589596c91d227ccb6a541d37fb1307b"
+  integrity sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==
 
 "@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.12.3", "@babel/core@^7.14.0", "@babel/core@^7.16.0", "@babel/core@^7.28.6", "@babel/core@^7.7.2", "@babel/core@^7.8.0":
   version "7.29.0"
@@ -331,16 +331,16 @@
     semver "^6.3.1"
 
 "@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.21.0", "@babel/helper-create-class-features-plugin@^7.28.6":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz#611ff5482da9ef0db6291bcd24303400bca170fb"
-  integrity sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==
+  version "7.29.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz#67328947d956f06fc7b48def269bf0489155fd42"
+  integrity sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.27.3"
     "@babel/helper-member-expression-to-functions" "^7.28.5"
     "@babel/helper-optimise-call-expression" "^7.27.1"
     "@babel/helper-replace-supers" "^7.28.6"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
-    "@babel/traverse" "^7.28.6"
+    "@babel/traverse" "^7.29.0"
     semver "^6.3.1"
 
 "@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.27.1", "@babel/helper-create-regexp-features-plugin@^7.28.5":
@@ -464,9 +464,9 @@
     "@babel/types" "^7.29.0"
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.1.3", "@babel/parser@^7.14.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.28.6", "@babel/parser@^7.29.0", "@babel/parser@^7.29.2":
-  version "7.29.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.2.tgz#58bd50b9a7951d134988a1ae177a35ef9a703ba1"
-  integrity sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==
+  version "7.29.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.3.tgz#116f70a77958307fceac27747573032f8a62f88e"
+  integrity sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==
   dependencies:
     "@babel/types" "^7.29.0"
 
@@ -491,6 +491,14 @@
   integrity sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@^7.29.3":
+  version "7.29.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.3.tgz#2e14f9335803d892ccb67ef487e23cf9726156fe"
+  integrity sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.28.6"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.27.1":
   version "7.27.1"
@@ -937,10 +945,10 @@
     "@babel/helper-module-transforms" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"
 
-"@babel/plugin-transform-modules-systemjs@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz#e458a95a17807c415924106a3ff188a3b8dee964"
-  integrity sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==
+"@babel/plugin-transform-modules-systemjs@^7.29.4":
+  version "7.29.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz#f621105da99919c15cf4bde6fcc7346ef95e7b20"
+  integrity sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==
   dependencies:
     "@babel/helper-module-transforms" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"
@@ -1202,17 +1210,18 @@
     "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/preset-env@^7.11.0", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.16.4":
-  version "7.29.2"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.29.2.tgz#5a173f22c7d8df362af1c9fe31facd320de4a86c"
-  integrity sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==
+  version "7.29.5"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.29.5.tgz#c48b7ed94582c8b685e21b8b42de8633ec289268"
+  integrity sha512-/69t2aEzGKHD76DyLbHysF/QH2LJOB8iFnYO37unDTKBTubzcMRv0f3H5EiN1Q6ajOd/eB7dAInF0qdFVS06kA==
   dependencies:
-    "@babel/compat-data" "^7.29.0"
+    "@babel/compat-data" "^7.29.3"
     "@babel/helper-compilation-targets" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"
     "@babel/helper-validator-option" "^7.27.1"
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key" "^7.28.5"
     "@babel/plugin-bugfix-safari-class-field-initializer-scope" "^7.27.1"
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.27.1"
+    "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array" "^7.29.3"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.27.1"
     "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly" "^7.28.6"
     "@babel/plugin-proposal-private-property-in-object" "7.21.0-placeholder-for-preset-env.2"
@@ -1244,7 +1253,7 @@
     "@babel/plugin-transform-member-expression-literals" "^7.27.1"
     "@babel/plugin-transform-modules-amd" "^7.27.1"
     "@babel/plugin-transform-modules-commonjs" "^7.28.6"
-    "@babel/plugin-transform-modules-systemjs" "^7.29.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.29.4"
     "@babel/plugin-transform-modules-umd" "^7.27.1"
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.29.0"
     "@babel/plugin-transform-new-target" "^7.27.1"
@@ -1490,9 +1499,9 @@
     kuler "^2.0.0"
 
 "@databricks/sql@^1.11.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@databricks/sql/-/sql-1.13.0.tgz#c5f48cf09111cdb041c7ba697e0d994770f64518"
-  integrity sha512-xBuxCKmq3gR2fXnCzHsWkPujd5Vi/QxtHAyZXlj180v0fAqucIrG3SckSS5bpbF/NOH7uPLjolBUiZWDJ8E4xQ==
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@databricks/sql/-/sql-1.14.0.tgz#883500c6f22537f7dc4aa4ec9d64d131cbab95c2"
+  integrity sha512-zMmt+idrDRDtXuoMC7sXdr1AJh7Q8Vy6tKovbJ/PvA24zDBz2w8Z1FQApT39IMNL9SAz89IeRZJcMOzfxVelaQ==
   dependencies:
     apache-arrow "^13.0.0"
     commander "^9.3.0"
@@ -1590,6 +1599,11 @@
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
+
+"@gar/promisify@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
+  integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
 "@graphql-codegen/add@^5.0.3":
   version "5.0.3"
@@ -1725,15 +1739,6 @@
     lodash "~4.17.0"
     tslib "~2.6.0"
 
-"@graphql-codegen/schema-ast@^2.5.0", "@graphql-codegen/schema-ast@^2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/schema-ast/-/schema-ast-2.6.1.tgz#8ba1b38827c034b51ecd3ce88622c2ae6cd3fe1a"
-  integrity sha512-5TNW3b1IHJjCh07D2yQNGDQzUpUl2AD+GVe1Dzjqyx/d2Fn0TPMxLsHsKPS4Plg4saO8FK/QO70wLsP7fdbQ1w==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^3.1.2"
-    "@graphql-tools/utils" "^9.0.0"
-    tslib "~2.4.0"
-
 "@graphql-codegen/schema-ast@^4.0.2":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/schema-ast/-/schema-ast-4.1.0.tgz#a1e71f99346495b9272161a9ed07756e82648726"
@@ -1754,25 +1759,14 @@
     change-case-all "1.0.15"
     tslib "~2.6.0"
 
-"@graphql-codegen/typescript-operations@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-2.5.1.tgz#99a6f3b3086214086582d2731058ec74090da308"
-  integrity sha512-lGv+sPDXGcp/vDdIh7SoQjz8BRCZhLats4Hbqnf6gB7UtIasMvGuFDQyrKb3XAkQQYWqx/xtmEo0rBN8syV+Wg==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.5.0"
-    "@graphql-codegen/typescript" "^2.7.1"
-    "@graphql-codegen/visitor-plugin-common" "2.11.1"
-    auto-bind "~4.0.0"
-    tslib "~2.4.0"
-
-"@graphql-codegen/typescript-operations@^4.6.1":
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-4.6.1.tgz#763eda28c77fddee2b9ae9bd7baad050cffff0a5"
-  integrity sha512-k92laxhih7s0WZ8j5WMIbgKwhe64C0As6x+PdcvgZFMudDJ7rPJ/hFqJ9DCRxNjXoHmSjnr6VUuQZq4lT1RzCA==
+"@graphql-codegen/typescript-operations@2.5.1", "@graphql-codegen/typescript-operations@4.4.1", "@graphql-codegen/typescript-operations@^4.6.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-4.4.1.tgz#a3d10ff2f0cc7c016493c035cc8f00fad38485b4"
+  integrity sha512-iqAdEe4wfxGPT9s/VD+EhehBzaTxvWdisbsqiM6dMfk+8FfjrOj8SDBsHzKwmkRcrpMK6h9gLr3XcuBPu0JoFg==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^5.1.0"
-    "@graphql-codegen/typescript" "^4.1.6"
-    "@graphql-codegen/visitor-plugin-common" "5.8.0"
+    "@graphql-codegen/typescript" "^4.1.3"
+    "@graphql-codegen/visitor-plugin-common" "5.6.1"
     auto-bind "~4.0.0"
     tslib "~2.6.0"
 
@@ -1787,29 +1781,7 @@
     change-case-all "1.0.14"
     tslib "~2.4.0"
 
-"@graphql-codegen/typescript@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.7.1.tgz#e237dd8829842282245b79ce7ea024aaa3c39afb"
-  integrity sha512-qF4SBMgBnLcegba2s9+zC3NwgRhU0Kv+eS8kl9G5ldEHx9Bpu2tft+lk6fjqqhExDzJT+MEOU3Ecog3BzL2R1g==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^2.5.0"
-    "@graphql-codegen/schema-ast" "^2.5.0"
-    "@graphql-codegen/visitor-plugin-common" "2.11.1"
-    auto-bind "~4.0.0"
-    tslib "~2.4.0"
-
-"@graphql-codegen/typescript@^2.7.1":
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.8.8.tgz#8c3b9153e334db43c65f8f31ced69b4c60d14861"
-  integrity sha512-A0oUi3Oy6+DormOlrTC4orxT9OBZkIglhbJBcDmk34jAKKUgesukXRd4yOhmTrnbchpXz2T8IAOFB3FWIaK4Rw==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^3.1.2"
-    "@graphql-codegen/schema-ast" "^2.6.1"
-    "@graphql-codegen/visitor-plugin-common" "2.13.8"
-    auto-bind "~4.0.0"
-    tslib "~2.4.0"
-
-"@graphql-codegen/typescript@^4.0.0", "@graphql-codegen/typescript@^4.1.6":
+"@graphql-codegen/typescript@2.7.1", "@graphql-codegen/typescript@4.1.6", "@graphql-codegen/typescript@^4.0.0", "@graphql-codegen/typescript@^4.1.3", "@graphql-codegen/typescript@^4.1.6":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-4.1.6.tgz#f3481ccc1656e96892d629671fb2cff5dabc458b"
   integrity sha512-vpw3sfwf9A7S+kIUjyFxuvrywGxd4lmwmyYnnDVjVE4kSQ6Td3DpqaPTy8aNQ6O96vFoi/bxbZS2BW49PwSUUA==
@@ -1836,21 +1808,21 @@
     parse-filepath "^1.0.2"
     tslib "~2.4.0"
 
-"@graphql-codegen/visitor-plugin-common@2.13.8", "@graphql-codegen/visitor-plugin-common@^2.11.0":
-  version "2.13.8"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.8.tgz#09bc6317b227e5a278f394f4cef0d6c2d1910597"
-  integrity sha512-IQWu99YV4wt8hGxIbBQPtqRuaWZhkQRG2IZKbMoSvh0vGeWb3dB0n0hSgKaOOxDY+tljtOf9MTcUYvJslQucMQ==
+"@graphql-codegen/visitor-plugin-common@5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-5.6.1.tgz#492ed514530e43a38d875cdbc8b312a565ac8ce0"
+  integrity sha512-q+DkGWWS7pvSc1c4Hw1xD0RI+EplTe2PCyTCT0WuaswnodBytteKTqFOVVGadISLX0xhO25aANTFB4+TLwTBSA==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^3.1.2"
-    "@graphql-tools/optimize" "^1.3.0"
-    "@graphql-tools/relay-operation-optimizer" "^6.5.0"
-    "@graphql-tools/utils" "^9.0.0"
+    "@graphql-codegen/plugin-helpers" "^5.1.0"
+    "@graphql-tools/optimize" "^2.0.0"
+    "@graphql-tools/relay-operation-optimizer" "^7.0.0"
+    "@graphql-tools/utils" "^10.0.0"
     auto-bind "~4.0.0"
     change-case-all "1.0.15"
     dependency-graph "^0.11.0"
     graphql-tag "^2.11.0"
     parse-filepath "^1.0.2"
-    tslib "~2.4.0"
+    tslib "~2.6.0"
 
 "@graphql-codegen/visitor-plugin-common@5.8.0", "@graphql-codegen/visitor-plugin-common@^5.8.0":
   version "5.8.0"
@@ -1867,6 +1839,22 @@
     graphql-tag "^2.11.0"
     parse-filepath "^1.0.2"
     tslib "~2.6.0"
+
+"@graphql-codegen/visitor-plugin-common@^2.11.0":
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.8.tgz#09bc6317b227e5a278f394f4cef0d6c2d1910597"
+  integrity sha512-IQWu99YV4wt8hGxIbBQPtqRuaWZhkQRG2IZKbMoSvh0vGeWb3dB0n0hSgKaOOxDY+tljtOf9MTcUYvJslQucMQ==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^3.1.2"
+    "@graphql-tools/optimize" "^1.3.0"
+    "@graphql-tools/relay-operation-optimizer" "^6.5.0"
+    "@graphql-tools/utils" "^9.0.0"
+    auto-bind "~4.0.0"
+    change-case-all "1.0.15"
+    dependency-graph "^0.11.0"
+    graphql-tag "^2.11.0"
+    parse-filepath "^1.0.2"
+    tslib "~2.4.0"
 
 "@graphql-tools/apollo-engine-loader@8.0.12", "@graphql-tools/apollo-engine-loader@^8.0.0":
   version "8.0.12"
@@ -2751,6 +2739,22 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@npmcli/fs@^2.1.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-2.1.2.tgz#a9e2541a4a2fec2e69c29b35e6060973da79b865"
+  integrity sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==
+  dependencies:
+    "@gar/promisify" "^1.1.3"
+    semver "^7.3.5"
+
+"@npmcli/move-file@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-2.0.1.tgz#26f6bdc379d87f75e55739bab89db525b06100e4"
+  integrity sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==
+  dependencies:
+    mkdirp "^1.0.4"
+    rimraf "^3.0.2"
+
 "@oclif/color@^1.0.0", "@oclif/color@^1.0.1":
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/@oclif/color/-/color-1.0.13.tgz#91a5c9c271f686bb72ce013e67fa363ddaab2f43"
@@ -3381,6 +3385,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tootallnate/once@2":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.1.tgz#35adc6222e3662fa2222ce123b961476a746b9ea"
+  integrity sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==
+
 "@tootallnate/quickjs-emscripten@^0.23.0":
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
@@ -3524,9 +3533,9 @@
     "@types/json-schema" "*"
 
 "@types/estree@*", "@types/estree@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
-  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
+  integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
 
 "@types/estree@0.0.39":
   version "0.0.39"
@@ -3688,9 +3697,9 @@
     "@types/node" "*"
 
 "@types/node@*", "@types/node@>=6":
-  version "25.6.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.0.tgz#4e09bad9b469871f2d0f68140198cbd714f4edca"
-  integrity sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==
+  version "25.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.2.tgz#8c491201373690e4ef2a2ffed0dfb510a5830b92"
+  integrity sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==
   dependencies:
     undici-types "~7.19.0"
 
@@ -3742,9 +3751,9 @@
   integrity sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==
 
 "@types/qs@*":
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.15.0.tgz#963ab61779843fe910639a50661b48f162bc7f79"
-  integrity sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==
+  version "6.15.1"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.15.1.tgz#8606884272c63f0db96986bd3548650d8a9388bf"
+  integrity sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==
 
 "@types/range-parser@*":
   version "1.2.7"
@@ -4017,9 +4026,9 @@
     eslint-visitor-keys "^3.3.0"
 
 "@ungap/structured-clone@^1.2.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
-  integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.1.tgz#0e8f34854df7966b09304a18e808b23997bb9fc1"
+  integrity sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==
 
 "@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.14.1":
   version "1.14.1"
@@ -4231,6 +4240,11 @@ abab@^2.0.3, abab@^2.0.5:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
+abbrev@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
 accepts@^1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -4309,7 +4323,7 @@ ag-grid-react@^28.2.1:
   dependencies:
     prop-types "^15.8.1"
 
-agent-base@6:
+agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
@@ -4320,6 +4334,13 @@ agent-base@^7.1.0, agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
   integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
+agentkeepalive@^4.2.1:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.6.0.tgz#35f73e94b3f40bf65f105219c623ad19c136ea6a"
+  integrity sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==
+  dependencies:
+    humanize-ms "^1.2.1"
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -4828,6 +4849,19 @@ apollo@^2.34.0:
     tty "1.0.1"
     vscode-uri "1.0.6"
 
+"aproba@^1.0.3 || ^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.1.0.tgz#75500a190313d95c64e871e7e4284c6ac219f0b1"
+  integrity sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==
+
+are-we-there-yet@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz#679df222b278c64f2cdba1175cdc00b0d96164bd"
+  integrity sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^3.6.0"
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
@@ -5330,9 +5364,9 @@ base64-js@^1.3.1:
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 baseline-browser-mapping@^2.10.12:
-  version "2.10.24"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz#6dc320c7bf53859ec2bf55d54db6d2e5c078df16"
-  integrity sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==
+  version "2.10.28"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.28.tgz#9ba8e7b5ef9d40ceb3dd1cdcb936f63383b6833b"
+  integrity sha512-Ic44hnOtFIgravCunj1ifSoQPSUrkNiJuH9Mf6jr2jjoA74icqV8wU0KuadXeOR8zuIJMOoTv0GuQjZ9ZYNMeA==
 
 basic-auth@~2.0.1:
   version "2.0.1"
@@ -5522,6 +5556,30 @@ bytes@3.1.2, bytes@~3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
+cacache@^16.1.0:
+  version "16.1.3"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-16.1.3.tgz#a02b9f34ecfaf9a78c9f4bc16fceb94d5d67a38e"
+  integrity sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==
+  dependencies:
+    "@npmcli/fs" "^2.1.0"
+    "@npmcli/move-file" "^2.0.0"
+    chownr "^2.0.0"
+    fs-minipass "^2.1.0"
+    glob "^8.0.1"
+    infer-owner "^1.0.4"
+    lru-cache "^7.7.1"
+    minipass "^3.1.6"
+    minipass-collect "^1.0.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    mkdirp "^1.0.4"
+    p-map "^4.0.0"
+    promise-inflight "^1.0.1"
+    rimraf "^3.0.2"
+    ssri "^9.0.0"
+    tar "^6.1.11"
+    unique-filename "^2.0.0"
+
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
@@ -5592,9 +5650,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001782, caniuse-lite@^1.0.30001787:
-  version "1.0.30001791"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz#dfb93d85c40ad380c57123e72e10f3c575786b51"
-  integrity sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==
+  version "1.0.30001792"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz#ca8bb9be244835a335e2018272ce7223691873c5"
+  integrity sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -5749,6 +5807,11 @@ chokidar@^4.0.0:
   integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
   dependencies:
     readdirp "^4.0.1"
+
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 chrome-trace-event@^1.0.2:
   version "1.0.4"
@@ -5977,6 +6040,11 @@ color-string@1.9.1, color-string@^1.9.0:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
+color-support@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
+  integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
 color@4.2.3, color@^5.0.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
@@ -6111,6 +6179,11 @@ connect-history-api-fallback@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
   integrity sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==
+
+console-control-strings@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+  integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
 constant-case@^3.0.4:
   version "3.0.4"
@@ -6569,7 +6642,7 @@ debug@2.6.9, debug@^2.6.0, debug@~2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.3:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -6663,6 +6736,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
 
 depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
@@ -6915,9 +6993,9 @@ ejs@^3.1.6:
     jake "^10.8.5"
 
 electron-to-chromium@^1.5.328:
-  version "1.5.344"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz#6437cc08a7d9b914a98120e182f37793c9eaffd4"
-  integrity sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==
+  version "1.5.353"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz#01e8a8e25a0bf13e631106045f177d0568ca91c2"
+  integrity sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -6959,10 +7037,17 @@ encodeurl@~2.0.0:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
+encoding@^0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
+
 enhanced-resolve@^5.20.0:
-  version "5.21.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz#bb8e6fabaf74930de70e61397798750429e5b1ae"
-  integrity sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==
+  version "5.21.2"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.21.2.tgz#ddbedd0c7f14c3c51adfc24f5a14d76a83395442"
+  integrity sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.3.3"
@@ -6980,6 +7065,16 @@ env-ci@7.1.0:
     execa "^5.0.0"
     fromentries "^1.3.2"
     java-properties "^1.0.0"
+
+env-paths@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
+  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
+
+err-code@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
+  integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
 error-ex@^1.3.1:
   version "1.3.4"
@@ -7483,6 +7578,11 @@ expect@^27.5.1:
     jest-matcher-utils "^27.5.1"
     jest-message-util "^27.5.1"
 
+exponential-backoff@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.3.tgz#51cf92c1c0493c766053f9d3abee4434c244d2f6"
+  integrity sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==
+
 express-session@^1.17.3:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.19.0.tgz#682139f6eec6c69db9febbe2362e8a85dd84af2f"
@@ -7614,9 +7714,9 @@ fast-querystring@^1.1.1:
     fast-decode-uri-component "^1.0.1"
 
 fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fastest-levenshtein@^1.0.7:
   version "1.0.16"
@@ -7924,6 +8024,13 @@ fs-extra@^9.0, fs-extra@^9.0.0, fs-extra@^9.0.1, fs-extra@^9.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-minipass@^2.0.0, fs-minipass@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
 fs-monkey@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.1.0.tgz#632aa15a20e71828ed56b24303363fb1414e5997"
@@ -7960,6 +8067,20 @@ functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+gauge@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-4.0.4.tgz#52ff0652f2bbf607a989793d53b751bef2328dce"
+  integrity sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==
+  dependencies:
+    aproba "^1.0.3 || ^2.0.0"
+    color-support "^1.1.3"
+    console-control-strings "^1.1.0"
+    has-unicode "^2.0.1"
+    signal-exit "^3.0.7"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    wide-align "^1.1.5"
 
 gaze@1.1.3:
   version "1.1.3"
@@ -8122,7 +8243,7 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.0:
+glob@^8.0.0, glob@^8.0.1:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
@@ -8305,9 +8426,9 @@ graphql-ws@^5.14.0:
   integrity sha512-1PRqdDPAmViWr4h1GVBT8RoPZfWSGZa7kDzleTilOfVIslsgf+cia3Nl95v1KDmR4iERPaT7WzQ+tN4MJmbg3w==
 
 graphql@^16.5.0, graphql@^16.6.0:
-  version "16.13.2"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.13.2.tgz#4d2b73df5796b201f1bc2765f5d7067f689cb55f"
-  integrity sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.14.0.tgz#f1128a74b16a34d1245c8436bb07b488d87b83e1"
+  integrity sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==
 
 gyp-conditions@0.0.4:
   version "0.0.4"
@@ -8424,7 +8545,12 @@ has-tostringtag@^1.0.2:
   dependencies:
     has-symbols "^1.0.3"
 
-hasown@^2.0.2:
+has-unicode@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+  integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
+
+hasown@^2.0.2, hasown@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.3.tgz#5e5c2b15b60370a4c7930c383dfb76bf17bc403c"
   integrity sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==
@@ -8575,6 +8701,15 @@ http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
 http-proxy-agent@^7.0.0, http-proxy-agent@^7.0.1:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
@@ -8638,6 +8773,13 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
+  dependencies:
+    ms "^2.0.0"
+
 hyperlinker@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
@@ -8655,7 +8797,7 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.3:
+iconv-lite@^0.6.2, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -8740,6 +8882,11 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
+infer-owner@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
+  integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
+
 inflected@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/inflected/-/inflected-2.1.0.tgz#2816ac17a570bbbc8303ca05bca8bf9b3f959687"
@@ -8806,9 +8953,9 @@ invariant@^2.2.4:
     loose-envify "^1.0.0"
 
 ip-address@^10.1.1:
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.1.1.tgz#a7614252413e3751b841aaffba939090d2c4c37b"
-  integrity sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
+  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -8816,9 +8963,9 @@ ipaddr.js@1.9.1:
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 ipaddr.js@^2.0.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.3.0.tgz#71dce70e1398122208996d1c22f2ba46a24b1abc"
-  integrity sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.4.0.tgz#038e9ceaf8219efc5bb76347b7eb787875d5095b"
+  integrity sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==
 
 is-absolute@^1.0.0:
   version "1.0.0"
@@ -8886,11 +9033,11 @@ is-callable@^1.2.7:
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
 is-core-module@^2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
-  integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
   dependencies:
-    hasown "^2.0.2"
+    hasown "^2.0.3"
 
 is-data-view@^1.0.1, is-data-view@^1.0.2:
   version "1.0.2"
@@ -8975,6 +9122,11 @@ is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
+is-lambda@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
+  integrity sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==
 
 is-lower-case@^2.0.2:
   version "2.0.2"
@@ -9780,9 +9932,9 @@ jiti@^1.17.1, jiti@^1.21.7:
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
 
 jiti@^2.0.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.6.1.tgz#178ef2fc9a1a594248c20627cd820187a4d78d92"
-  integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.7.0.tgz#974228f2f4ca2bc21885a1797b45fea68e950c64"
+  integrity sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==
 
 jose@^4.15.9:
   version "4.15.9"
@@ -10448,7 +10600,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-cache@^7.14.1:
+lru-cache@^7.14.1, lru-cache@^7.7.1:
   version "7.18.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
@@ -10488,6 +10640,28 @@ make-error@^1, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
+make-fetch-happen@^10.0.3:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz#f5e3835c5e9817b617f2770870d9492d28678164"
+  integrity sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==
+  dependencies:
+    agentkeepalive "^4.2.1"
+    cacache "^16.1.0"
+    http-cache-semantics "^4.1.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.0"
+    is-lambda "^1.0.1"
+    lru-cache "^7.7.1"
+    minipass "^3.1.6"
+    minipass-collect "^1.0.2"
+    minipass-fetch "^2.0.3"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    negotiator "^0.6.3"
+    promise-retry "^2.0.1"
+    socks-proxy-agent "^7.0.0"
+    ssri "^9.0.0"
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -10646,7 +10820,66 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-mkdirp@1.0.4, mkdirp@^1.0.4:
+minipass-collect@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-1.0.2.tgz#22b813bf745dc6edba2576b940022ad6edc8c617"
+  integrity sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-fetch@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-2.1.2.tgz#95560b50c472d81a3bc76f20ede80eaed76d8add"
+  integrity sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==
+  dependencies:
+    minipass "^3.1.6"
+    minipass-sized "^1.0.3"
+    minizlib "^2.1.2"
+  optionalDependencies:
+    encoding "^0.1.13"
+
+minipass-flush@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.7.tgz#145c383d5ae294b36030aa80d4e872d08bebcb73"
+  integrity sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-pipeline@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz#68472f79711c084657c067c5c6ad93cddea8214c"
+  integrity sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-sized@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/minipass-sized/-/minipass-sized-1.0.3.tgz#70ee5a7c5052070afacfbc22977ea79def353b70"
+  integrity sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass@^3.0.0, minipass@^3.1.1, minipass@^3.1.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
+  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
+  dependencies:
+    yallist "^4.0.0"
+
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
+minizlib@^2.1.1, minizlib@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
+mkdirp@1.0.4, mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -10679,7 +10912,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
-ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -10712,9 +10945,9 @@ nan@^2.13.2:
   integrity sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==
 
 nanoid@^3.3.11:
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+  version "3.3.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
+  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
 
 nats@^2.7.1:
   version "2.29.3"
@@ -10743,7 +10976,7 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-negotiator@~0.6.4:
+negotiator@^0.6.3, negotiator@~0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.4.tgz#777948e2452651c570b712dd01c23e262713fff7"
   integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
@@ -10845,6 +11078,23 @@ node-forge@^1:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.4.0.tgz#1c7b7d8bdc2d078739f58287d589d903a11b2fc2"
   integrity sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==
 
+node-gyp@9.4.1:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-9.4.1.tgz#8a1023e0d6766ecb52764cc3a734b36ff275e185"
+  integrity sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==
+  dependencies:
+    env-paths "^2.2.0"
+    exponential-backoff "^3.1.1"
+    glob "^7.1.4"
+    graceful-fs "^4.2.6"
+    make-fetch-happen "^10.0.3"
+    nopt "^6.0.0"
+    npmlog "^6.0.0"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.2"
+    which "^2.0.2"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -10854,6 +11104,13 @@ node-releases@^2.0.36:
   version "2.0.38"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.38.tgz#791569b9e4424a044e12c3abfad418ed83ce9947"
   integrity sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==
+
+nopt@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-6.0.0.tgz#245801d8ebf409c6df22ab9d95b65e1309cdb16d"
+  integrity sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==
+  dependencies:
+    abbrev "^1.0.0"
 
 normalize-path@^2.1.1:
   version "2.1.1"
@@ -10878,6 +11135,16 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+npmlog@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-6.0.2.tgz#c8166017a42f2dea92d6453168dd865186a70830"
+  integrity sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==
+  dependencies:
+    are-we-there-yet "^3.0.0"
+    console-control-strings "^1.1.0"
+    gauge "^4.0.3"
+    set-blocking "^2.0.0"
 
 nth-check@^1.0.2:
   version "1.0.2"
@@ -12034,9 +12301,9 @@ postcss@^7.0.35:
     source-map "^0.6.1"
 
 postcss@^8.3.5, postcss@^8.4.33, postcss@^8.4.4, postcss@^8.4.47:
-  version "8.5.12"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.12.tgz#cd0c0f667f7cb0521e2313234ea6e707a9ec1ddb"
-  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
+  version "8.5.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.14.tgz#a66c2d7808fadf69ebb5b84a03f8bafd76c4919c"
+  integrity sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==
   dependencies:
     nanoid "^3.3.11"
     picocolors "^1.1.1"
@@ -12102,6 +12369,19 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+promise-inflight@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
+  integrity sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==
+
+promise-retry@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-2.0.1.tgz#ff747a13620ab57ba688f5fc67855410c370da22"
+  integrity sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==
+  dependencies:
+    err-code "^2.0.2"
+    retry "^0.12.0"
 
 promise@^7.1.1:
   version "7.3.1"
@@ -12553,7 +12833,7 @@ readable-stream@^2.0.1, readable-stream@^2.2.2:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6, readable-stream@^3.4.0, readable-stream@^3.6.2:
+readable-stream@^3.0.6, readable-stream@^3.4.0, readable-stream@^3.6.0, readable-stream@^3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -12865,6 +13145,11 @@ retry@0.13.1, retry@^0.13.1:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
   integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==
+
 reusify@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
@@ -13107,9 +13392,9 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
-  version "7.7.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
-  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.0.tgz#ed0661039fcbcda2ce71f01fa6adbefaa77040df"
+  integrity sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==
 
 send@~0.19.0, send@~0.19.1:
   version "0.19.2"
@@ -13321,7 +13606,7 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
-signal-exit@^3.0.2, signal-exit@^3.0.3:
+signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -13398,6 +13683,15 @@ sockjs@^0.3.24:
     uuid "^8.3.2"
     websocket-driver "^0.7.4"
 
+socks-proxy-agent@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz#dc069ecf34436621acb41e3efa66ca1b5fed15b6"
+  integrity sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==
+  dependencies:
+    agent-base "^6.0.2"
+    debug "^4.3.3"
+    socks "^2.6.2"
+
 socks-proxy-agent@^8.0.5:
   version "8.0.5"
   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz#b9cdb4e7e998509d7659d689ce7697ac21645bee"
@@ -13407,10 +13701,10 @@ socks-proxy-agent@^8.0.5:
     debug "^4.3.4"
     socks "^2.8.3"
 
-socks@^2.8.3:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.8.tgz#23bef6d02748eac847ad75610deb6c472554c67a"
-  integrity sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==
+socks@^2.6.2, socks@^2.8.3:
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.9.tgz#aa5f130ca0f88a43fa44faf4869c50d22aa27752"
+  integrity sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==
   dependencies:
     ip-address "^10.1.1"
     smart-buffer "^4.2.0"
@@ -13532,6 +13826,13 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
+ssri@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-9.0.1.tgz#544d4c357a8d7b71a19700074b6883fcb4eae057"
+  integrity sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==
+  dependencies:
+    minipass "^3.1.1"
+
 stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
@@ -13634,15 +13935,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
-  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
-  dependencies:
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^4.0.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13650,6 +13943,14 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string-width@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
 
 string.prototype.includes@^2.0.1:
   version "2.0.1"
@@ -14010,6 +14311,18 @@ tapable@^2.0.0, tapable@^2.2.1, tapable@^2.3.0, tapable@^2.3.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.3.tgz#5da7c9992c46038221267985ab28421a8879f160"
   integrity sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==
 
+tar@^6.1.11, tar@^6.1.2:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
+  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^5.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
 temp-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
@@ -14034,9 +14347,9 @@ terminal-link@^2.0.0:
     supports-hyperlinks "^2.0.0"
 
 terser-webpack-plugin@^5.2.5, terser-webpack-plugin@^5.3.17:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz#d92b8e2c892dd09c683c38120394267e8d8660ef"
-  integrity sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz#8e7caad248183ab9e91ff08a83b0fc9f0439c3c3"
+  integrity sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.25"
     jest-worker "^27.4.5"
@@ -14044,9 +14357,9 @@ terser-webpack-plugin@^5.2.5, terser-webpack-plugin@^5.3.17:
     terser "^5.31.1"
 
 terser@^5.0.0, terser@^5.10.0, terser@^5.31.1:
-  version "5.46.2"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.46.2.tgz#b9529672d5b0024c7959571c83b82f65077b2a4f"
-  integrity sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.47.1.tgz#99b298e51bc41214304847de1429ec92fd1f7648"
+  integrity sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.15.0"
@@ -14573,6 +14886,20 @@ unicode-property-aliases-ecmascript@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz#301d4f8a43d2b75c97adfad87c9dd5350c9475d1"
   integrity sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==
+
+unique-filename@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-2.0.1.tgz#e785f8675a9a7589e0ac77e0b5c34d2eaeac6da2"
+  integrity sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==
+  dependencies:
+    unique-slug "^3.0.0"
+
+unique-slug@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-3.0.0.tgz#6d347cf57c8a7a7a6044aabd0e2d74e4d76dc7c9"
+  integrity sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==
+  dependencies:
+    imurmurhash "^0.1.4"
 
 unique-string@^2.0.0:
   version "2.0.0"
@@ -15104,12 +15431,19 @@ which@^1.2.9, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wide-align@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
+  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
+  dependencies:
+    string-width "^1.0.2 || 2 || 3 || 4"
 
 widest-line@^3.1.0:
   version "3.1.0"
@@ -15447,9 +15781,9 @@ yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==
 
 yaml@^2.3.1, yaml@^2.3.4:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"
-  integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.4.tgz#4b5f411dd25f9544914d8673d4da7f29248e5e2e"
+  integrity sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==
 
 yargs-parser@^18.1.2:
   version "18.1.3"


### PR DESCRIPTION
- Added cohortStatus to the typeDefs for cohorts data
- regnerated graphql types

These changes also resolve issues during build when installing the project from scratch:
- package/python version clashing with gyp/lz4

## Description

<Include a summary of the changes. Please also include relevant motivation and context. List any external dependencies that are required for this change, like new environment variables.>

<img width="774" height="309" alt="image" src="https://github.com/user-attachments/assets/238fa187-974f-47b5-98fa-d39fda69e141" />


## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [x] Searching for a single term or multiple terms returns relevant results
- [ ] Searching in PHI mode returns results with PHI columns
- [x] Filtering columns returns the results matching the filter
- [x] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [x] Clicking "Download as TSV"
- [x] Searching for some terms then clicking "Download as TSV"
- [x] Filtering a column then clicking "Download as TSV"
- [x] Search in PHI mode then clicking "Download as TSV"
- [x] Clicking the dropdown download option <download option name>
- [x] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
- [x] Viewing a sample's data diff and clicking "Download as TSV"

#### AG Grid interactions

- [x] [Samples page] Editing a cell updates the value as expected
- [x] [Samples page] Pasting data into the grid works as expected
- [x] Editing a cell in a non-editable row/column is prevented
- [x] Column sorting in ascending and descending order works as expected
- [x] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [x] [Samples page] Cell changes confirmation modal appears and works as expected
- [x] [Requests page] Validation errors are displayed in the Record Validation modal
- [x] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [x] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [x] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [x] The GraphQL types that are auto-generated via `yarn run codegen`
- [x] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
