### PR TITLE
Add method of forcing label generation for all samples in a request

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.21",
     "neo4j-graphql-cli": "^0.0.11",
     "pre-commit": "^1.2.2",
-    "prettier": "1.19.1",
+    "prettier": "2.8.8",
     "react": "^17.0.2",
     "react-bootstrap": "^2.5.0",
     "react-dom": "^17.0.2",

--- a/frontend/src/components/SamplesModal.tsx
+++ b/frontend/src/components/SamplesModal.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import {
   DashboardRecordContext,
   DashboardSample,
-  useDashboardSamplesLazyQuery,
+  useDashboardSamplesLazyQuery
 } from "../generated/graphql";
 import { useFetchData } from "../hooks/useFetchData";
 import { useCellChanges } from "../hooks/useCellChanges";
@@ -12,13 +12,13 @@ import { useDownload } from "../hooks/useDownload";
 import {
   buildDownloadOptions,
   fieldToHeaderName,
-  phiModeSwitchTooltipContent,
+  phiModeSwitchTooltipContent
 } from "../pages/samples/config";
 import { useTogglePhiColumnsVisibility } from "../hooks/useTogglePhiColumns";
 import { ErrorMessage } from "./ErrorMessage";
 import { Title } from "../components/Title";
 import { Toolbar } from "../components/Toolbar";
-import { Button, Col, Modal } from "react-bootstrap";
+import { Button, Col, Form, Modal } from "react-bootstrap";
 import { SearchBar } from "../components/SearchBar";
 import { PhiModeSwitch } from "./PhiModeSwitch";
 import { CellChangesContainer } from "./CellChangesContainer";
@@ -26,14 +26,25 @@ import { DownloadButton } from "../components/DownloadButton";
 import { DataGrid } from "./DataGrid";
 import { DownloadModal } from "./DownloadModal";
 import { ColDef } from "ag-grid-community";
-import { POLL_INTERVAL, ROUTE_PARAMS } from "../configs/shared";
+import {
+  POLL_INTERVAL,
+  ROUTE_PARAMS,
+  CMO_SAMPLE_NAME_OVERWRITE_WARNING,
+  FORCE_LABEL_SOFT_REQUIRED_FIELDS,
+  MISSING_CMO_PATIENT_ID_WARNING,
+  MISSING_FORCE_LABEL_SOFT_FIELDS_WARNING
+} from "../configs/shared";
 import { RecordChange } from "../types/shared";
 import { useCellDoubleClicked } from "../hooks/useCellDoubleClicked";
 import {
   useFetchSampleHistory,
   historyColDefs,
-  historyAutoGroupColumnDef,
+  historyAutoGroupColumnDef
 } from "../hooks/useFetchSampleHistory";
+import { Refresh } from "@material-ui/icons";
+import { useUserEmail } from "../contexts/UserEmailContext";
+import { awaitLoginPopup } from "../utils/awaitLoginPopup";
+import { CustomTooltip } from "./CustomToolTip";
 
 const QUERY_NAME = "dashboardSamples";
 const INITIAL_SORT_FIELD_NAME = "importDate";
@@ -44,6 +55,7 @@ interface SamplesModalProps {
   contextFieldName: string;
   parentRecordName: keyof typeof ROUTE_PARAMS;
   showPhiModeSwitch?: boolean;
+  showForceLabelButton?: boolean;
 }
 
 export function SamplesModal({
@@ -51,12 +63,19 @@ export function SamplesModal({
   contextFieldName,
   parentRecordName,
   showPhiModeSwitch = false,
+  showForceLabelButton = false
 }: SamplesModalProps) {
   const [userSearchVal, setUserSearchVal] = useState("");
   const [colDefs, setColDefs] = useState(sampleColDefs);
   const parentRecordId = useParams()[ROUTE_PARAMS[parentRecordName]];
   const gridRef = useRef<AgGridReactType<DashboardSample>>(null);
   const { handleCellDoubleClicked } = useCellDoubleClicked();
+  const { userEmail, setUserEmail } = useUserEmail();
+  const [showForceLabelModal, setShowForceLabelModal] = useState(false);
+  const [allSamplesForForceLabel, setAllSamplesForForceLabel] = useState<
+    DashboardSample[]
+  >([]);
+  const [isFetchingAllSamples, setIsFetchingAllSamples] = useState(false);
 
   const {
     refreshData,
@@ -66,7 +85,7 @@ export function SamplesModal({
     data,
     fetchMore,
     startPolling,
-    stopPolling,
+    stopPolling
   } = useFetchData({
     useRecordsLazyQuery: useDashboardSamplesLazyQuery,
     queryName: QUERY_NAME,
@@ -76,10 +95,10 @@ export function SamplesModal({
     recordContexts: [
       {
         fieldName: contextFieldName,
-        values: [parentRecordId!],
-      },
+        values: [parentRecordId!]
+      }
     ],
-    pollInterval: POLL_INTERVAL,
+    pollInterval: POLL_INTERVAL
   });
 
   const {
@@ -88,39 +107,74 @@ export function SamplesModal({
     cellChangesHandlers,
     handleCellEditRequest,
     handlePaste,
+    handleForceLabelSubmit
   } = useCellChanges({
     gridRef,
     startPolling,
     stopPolling,
     records: data?.[QUERY_NAME],
     refreshData,
-    isSampleLevelChanges: true,
+    isSampleLevelChanges: true
   });
 
-  const { isDownloading, handleDownload, getCurrentData } =
-    useDownload<DashboardSample>({
-      gridRef,
-      downloadFileName: `${parentRecordName.slice(
-        0,
-        -1
-      )}_${parentRecordId}_samples`,
-      fetchMore,
-      userSearchVal,
-      recordCount,
-      queryName: QUERY_NAME,
-    });
+  const { isDownloading, handleDownload, getCurrentData } = useDownload<
+    DashboardSample
+  >({
+    gridRef,
+    downloadFileName: `${parentRecordName.slice(
+      0,
+      -1
+    )}_${parentRecordId}_samples`,
+    fetchMore,
+    userSearchVal,
+    recordCount,
+    queryName: QUERY_NAME
+  });
 
   const downloadOptions = buildDownloadOptions({
     getCurrentData,
-    currentColDefs: colDefs,
+    currentColDefs: colDefs
   });
 
-  const { handlePhiColumnsVisibilityBeforeSearch } =
-    useTogglePhiColumnsVisibility({
-      setColDefs,
-      phiFields: PHI_FIELDS,
-      userSearchVal,
-    });
+  const {
+    handlePhiColumnsVisibilityBeforeSearch
+  } = useTogglePhiColumnsVisibility({
+    setColDefs,
+    phiFields: PHI_FIELDS,
+    userSearchVal
+  });
+
+  async function handleForceLabelClick() {
+    if (!userEmail) {
+      const loggedInEmail = await awaitLoginPopup();
+      if (!loggedInEmail) return;
+      setUserEmail(loggedInEmail);
+    }
+    setIsFetchingAllSamples(true);
+    try {
+      const { data: allSamplesData } = await fetchMore({
+        variables: {
+          searchVals: [],
+          offset: 0,
+          limit: recordCount
+        }
+      });
+      const allSamples: DashboardSample[] = allSamplesData?.[QUERY_NAME] ?? [];
+      setAllSamplesForForceLabel(allSamples);
+      setShowForceLabelModal(true);
+    } catch (error) {
+      console.error("Failed to fetch all samples for force label:", error);
+    } finally {
+      setIsFetchingAllSamples(false);
+    }
+  }
+
+  function handleForceLabelConfirm() {
+    if (!userEmail) return;
+    setShowForceLabelModal(false);
+    const username = userEmail.split("@")[0];
+    handleForceLabelSubmit(allSamplesForForceLabel, username);
+  }
 
   if (error) {
     return <ErrorMessage error={error} />;
@@ -162,7 +216,28 @@ export function SamplesModal({
           )}
         </Col>
 
-        <Col className="text-end">
+        <Col className="text-end d-flex gap-2 justify-content-end align-items-center">
+          {showForceLabelButton && (
+            <CustomTooltip
+              icon={
+                <Button
+                  className="btn btn-secondary"
+                  size="sm"
+                  onClick={handleForceLabelClick}
+                  disabled={recordCount === 0 || isFetchingAllSamples}
+                >
+                  <Refresh fontSize="small" className="me-1" />
+                  {isFetchingAllSamples
+                    ? "Loading..."
+                    : "Force Label Generation"}
+                </Button>
+              }
+            >
+              {!userEmail
+                ? "Must be logged in to make changes to sample data"
+                : ""}
+            </CustomTooltip>
+          )}
           <DownloadButton
             downloadOptions={downloadOptions}
             onDownload={handleDownload}
@@ -183,6 +258,90 @@ export function SamplesModal({
       />
 
       {isDownloading && <DownloadModal />}
+
+      {showForceLabelModal && (
+        <Modal
+          show={true}
+          centered
+          onHide={() => setShowForceLabelModal(false)}
+          className="overlay"
+        >
+          <Modal.Header closeButton>
+            <Modal.Title>Force Label Generation</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <p>
+              This will force label generation for{" "}
+              <strong>{recordCount}</strong> sample
+              {recordCount !== 1 ? "s" : ""} in this request.
+            </p>
+            {allSamplesForForceLabel.some(s => s.cmoSampleName) && (
+              <p className="text-warning mb-0">
+                <strong>Caution:</strong> {CMO_SAMPLE_NAME_OVERWRITE_WARNING}
+              </p>
+            )}
+            <Form.Group className="d-flex align-items-center mt-3">
+              <Form.Label className="mb-0 me-2 text-nowrap">
+                Reason for Change:
+              </Form.Label>
+              <Form.Control
+                type="text"
+                size="sm"
+                className="me-3"
+                value="Forcing label generation"
+                disabled
+              />
+              <Form.Label className="mb-0 me-2 text-nowrap">Author:</Form.Label>
+              <Form.Control
+                style={{ width: "30%" }}
+                type="text"
+                size="sm"
+                value={userEmail?.split("@")[0] ?? ""}
+                disabled
+              />
+            </Form.Group>
+          </Modal.Body>
+          <Modal.Footer>
+            {(() => {
+              const hasMissingCmoPatientId = allSamplesForForceLabel.some(
+                s => !s["cmoPatientId"]
+              );
+              const hasMissingSoftFields = allSamplesForForceLabel.some(s =>
+                FORCE_LABEL_SOFT_REQUIRED_FIELDS.some(field => !s[field])
+              );
+              return (
+                <>
+                  <Button
+                    className="btn btn-secondary"
+                    onClick={() => setShowForceLabelModal(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    className="btn btn-success"
+                    onClick={handleForceLabelConfirm}
+                    disabled={hasMissingCmoPatientId}
+                  >
+                    {hasMissingSoftFields && !hasMissingCmoPatientId
+                      ? "Proceed Anyway"
+                      : "Submit Updates"}
+                  </Button>
+                  {hasMissingCmoPatientId && (
+                    <span className="changelog-alert">
+                      {MISSING_CMO_PATIENT_ID_WARNING}
+                    </span>
+                  )}
+                  {hasMissingSoftFields && !hasMissingCmoPatientId && (
+                    <span className="changelog-alert">
+                      {MISSING_FORCE_LABEL_SOFT_FIELDS_WARNING}
+                    </span>
+                  )}
+                </>
+              );
+            })()}
+          </Modal.Footer>
+        </Modal>
+      )}
     </ModalContainerWithClosingWarning>
   );
 }
@@ -194,7 +353,7 @@ interface SampleHistoryModalProps {
 
 export function SampleHistoryModal({
   recordContext,
-  parentRecordName,
+  parentRecordName
 }: SampleHistoryModalProps) {
   const smileSampleId = recordContext.values?.[0] ?? "";
 
@@ -205,7 +364,7 @@ export function SampleHistoryModal({
     displayText,
     isDownloading,
     historyDownloadOptions,
-    handleDownload,
+    handleDownload
   } = useFetchSampleHistory(smileSampleId);
 
   if (error) {
@@ -238,7 +397,7 @@ export function SampleHistoryModal({
           groupRemoveSingleChildren={true}
           autoGroupColumnDef={historyAutoGroupColumnDef}
           groupDefaultExpanded={1}
-          onFirstDataRendered={(e) => e.columnApi.autoSizeAllColumns()}
+          onFirstDataRendered={e => e.columnApi.autoSizeAllColumns()}
         />
       </div>
 
@@ -260,7 +419,7 @@ function ModalContainerWithClosingWarning({
   setChanges,
   parentRecordName,
   children,
-  displayText,
+  displayText
 }: ModalContainerProps) {
   const navigate = useNavigate();
   const parentRecordId = useParams()[ROUTE_PARAMS[parentRecordName]];

--- a/frontend/src/components/SamplesModal.tsx
+++ b/frontend/src/components/SamplesModal.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import {
   DashboardRecordContext,
   DashboardSample,
-  useDashboardSamplesLazyQuery
+  useDashboardSamplesLazyQuery,
 } from "../generated/graphql";
 import { useFetchData } from "../hooks/useFetchData";
 import { useCellChanges } from "../hooks/useCellChanges";
@@ -12,7 +12,7 @@ import { useDownload } from "../hooks/useDownload";
 import {
   buildDownloadOptions,
   fieldToHeaderName,
-  phiModeSwitchTooltipContent
+  phiModeSwitchTooltipContent,
 } from "../pages/samples/config";
 import { useTogglePhiColumnsVisibility } from "../hooks/useTogglePhiColumns";
 import { ErrorMessage } from "./ErrorMessage";
@@ -32,14 +32,14 @@ import {
   CMO_SAMPLE_NAME_OVERWRITE_WARNING,
   FORCE_LABEL_SOFT_REQUIRED_FIELDS,
   MISSING_CMO_PATIENT_ID_WARNING,
-  MISSING_FORCE_LABEL_SOFT_FIELDS_WARNING
+  MISSING_FORCE_LABEL_SOFT_FIELDS_WARNING,
 } from "../configs/shared";
 import { RecordChange } from "../types/shared";
 import { useCellDoubleClicked } from "../hooks/useCellDoubleClicked";
 import {
   useFetchSampleHistory,
   historyColDefs,
-  historyAutoGroupColumnDef
+  historyAutoGroupColumnDef,
 } from "../hooks/useFetchSampleHistory";
 import { Refresh } from "@material-ui/icons";
 import { useUserEmail } from "../contexts/UserEmailContext";
@@ -63,7 +63,7 @@ export function SamplesModal({
   contextFieldName,
   parentRecordName,
   showPhiModeSwitch = false,
-  showForceLabelButton = false
+  showForceLabelButton = false,
 }: SamplesModalProps) {
   const [userSearchVal, setUserSearchVal] = useState("");
   const [colDefs, setColDefs] = useState(sampleColDefs);
@@ -85,7 +85,7 @@ export function SamplesModal({
     data,
     fetchMore,
     startPolling,
-    stopPolling
+    stopPolling,
   } = useFetchData({
     useRecordsLazyQuery: useDashboardSamplesLazyQuery,
     queryName: QUERY_NAME,
@@ -95,10 +95,10 @@ export function SamplesModal({
     recordContexts: [
       {
         fieldName: contextFieldName,
-        values: [parentRecordId!]
-      }
+        values: [parentRecordId!],
+      },
     ],
-    pollInterval: POLL_INTERVAL
+    pollInterval: POLL_INTERVAL,
   });
 
   const {
@@ -107,42 +107,40 @@ export function SamplesModal({
     cellChangesHandlers,
     handleCellEditRequest,
     handlePaste,
-    handleForceLabelSubmit
+    handleForceLabelSubmit,
   } = useCellChanges({
     gridRef,
     startPolling,
     stopPolling,
     records: data?.[QUERY_NAME],
     refreshData,
-    isSampleLevelChanges: true
+    isSampleLevelChanges: true,
   });
 
-  const { isDownloading, handleDownload, getCurrentData } = useDownload<
-    DashboardSample
-  >({
-    gridRef,
-    downloadFileName: `${parentRecordName.slice(
-      0,
-      -1
-    )}_${parentRecordId}_samples`,
-    fetchMore,
-    userSearchVal,
-    recordCount,
-    queryName: QUERY_NAME
-  });
+  const { isDownloading, handleDownload, getCurrentData } =
+    useDownload<DashboardSample>({
+      gridRef,
+      downloadFileName: `${parentRecordName.slice(
+        0,
+        -1
+      )}_${parentRecordId}_samples`,
+      fetchMore,
+      userSearchVal,
+      recordCount,
+      queryName: QUERY_NAME,
+    });
 
   const downloadOptions = buildDownloadOptions({
     getCurrentData,
-    currentColDefs: colDefs
+    currentColDefs: colDefs,
   });
 
-  const {
-    handlePhiColumnsVisibilityBeforeSearch
-  } = useTogglePhiColumnsVisibility({
-    setColDefs,
-    phiFields: PHI_FIELDS,
-    userSearchVal
-  });
+  const { handlePhiColumnsVisibilityBeforeSearch } =
+    useTogglePhiColumnsVisibility({
+      setColDefs,
+      phiFields: PHI_FIELDS,
+      userSearchVal,
+    });
 
   async function handleForceLabelClick() {
     if (!userEmail) {
@@ -156,8 +154,8 @@ export function SamplesModal({
         variables: {
           searchVals: [],
           offset: 0,
-          limit: recordCount
-        }
+          limit: recordCount,
+        },
       });
       const allSamples: DashboardSample[] = allSamplesData?.[QUERY_NAME] ?? [];
       setAllSamplesForForceLabel(allSamples);
@@ -275,7 +273,7 @@ export function SamplesModal({
               <strong>{recordCount}</strong> sample
               {recordCount !== 1 ? "s" : ""} in this request.
             </p>
-            {allSamplesForForceLabel.some(s => s.cmoSampleName) && (
+            {allSamplesForForceLabel.some((s) => s.cmoSampleName) && (
               <p className="text-warning mb-0">
                 <strong>Caution:</strong> {CMO_SAMPLE_NAME_OVERWRITE_WARNING}
               </p>
@@ -304,10 +302,10 @@ export function SamplesModal({
           <Modal.Footer>
             {(() => {
               const hasMissingCmoPatientId = allSamplesForForceLabel.some(
-                s => !s["cmoPatientId"]
+                (s) => !s["cmoPatientId"]
               );
-              const hasMissingSoftFields = allSamplesForForceLabel.some(s =>
-                FORCE_LABEL_SOFT_REQUIRED_FIELDS.some(field => !s[field])
+              const hasMissingSoftFields = allSamplesForForceLabel.some((s) =>
+                FORCE_LABEL_SOFT_REQUIRED_FIELDS.some((field) => !s[field])
               );
               return (
                 <>
@@ -353,7 +351,7 @@ interface SampleHistoryModalProps {
 
 export function SampleHistoryModal({
   recordContext,
-  parentRecordName
+  parentRecordName,
 }: SampleHistoryModalProps) {
   const smileSampleId = recordContext.values?.[0] ?? "";
 
@@ -364,7 +362,7 @@ export function SampleHistoryModal({
     displayText,
     isDownloading,
     historyDownloadOptions,
-    handleDownload
+    handleDownload,
   } = useFetchSampleHistory(smileSampleId);
 
   if (error) {
@@ -397,7 +395,7 @@ export function SampleHistoryModal({
           groupRemoveSingleChildren={true}
           autoGroupColumnDef={historyAutoGroupColumnDef}
           groupDefaultExpanded={1}
-          onFirstDataRendered={e => e.columnApi.autoSizeAllColumns()}
+          onFirstDataRendered={(e) => e.columnApi.autoSizeAllColumns()}
         />
       </div>
 
@@ -419,7 +417,7 @@ function ModalContainerWithClosingWarning({
   setChanges,
   parentRecordName,
   children,
-  displayText
+  displayText,
 }: ModalContainerProps) {
   const navigate = useNavigate();
   const parentRecordId = useParams()[ROUTE_PARAMS[parentRecordName]];

--- a/frontend/src/configs/shared.tsx
+++ b/frontend/src/configs/shared.tsx
@@ -18,11 +18,11 @@ export const ROUTE_PARAMS = {
   requests: "igoRequestId",
   patients: "patientId",
   cohorts: "cohortId",
-  samples: "smileSampleId"
+  samples: "smileSampleId",
 } as const;
 
 export function getPhiColDefProps({
-  widthSize
+  widthSize,
 }: {
   widthSize: number;
 }): ColDef {
@@ -30,7 +30,7 @@ export function getPhiColDefProps({
     width: widthSize, // prevent truncation when columns are unhidden
     hide: true,
     cellStyle: { color: "crimson" },
-    sortable: false
+    sortable: false,
   };
 }
 
@@ -40,8 +40,8 @@ export const multiLineColDef: ColDef = {
   cellStyle: {
     wordBreak: "break-word",
     lineHeight: "1.25",
-    padding: "6px 18px"
-  }
+    padding: "6px 18px",
+  },
 };
 
 export const PHI_WARNING =
@@ -83,9 +83,8 @@ export const FORCE_LABEL_REQUIRED_FIELDS = [
   "baitSet",
   "sampleOrigin",
   "tumorOrNormal",
-  "sampleClass"
+  "sampleClass",
 ] as const;
 
-export const FORCE_LABEL_SOFT_REQUIRED_FIELDS = FORCE_LABEL_REQUIRED_FIELDS.filter(
-  f => f !== "cmoPatientId"
-);
+export const FORCE_LABEL_SOFT_REQUIRED_FIELDS =
+  FORCE_LABEL_REQUIRED_FIELDS.filter((f) => f !== "cmoPatientId");

--- a/frontend/src/configs/shared.tsx
+++ b/frontend/src/configs/shared.tsx
@@ -18,11 +18,11 @@ export const ROUTE_PARAMS = {
   requests: "igoRequestId",
   patients: "patientId",
   cohorts: "cohortId",
-  samples: "smileSampleId",
+  samples: "smileSampleId"
 } as const;
 
 export function getPhiColDefProps({
-  widthSize,
+  widthSize
 }: {
   widthSize: number;
 }): ColDef {
@@ -30,7 +30,7 @@ export function getPhiColDefProps({
     width: widthSize, // prevent truncation when columns are unhidden
     hide: true,
     cellStyle: { color: "crimson" },
-    sortable: false,
+    sortable: false
   };
 }
 
@@ -40,8 +40,8 @@ export const multiLineColDef: ColDef = {
   cellStyle: {
     wordBreak: "break-word",
     lineHeight: "1.25",
-    padding: "6px 18px",
-  },
+    padding: "6px 18px"
+  }
 };
 
 export const PHI_WARNING =
@@ -65,3 +65,27 @@ export const INVALID_COST_CENTER_WARNING =
 
 export const NO_CHANGELOG_WARNING =
   "Reason for Change field must be filled in before submitting updates.";
+
+export const CMO_SAMPLE_NAME_OVERWRITE_WARNING =
+  "At least 1 sample already has a CMO Sample Name. Proceeding may overwrite existing CMO Sample Names.";
+
+export const MISSING_CMO_PATIENT_ID_WARNING =
+  "All samples must have a CMO Patient ID before forcing label generation.";
+
+export const MISSING_FORCE_LABEL_SOFT_FIELDS_WARNING =
+  "Some samples have missing values in one or more of the following fields: Sample Type, Gene Panel, Recipe, Bait Set, Sample Origin, Tumor or Normal, Sample Class. Proceeding may result in incomplete label generation.";
+
+export const FORCE_LABEL_REQUIRED_FIELDS = [
+  "cmoPatientId",
+  "sampleType",
+  "genePanel",
+  "recipe",
+  "baitSet",
+  "sampleOrigin",
+  "tumorOrNormal",
+  "sampleClass"
+] as const;
+
+export const FORCE_LABEL_SOFT_REQUIRED_FIELDS = FORCE_LABEL_REQUIRED_FIELDS.filter(
+  f => f !== "cmoPatientId"
+);

--- a/frontend/src/hooks/useCellChanges.ts
+++ b/frontend/src/hooks/useCellChanges.ts
@@ -3,7 +3,7 @@ import { useUserEmail } from "../contexts/UserEmailContext";
 import { useWarningModal } from "../contexts/WarningContext";
 import {
   CellEditRequestEvent,
-  IServerSideGetRowsParams,
+  IServerSideGetRowsParams
 } from "ag-grid-community";
 import { getUserEmail } from "../utils/getUserEmail";
 import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
@@ -13,7 +13,7 @@ import {
   DashboardSample,
   DashboardSampleInput,
   useUpdateDashboardSamplesMutation,
-  useUpdateTempoCohortMutation,
+  useUpdateTempoCohortMutation
 } from "../generated/graphql";
 import { handleAgGridPaste } from "../utils/handleAgGridPaste";
 import { awaitLoginPopup } from "../utils/awaitLoginPopup";
@@ -21,7 +21,7 @@ import { RecordChange } from "../types/shared";
 import { formatCellDate, isInvalidCostCenter } from "../utils/agGrid";
 import {
   INVALID_COST_CENTER_WARNING,
-  POLLING_PAUSE_AFTER_UPDATE,
+  POLLING_PAUSE_AFTER_UPDATE
 } from "../configs/shared";
 import { formatCohortUsersString } from "../utils/formatCohortUsersString";
 import _ from "lodash";
@@ -41,7 +41,7 @@ export function useCellChanges({
   stopPolling,
   records,
   refreshData,
-  isSampleLevelChanges,
+  isSampleLevelChanges
 }: UseCellChangesParams) {
   const [changes, setChanges] = useState<Array<RecordChange>>([]);
   const { userEmail, setUserEmail } = useUserEmail();
@@ -70,9 +70,9 @@ export function useCellChanges({
     const noChangeInVal = rowNode.data[fieldName] === newValue;
     const noChangeInEmptyCell = !rowNode.data[fieldName] && !newValue;
     if (noChangeInVal || noChangeInEmptyCell) {
-      setChanges((changes) => {
+      setChanges(changes => {
         const updatedChanges = changes.filter(
-          (c) => !(c.recordId === recordId && c.fieldName === fieldName)
+          c => !(c.recordId === recordId && c.fieldName === fieldName)
         );
         return updatedChanges;
       });
@@ -95,9 +95,9 @@ export function useCellChanges({
 
       const currUsername = currUserEmail.split("@")[0];
 
-      setChanges((changes) => {
+      setChanges(changes => {
         const billedBy = changes.find(
-          (c) => c.recordId === recordId && c.fieldName === "billedBy"
+          c => c.recordId === recordId && c.fieldName === "billedBy"
         );
         if (billedBy) {
           billedBy.newValue = currUsername;
@@ -107,7 +107,7 @@ export function useCellChanges({
             fieldName: "billedBy",
             oldValue: "",
             newValue: currUsername,
-            rowNode,
+            rowNode
           });
         }
         return [...changes];
@@ -115,9 +115,9 @@ export function useCellChanges({
     }
 
     // Add/update the edited cell to/in the changes array
-    setChanges((changes) => {
+    setChanges(changes => {
       const change = changes.find(
-        (c) => c.recordId === recordId && c.fieldName === fieldName
+        c => c.recordId === recordId && c.fieldName === fieldName
       );
       if (change) {
         change.newValue = newValue;
@@ -127,7 +127,7 @@ export function useCellChanges({
           fieldName,
           oldValue,
           newValue,
-          rowNode,
+          rowNode
         });
       }
       return [...changes];
@@ -148,7 +148,7 @@ export function useCellChanges({
         e,
         gridRef,
         handleCellEditRequest,
-        context: { userEmail },
+        context: { userEmail }
       });
     } catch (error) {
       if (error instanceof Error) {
@@ -162,14 +162,14 @@ export function useCellChanges({
   function handleDiscardChanges() {
     // Remove cell styles associated with having been edited
     gridRef.current?.api?.redrawRows({
-      rowNodes: changes.map((c) => c.rowNode),
+      rowNodes: changes.map(c => c.rowNode)
     });
     setChanges([]);
     startPolling();
   }
 
   function handleConfirmUpdates() {
-    const hasInvalidCostCenter = changes.some((c) =>
+    const hasInvalidCostCenter = changes.some(c =>
       isInvalidCostCenter(c.fieldName, c.newValue)
     );
     if (hasInvalidCostCenter) {
@@ -185,7 +185,7 @@ export function useCellChanges({
       return;
     }
 
-    const recordIds = _.uniq(changes.map((c) => c.recordId));
+    const recordIds = _.uniq(changes.map(c => c.recordId));
 
     const changesWithReason = [...changes];
 
@@ -198,8 +198,8 @@ export function useCellChanges({
       const formattedChangelog = username
         ? `${username}: ${reasonForChange}`
         : reasonForChange;
-      recordIds.forEach((r) => {
-        const change = changes.find((c) => c.recordId === r);
+      recordIds.forEach(r => {
+        const change = changes.find(c => c.recordId === r);
         if (!change) {
           return;
         }
@@ -209,7 +209,7 @@ export function useCellChanges({
           fieldName: "changelog",
           oldValue: change.rowNode.data.changelog,
           newValue: formattedChangelog,
-          rowNode: change.rowNode,
+          rowNode: change.rowNode
         });
       });
     }
@@ -220,14 +220,14 @@ export function useCellChanges({
 
       // Send to GraphQL server to publish
       updateDashboardSamplesMutation({
-        variables: { newDashboardSamples },
+        variables: { newDashboardSamples }
       });
 
       // Manually handle optimistic updates by refreshing updated rows' UI to indicate them being updated
       // (We can't use GraphQL's optimistic response because it isn't a good fit for
       // AG Grid's Server-Side data model. e.g. GraphQL's optimistic response only returns
       // the updated data, while AG Grid expects the datasource == the entire dataset.)
-      const optimisticSamples = records!.map((s) => {
+      const optimisticSamples = records!.map(s => {
         s = s as DashboardSample; // we already know we're dealing with DashboardSample here
         const changesForSample =
           s.primaryId != null ? changesByRecordId.get(s.primaryId) : undefined;
@@ -240,7 +240,7 @@ export function useCellChanges({
             ...s,
             ...changedFields,
             revisable: false,
-            importDate: formatCellDate(new Date()) as string,
+            importDate: formatCellDate(new Date()) as string
           };
         }
         return s;
@@ -255,9 +255,9 @@ export function useCellChanges({
         getRows: (params: IServerSideGetRowsParams) => {
           params.success({
             rowData: optimisticSamples!,
-            rowCount: optimisticSamples[0]?._total || 0,
+            rowCount: optimisticSamples[0]?._total || 0
           });
-        },
+        }
       };
       gridRef.current?.api?.setServerSideDatasource(optimisticDatasource);
     } else {
@@ -276,18 +276,67 @@ export function useCellChanges({
     setShowUpdateModal(false);
   }
 
+  function handleForceLabelSubmit(
+    allSamples: DashboardSample[],
+    username: string
+  ) {
+    stopPolling();
+    const changelog = `${username}: Forcing label generation`;
+
+    const newDashboardSamples: DashboardSampleInput[] = allSamples.map(
+      sample => {
+        const { __typename, igoQcReports, ...sampleData } = sample as any;
+        return {
+          ...sampleData,
+          changedFieldNames: ["forceCmoLabel", "changelog"],
+          changelog,
+          revisable: false
+        };
+      }
+    );
+
+    updateDashboardSamplesMutation({ variables: { newDashboardSamples } });
+
+    const optimisticSamples = allSamples.map(s => ({
+      ...s,
+      changelog,
+      revisable: false,
+      importDate: formatCellDate(new Date()) as string
+    }));
+    optimisticSamples.sort(
+      (a, b) =>
+        new Date(b.importDate ?? "").getTime() -
+        new Date(a.importDate ?? "").getTime()
+    );
+    gridRef.current?.api?.setServerSideDatasource({
+      getRows: (params: IServerSideGetRowsParams) => {
+        params.success({
+          rowData: optimisticSamples,
+          rowCount: optimisticSamples[0]?._total || 0
+        });
+      }
+    });
+
+    setTimeout(async () => {
+      refreshData();
+      // No need to resume polling here as `refreshData` already does it
+    }, POLLING_PAUSE_AFTER_UPDATE);
+    startPolling();
+  }
+
   return {
     changes,
     setChanges,
     handleCellEditRequest,
     handlePaste,
+    handleForceLabelSubmit,
     cellChangesHandlers: {
       handleDiscardChanges,
       handleConfirmUpdates,
       handleSubmitUpdates,
       showUpdateModal,
-      setShowUpdateModal,
-    },
+      setShowUpdateModal
+    }
   };
 }
 
@@ -319,7 +368,7 @@ function buildNewDashboardSamples(
     newDashboardSamplesByPrimaryId.set(primaryId, {
       ...sampleData,
       revisable: false,
-      changedFieldNames: changes.map((c) => c.fieldName),
+      changedFieldNames: changes.map(c => c.fieldName)
     });
   });
   return Array.from(newDashboardSamplesByPrimaryId.values());
@@ -340,7 +389,7 @@ function buildNewDashboardCohorts(
     delete cohortData.__typename;
     newDashboardCohortsByCohortId.set(cohortId, {
       ...cohortData,
-      changedFieldNames: changes.map((c) => c.fieldName),
+      changedFieldNames: changes.map(c => c.fieldName)
     });
   });
   return Array.from(newDashboardCohortsByCohortId.values());

--- a/frontend/src/hooks/useCellChanges.ts
+++ b/frontend/src/hooks/useCellChanges.ts
@@ -3,7 +3,7 @@ import { useUserEmail } from "../contexts/UserEmailContext";
 import { useWarningModal } from "../contexts/WarningContext";
 import {
   CellEditRequestEvent,
-  IServerSideGetRowsParams
+  IServerSideGetRowsParams,
 } from "ag-grid-community";
 import { getUserEmail } from "../utils/getUserEmail";
 import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
@@ -13,7 +13,7 @@ import {
   DashboardSample,
   DashboardSampleInput,
   useUpdateDashboardSamplesMutation,
-  useUpdateTempoCohortMutation
+  useUpdateTempoCohortMutation,
 } from "../generated/graphql";
 import { handleAgGridPaste } from "../utils/handleAgGridPaste";
 import { awaitLoginPopup } from "../utils/awaitLoginPopup";
@@ -21,7 +21,7 @@ import { RecordChange } from "../types/shared";
 import { formatCellDate, isInvalidCostCenter } from "../utils/agGrid";
 import {
   INVALID_COST_CENTER_WARNING,
-  POLLING_PAUSE_AFTER_UPDATE
+  POLLING_PAUSE_AFTER_UPDATE,
 } from "../configs/shared";
 import { formatCohortUsersString } from "../utils/formatCohortUsersString";
 import _ from "lodash";
@@ -41,7 +41,7 @@ export function useCellChanges({
   stopPolling,
   records,
   refreshData,
-  isSampleLevelChanges
+  isSampleLevelChanges,
 }: UseCellChangesParams) {
   const [changes, setChanges] = useState<Array<RecordChange>>([]);
   const { userEmail, setUserEmail } = useUserEmail();
@@ -70,9 +70,9 @@ export function useCellChanges({
     const noChangeInVal = rowNode.data[fieldName] === newValue;
     const noChangeInEmptyCell = !rowNode.data[fieldName] && !newValue;
     if (noChangeInVal || noChangeInEmptyCell) {
-      setChanges(changes => {
+      setChanges((changes) => {
         const updatedChanges = changes.filter(
-          c => !(c.recordId === recordId && c.fieldName === fieldName)
+          (c) => !(c.recordId === recordId && c.fieldName === fieldName)
         );
         return updatedChanges;
       });
@@ -95,9 +95,9 @@ export function useCellChanges({
 
       const currUsername = currUserEmail.split("@")[0];
 
-      setChanges(changes => {
+      setChanges((changes) => {
         const billedBy = changes.find(
-          c => c.recordId === recordId && c.fieldName === "billedBy"
+          (c) => c.recordId === recordId && c.fieldName === "billedBy"
         );
         if (billedBy) {
           billedBy.newValue = currUsername;
@@ -107,7 +107,7 @@ export function useCellChanges({
             fieldName: "billedBy",
             oldValue: "",
             newValue: currUsername,
-            rowNode
+            rowNode,
           });
         }
         return [...changes];
@@ -115,9 +115,9 @@ export function useCellChanges({
     }
 
     // Add/update the edited cell to/in the changes array
-    setChanges(changes => {
+    setChanges((changes) => {
       const change = changes.find(
-        c => c.recordId === recordId && c.fieldName === fieldName
+        (c) => c.recordId === recordId && c.fieldName === fieldName
       );
       if (change) {
         change.newValue = newValue;
@@ -127,7 +127,7 @@ export function useCellChanges({
           fieldName,
           oldValue,
           newValue,
-          rowNode
+          rowNode,
         });
       }
       return [...changes];
@@ -148,7 +148,7 @@ export function useCellChanges({
         e,
         gridRef,
         handleCellEditRequest,
-        context: { userEmail }
+        context: { userEmail },
       });
     } catch (error) {
       if (error instanceof Error) {
@@ -162,14 +162,14 @@ export function useCellChanges({
   function handleDiscardChanges() {
     // Remove cell styles associated with having been edited
     gridRef.current?.api?.redrawRows({
-      rowNodes: changes.map(c => c.rowNode)
+      rowNodes: changes.map((c) => c.rowNode),
     });
     setChanges([]);
     startPolling();
   }
 
   function handleConfirmUpdates() {
-    const hasInvalidCostCenter = changes.some(c =>
+    const hasInvalidCostCenter = changes.some((c) =>
       isInvalidCostCenter(c.fieldName, c.newValue)
     );
     if (hasInvalidCostCenter) {
@@ -185,7 +185,7 @@ export function useCellChanges({
       return;
     }
 
-    const recordIds = _.uniq(changes.map(c => c.recordId));
+    const recordIds = _.uniq(changes.map((c) => c.recordId));
 
     const changesWithReason = [...changes];
 
@@ -198,8 +198,8 @@ export function useCellChanges({
       const formattedChangelog = username
         ? `${username}: ${reasonForChange}`
         : reasonForChange;
-      recordIds.forEach(r => {
-        const change = changes.find(c => c.recordId === r);
+      recordIds.forEach((r) => {
+        const change = changes.find((c) => c.recordId === r);
         if (!change) {
           return;
         }
@@ -209,7 +209,7 @@ export function useCellChanges({
           fieldName: "changelog",
           oldValue: change.rowNode.data.changelog,
           newValue: formattedChangelog,
-          rowNode: change.rowNode
+          rowNode: change.rowNode,
         });
       });
     }
@@ -220,14 +220,14 @@ export function useCellChanges({
 
       // Send to GraphQL server to publish
       updateDashboardSamplesMutation({
-        variables: { newDashboardSamples }
+        variables: { newDashboardSamples },
       });
 
       // Manually handle optimistic updates by refreshing updated rows' UI to indicate them being updated
       // (We can't use GraphQL's optimistic response because it isn't a good fit for
       // AG Grid's Server-Side data model. e.g. GraphQL's optimistic response only returns
       // the updated data, while AG Grid expects the datasource == the entire dataset.)
-      const optimisticSamples = records!.map(s => {
+      const optimisticSamples = records!.map((s) => {
         s = s as DashboardSample; // we already know we're dealing with DashboardSample here
         const changesForSample =
           s.primaryId != null ? changesByRecordId.get(s.primaryId) : undefined;
@@ -240,7 +240,7 @@ export function useCellChanges({
             ...s,
             ...changedFields,
             revisable: false,
-            importDate: formatCellDate(new Date()) as string
+            importDate: formatCellDate(new Date()) as string,
           };
         }
         return s;
@@ -255,9 +255,9 @@ export function useCellChanges({
         getRows: (params: IServerSideGetRowsParams) => {
           params.success({
             rowData: optimisticSamples!,
-            rowCount: optimisticSamples[0]?._total || 0
+            rowCount: optimisticSamples[0]?._total || 0,
           });
-        }
+        },
       };
       gridRef.current?.api?.setServerSideDatasource(optimisticDatasource);
     } else {
@@ -284,24 +284,24 @@ export function useCellChanges({
     const changelog = `${username}: Forcing label generation`;
 
     const newDashboardSamples: DashboardSampleInput[] = allSamples.map(
-      sample => {
+      (sample) => {
         const { __typename, igoQcReports, ...sampleData } = sample as any;
         return {
           ...sampleData,
           changedFieldNames: ["forceCmoLabel", "changelog"],
           changelog,
-          revisable: false
+          revisable: false,
         };
       }
     );
 
     updateDashboardSamplesMutation({ variables: { newDashboardSamples } });
 
-    const optimisticSamples = allSamples.map(s => ({
+    const optimisticSamples = allSamples.map((s) => ({
       ...s,
       changelog,
       revisable: false,
-      importDate: formatCellDate(new Date()) as string
+      importDate: formatCellDate(new Date()) as string,
     }));
     optimisticSamples.sort(
       (a, b) =>
@@ -312,9 +312,9 @@ export function useCellChanges({
       getRows: (params: IServerSideGetRowsParams) => {
         params.success({
           rowData: optimisticSamples,
-          rowCount: optimisticSamples[0]?._total || 0
+          rowCount: optimisticSamples[0]?._total || 0,
         });
-      }
+      },
     });
 
     setTimeout(async () => {
@@ -335,8 +335,8 @@ export function useCellChanges({
       handleConfirmUpdates,
       handleSubmitUpdates,
       showUpdateModal,
-      setShowUpdateModal
-    }
+      setShowUpdateModal,
+    },
   };
 }
 
@@ -368,7 +368,7 @@ function buildNewDashboardSamples(
     newDashboardSamplesByPrimaryId.set(primaryId, {
       ...sampleData,
       revisable: false,
-      changedFieldNames: changes.map(c => c.fieldName)
+      changedFieldNames: changes.map((c) => c.fieldName),
     });
   });
   return Array.from(newDashboardSamplesByPrimaryId.values());
@@ -389,7 +389,7 @@ function buildNewDashboardCohorts(
     delete cohortData.__typename;
     newDashboardCohortsByCohortId.set(cohortId, {
       ...cohortData,
-      changedFieldNames: changes.map(c => c.fieldName)
+      changedFieldNames: changes.map((c) => c.fieldName),
     });
   });
   return Array.from(newDashboardCohortsByCohortId.values());

--- a/frontend/src/pages/requests/RequestsPage.tsx
+++ b/frontend/src/pages/requests/RequestsPage.tsx
@@ -4,7 +4,7 @@ import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
 import { useFetchData } from "../../hooks/useFetchData";
 import {
   DashboardRequest,
-  useDashboardRequestsLazyQuery,
+  useDashboardRequestsLazyQuery
 } from "../../generated/graphql";
 import { Title } from "../../components/Title";
 import { Toolbar } from "../../components/Toolbar";
@@ -30,28 +30,34 @@ export function RequestsPage() {
   const gridRef = useRef<AgGridReactType<DashboardRequest>>(null);
   const hasParams = Object.keys(useParams()).length > 0;
 
-  const { refreshData, recordCount, isLoading, error, fetchMore } =
-    useFetchData({
-      useRecordsLazyQuery: useDashboardRequestsLazyQuery,
-      queryName: QUERY_NAME,
-      initialSortFieldName: INITIAL_SORT_FIELD_NAME,
-      gridRef,
-      userSearchVal,
-    });
+  const {
+    refreshData,
+    recordCount,
+    isLoading,
+    error,
+    fetchMore
+  } = useFetchData({
+    useRecordsLazyQuery: useDashboardRequestsLazyQuery,
+    queryName: QUERY_NAME,
+    initialSortFieldName: INITIAL_SORT_FIELD_NAME,
+    gridRef,
+    userSearchVal
+  });
 
-  const { isDownloading, handleDownload, getCurrentData } =
-    useDownload<DashboardRequest>({
-      gridRef,
-      downloadFileName: RECORD_NAME,
-      fetchMore,
-      userSearchVal,
-      recordCount,
-      queryName: QUERY_NAME,
-    });
+  const { isDownloading, handleDownload, getCurrentData } = useDownload<
+    DashboardRequest
+  >({
+    gridRef,
+    downloadFileName: RECORD_NAME,
+    fetchMore,
+    userSearchVal,
+    recordCount,
+    queryName: QUERY_NAME
+  });
 
   const downloadOptions = buildDownloadOptions({
     getCurrentData,
-    currentColDefs: requestColDefs,
+    currentColDefs: requestColDefs
   });
 
   if (error) {
@@ -96,6 +102,7 @@ export function RequestsPage() {
           sampleColDefs={sampleColDefs}
           contextFieldName={ROUTE_PARAMS.requests}
           parentRecordName={RECORD_NAME}
+          showForceLabelButton={true}
         />
       )}
 

--- a/frontend/src/pages/requests/RequestsPage.tsx
+++ b/frontend/src/pages/requests/RequestsPage.tsx
@@ -4,7 +4,7 @@ import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
 import { useFetchData } from "../../hooks/useFetchData";
 import {
   DashboardRequest,
-  useDashboardRequestsLazyQuery
+  useDashboardRequestsLazyQuery,
 } from "../../generated/graphql";
 import { Title } from "../../components/Title";
 import { Toolbar } from "../../components/Toolbar";
@@ -30,34 +30,28 @@ export function RequestsPage() {
   const gridRef = useRef<AgGridReactType<DashboardRequest>>(null);
   const hasParams = Object.keys(useParams()).length > 0;
 
-  const {
-    refreshData,
-    recordCount,
-    isLoading,
-    error,
-    fetchMore
-  } = useFetchData({
-    useRecordsLazyQuery: useDashboardRequestsLazyQuery,
-    queryName: QUERY_NAME,
-    initialSortFieldName: INITIAL_SORT_FIELD_NAME,
-    gridRef,
-    userSearchVal
-  });
+  const { refreshData, recordCount, isLoading, error, fetchMore } =
+    useFetchData({
+      useRecordsLazyQuery: useDashboardRequestsLazyQuery,
+      queryName: QUERY_NAME,
+      initialSortFieldName: INITIAL_SORT_FIELD_NAME,
+      gridRef,
+      userSearchVal,
+    });
 
-  const { isDownloading, handleDownload, getCurrentData } = useDownload<
-    DashboardRequest
-  >({
-    gridRef,
-    downloadFileName: RECORD_NAME,
-    fetchMore,
-    userSearchVal,
-    recordCount,
-    queryName: QUERY_NAME
-  });
+  const { isDownloading, handleDownload, getCurrentData } =
+    useDownload<DashboardRequest>({
+      gridRef,
+      downloadFileName: RECORD_NAME,
+      fetchMore,
+      userSearchVal,
+      recordCount,
+      queryName: QUERY_NAME,
+    });
 
   const downloadOptions = buildDownloadOptions({
     getCurrentData,
-    currentColDefs: requestColDefs
+    currentColDefs: requestColDefs,
   });
 
   if (error) {

--- a/graphql-server/package.json
+++ b/graphql-server/package.json
@@ -42,7 +42,7 @@
     "node-cache": "^5.1.2",
     "openid-client": "^5.6.1",
     "passport": "^0.6.0",
-    "prettier": "1.19.1",
+    "prettier": "2.8.8",
     "properties-reader": "^2.2.0",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9",

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -10,7 +10,7 @@ import {
   QueryDashboardRequestsArgs,
   QueryDashboardSamplesArgs,
   SeqDateAccessionBySampleId,
-  TempoCohortRequestInput
+  TempoCohortRequestInput,
 } from "../generated/graphql";
 import { props } from "../utils/constants";
 import { connect, headers, StringCodec } from "nats";
@@ -22,12 +22,12 @@ import {
   queryAllAnchorSeqDateData,
   queryAnchorSeqDateData,
   queryDashboardPatients,
-  queryPatientIdsTriplets
+  queryPatientIdsTriplets,
 } from "./queries/patients";
 import {
   buildCohortsQueryBody,
   buildCohortsQueryFinal,
-  queryDashboardCohorts
+  queryDashboardCohorts,
 } from "./queries/cohorts";
 import {
   buildSampleMetadataHistoryQueryBody,
@@ -36,7 +36,7 @@ import {
   getAddlOtCodesMatchingCtOrCtdVals,
   mapPhiToSamplesData,
   queryDashboardSamples,
-  querySeqDatesByDmpSampleId
+  querySeqDatesByDmpSampleId,
 } from "./queries/samples";
 import {
   COHORTS_CACHE_KEY,
@@ -52,12 +52,12 @@ import {
   SAMPLES_CACHE_KEY,
   SamplesCache,
   updateCacheWithNewCohortUpdates,
-  updateCacheWithNewSampleUpdates
+  updateCacheWithNewSampleUpdates,
 } from "../utils/cache";
 import {
   buildRequestsQueryBody,
   buildRequestsQueryFinal,
-  queryDashboardRequests
+  queryDashboardRequests,
 } from "./queries/requests";
 import { typeDefs } from "../utils/typeDefs";
 const request = require("request-promise-native");
@@ -86,7 +86,7 @@ type AuthMiddleware = {
 function canSearchPhiData({
   phiEnabled,
   searchVals,
-  searchValsIsRequired = true
+  searchValsIsRequired = true,
 }: {
   phiEnabled?: boolean | null;
   searchVals?: string[] | null;
@@ -111,7 +111,7 @@ export async function buildCustomSchema(ogm: OGM) {
         if (
           canSearchPhiData({
             phiEnabled: args.phiEnabled,
-            searchVals: args.searchVals
+            searchVals: args.searchVals,
           }) &&
           !context.req.isAuthenticated()
         ) {
@@ -132,7 +132,7 @@ export async function buildCustomSchema(ogm: OGM) {
         if (
           canSearchPhiData({
             phiEnabled: args.phiEnabled,
-            searchVals: args.searchVals
+            searchVals: args.searchVals,
           }) &&
           !context.req.isAuthenticated()
         ) {
@@ -153,7 +153,7 @@ export async function buildCustomSchema(ogm: OGM) {
         if (
           !canSearchPhiData({
             phiEnabled: args.phiEnabled,
-            searchValsIsRequired: false
+            searchValsIsRequired: false,
           }) ||
           !context.req.isAuthenticated()
         ) {
@@ -192,8 +192,8 @@ export async function buildCustomSchema(ogm: OGM) {
           );
         }
         return await resolve(parent, args, context, info);
-      }
-    }
+      },
+    },
   };
 
   const authorizationMiddleware: AuthMiddleware = {
@@ -208,7 +208,7 @@ export async function buildCustomSchema(ogm: OGM) {
         if (
           canSearchPhiData({
             phiEnabled: args.phiEnabled,
-            searchVals: args.searchVals
+            searchVals: args.searchVals,
           }) &&
           !context.req.user.groups.includes(KEYCLOAK_PHI_ACCESS_GROUP)
         ) {
@@ -229,7 +229,7 @@ export async function buildCustomSchema(ogm: OGM) {
         if (
           canSearchPhiData({
             phiEnabled: args.phiEnabled,
-            searchVals: args.searchVals
+            searchVals: args.searchVals,
           }) &&
           !context.req.user.groups.includes(KEYCLOAK_PHI_ACCESS_GROUP)
         ) {
@@ -250,7 +250,7 @@ export async function buildCustomSchema(ogm: OGM) {
         if (
           !canSearchPhiData({
             phiEnabled: args.phiEnabled,
-            searchValsIsRequired: false
+            searchValsIsRequired: false,
           }) ||
           !context.req.user.groups.includes(KEYCLOAK_PHI_ACCESS_GROUP)
         ) {
@@ -267,8 +267,8 @@ export async function buildCustomSchema(ogm: OGM) {
 
       async dashboardCohorts(resolve, parent, args, context, info) {
         return await resolve(parent, args, context, info);
-      }
-    }
+      },
+    },
   };
 
   const resolvers = {
@@ -280,7 +280,7 @@ export async function buildCustomSchema(ogm: OGM) {
           columnFilters,
           sort,
           limit,
-          offset
+          offset,
         }: QueryDashboardRequestsArgs,
         { inMemoryCache }: ApolloServerContext
       ) {
@@ -293,7 +293,7 @@ export async function buildCustomSchema(ogm: OGM) {
           queryBody,
           sort,
           limit,
-          offset
+          offset,
         });
 
         if (requestsCache && requestsCypherQuery in requestsCache) {
@@ -304,7 +304,7 @@ export async function buildCustomSchema(ogm: OGM) {
           queryBody,
           sort,
           limit,
-          offset
+          offset,
         });
       },
 
@@ -316,7 +316,7 @@ export async function buildCustomSchema(ogm: OGM) {
           sort,
           limit,
           offset,
-          phiEnabled
+          phiEnabled,
         }: QueryDashboardPatientsArgs,
         { inMemoryCache }: ApolloServerContext
       ) {
@@ -328,9 +328,9 @@ export async function buildCustomSchema(ogm: OGM) {
         if (searchVals && canSearchPhiData({ phiEnabled, searchVals })) {
           patientIdsTriplets = await queryPatientIdsTriplets(searchVals);
           const mappedPatientIds = patientIdsTriplets
-            .flatMap(triplet => [
+            .flatMap((triplet) => [
               triplet.DMP_PATIENT_ID,
-              triplet.CMO_PATIENT_ID
+              triplet.CMO_PATIENT_ID,
             ])
             .filter((id): id is string => !!id && !searchVals.includes(id));
           searchVals.push(...mappedPatientIds);
@@ -338,13 +338,13 @@ export async function buildCustomSchema(ogm: OGM) {
 
         const queryBody = buildPatientsQueryBody({
           searchVals,
-          columnFilters
+          columnFilters,
         });
         const queryFinal = buildPatientsQueryFinal({
           queryBody,
           sort,
           limit,
-          offset
+          offset,
         });
 
         if (patientsCache && queryFinal in patientsCache) {
@@ -358,21 +358,21 @@ export async function buildCustomSchema(ogm: OGM) {
         }
 
         const allMappedPatientIds = patientIdsTriplets
-          .flatMap(triplet => [
+          .flatMap((triplet) => [
             triplet.MRN,
             triplet.DMP_PATIENT_ID,
-            triplet.CMO_PATIENT_ID
+            triplet.CMO_PATIENT_ID,
           ])
           .filter((id): id is string => !!id);
         const [patientsData, anchorSeqDateData] = await Promise.all([
           patientsDataPromise,
-          queryAnchorSeqDateData(allMappedPatientIds)
+          queryAnchorSeqDateData(allMappedPatientIds),
         ]);
 
         return mapPhiToPatientsData({
           patientsData,
           patientIdsTriplets,
-          anchorSeqDateData
+          anchorSeqDateData,
         });
       },
 
@@ -391,7 +391,7 @@ export async function buildCustomSchema(ogm: OGM) {
           columnFilters,
           sort,
           limit,
-          offset
+          offset,
         }: QueryDashboardCohortsArgs,
         { inMemoryCache }: ApolloServerContext
       ) {
@@ -404,7 +404,7 @@ export async function buildCustomSchema(ogm: OGM) {
           queryBody,
           sort,
           limit,
-          offset
+          offset,
         });
 
         if (cohortsCache && cohortsCypherQuery in cohortsCache) {
@@ -415,7 +415,7 @@ export async function buildCustomSchema(ogm: OGM) {
           queryBody,
           sort,
           limit,
-          offset
+          offset,
         });
       },
 
@@ -429,7 +429,7 @@ export async function buildCustomSchema(ogm: OGM) {
           limit,
           offset,
           phiEnabled,
-          includeDemographics
+          includeDemographics,
         }: QueryDashboardSamplesArgs,
         { inMemoryCache }: ApolloServerContext
       ) {
@@ -451,7 +451,7 @@ export async function buildCustomSchema(ogm: OGM) {
           );
           let mappedSampleIds: string[] = [];
           let toRemove: string[] = [];
-          dmpSampleSeqDateAccessions.forEach(v => {
+          dmpSampleSeqDateAccessions.forEach((v) => {
             if (
               v.DMP_SAMPLE_ID &&
               searchVals &&
@@ -468,26 +468,26 @@ export async function buildCustomSchema(ogm: OGM) {
             }
           });
           searchVals.push(...mappedSampleIds);
-          searchVals = searchVals.filter(val => !toRemove.includes(val));
+          searchVals = searchVals.filter((val) => !toRemove.includes(val));
         }
 
         const addlOncotreeCodes = getAddlOtCodesMatchingCtOrCtdVals({
           searchVals,
-          oncotreeCache
+          oncotreeCache,
         });
 
         const queryBody = buildSamplesQueryBody({
           searchVals,
           recordContexts,
           columnFilters,
-          addlOncotreeCodes
+          addlOncotreeCodes,
         });
 
         const samplesCypherQuery = buildSamplesQueryFinal({
           queryBody,
           sort,
           limit,
-          offset
+          offset,
         });
 
         if (samplesCache && samplesCypherQuery in samplesCache) {
@@ -497,7 +497,7 @@ export async function buildCustomSchema(ogm: OGM) {
         const samplesDataPromise = queryDashboardSamples({
           samplesCypherQuery,
           oncotreeCache,
-          patientDemographicsCache
+          patientDemographicsCache,
         });
 
         if (!canSearchPhiData({ phiEnabled, searchVals })) {
@@ -506,12 +506,12 @@ export async function buildCustomSchema(ogm: OGM) {
 
         const [samplesData, seqDatesBySampleId] = await Promise.all([
           samplesDataPromise,
-          querySeqDatesByDmpSampleId(searchVals!)
+          querySeqDatesByDmpSampleId(searchVals!),
         ]);
 
         return mapPhiToSamplesData({
           samplesData,
-          seqDatesBySampleId
+          seqDatesBySampleId,
         });
       },
 
@@ -528,29 +528,29 @@ export async function buildCustomSchema(ogm: OGM) {
         ) as PatientDemographicsCache;
 
         const queryBody = buildSampleMetadataHistoryQueryBody({
-          smileSampleId: searchVals ? searchVals[0] : ""
+          smileSampleId: searchVals ? searchVals[0] : "",
         });
 
         const samplesCypherQuery = buildSamplesQueryFinal({
           queryBody,
           sort,
           limit,
-          offset
+          offset,
         });
 
         return await queryDashboardSamples({
           samplesCypherQuery,
           oncotreeCache,
-          patientDemographicsCache
+          patientDemographicsCache,
         });
-      }
+      },
     },
 
     Mutation: {
       async updateDashboardSamples(
         _source: undefined,
         {
-          newDashboardSamples
+          newDashboardSamples,
         }: { newDashboardSamples: DashboardSampleInput[] },
         { inMemoryCache }: ApolloServerContext
       ) {
@@ -570,7 +570,7 @@ export async function buildCustomSchema(ogm: OGM) {
       async updateTempoCohort(
         _source: undefined,
         {
-          dashboardCohort
+          dashboardCohort,
         }: {
           dashboardCohort: DashboardCohortInput;
         },
@@ -582,19 +582,19 @@ export async function buildCustomSchema(ogm: OGM) {
       async publishNewTempoCohortRequest(
         _source: undefined,
         {
-          tempoCohortRequest
+          tempoCohortRequest,
         }: {
           tempoCohortRequest: TempoCohortRequestInput;
         }
       ) {
         await publishNewTempoCohortRequestPromise(tempoCohortRequest);
-      }
-    }
+      },
+    },
   };
 
   const executableSchema = makeExecutableSchema({
     typeDefs: typeDefs,
-    resolvers: resolvers
+    resolvers: resolvers,
   });
 
   return applyMiddleware(
@@ -613,11 +613,11 @@ async function updateSampleMetadataPromises(
     const sampleManifest = await request(
       props.smile_sample_endpoint + newDashboardSample.primaryId,
       {
-        json: true
+        json: true,
       }
     );
 
-    Object.keys(newDashboardSample).forEach(key => {
+    Object.keys(newDashboardSample).forEach((key) => {
       if (key in sampleManifest) {
         sampleManifest[key] =
           newDashboardSample[key as keyof DashboardSampleInput];
@@ -646,9 +646,10 @@ async function updateSampleMetadataPromises(
         const requestId = sampleManifest.additionalProperties.igoRequestId;
         let requestOgm = ogm.model("Request");
         const requestOfSample = await requestOgm.find({
-          where: { igoRequestId: requestId }
+          where: { igoRequestId: requestId },
         });
-        sampleManifest.additionalProperties.isCmoSample = requestOfSample[0].isCmoRequest.toString();
+        sampleManifest.additionalProperties.isCmoSample =
+          requestOfSample[0].isCmoRequest.toString();
       }
 
       if (sampleManifest.datasource === "dmp") {
@@ -658,13 +659,13 @@ async function updateSampleMetadataPromises(
 
     await ogm.model("Sample").update({
       where: { smileSampleId: sampleManifest.smileSampleId },
-      update: { revisable: false }
+      update: { revisable: false },
     });
 
     sampleManifests.push(sampleManifest);
   }
 
-  return new Promise(async resolve => {
+  return new Promise(async (resolve) => {
     publishNatsMessage(
       props.pub_validate_sample_update,
       JSON.stringify(sampleManifests)
@@ -674,14 +675,14 @@ async function updateSampleMetadataPromises(
 }
 
 async function updateTempoPromise(newDashboardSample: DashboardSampleInput) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     const dataForTempoBillingUpdate = {
       primaryId: newDashboardSample.primaryId,
       billed: newDashboardSample.billed,
       billedBy: newDashboardSample.billedBy,
       costCenter: newDashboardSample.costCenter,
       accessLevel: newDashboardSample.accessLevel,
-      custodianInformation: newDashboardSample.custodianInformation
+      custodianInformation: newDashboardSample.custodianInformation,
     };
 
     publishNatsMessage(
@@ -698,22 +699,22 @@ async function publishNewTempoCohortRequestPromise(
 ) {
   const topics = [
     props.pub_tempo_new_cohort_submit,
-    props.pub_tempo_provisional_cohort
+    props.pub_tempo_provisional_cohort,
   ];
   for (const topic of topics) {
     publishNatsMessage(topic, JSON.stringify(tempoCohortRequest));
   }
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     resolve(null);
   });
 }
 
 async function updateDbGapPromise(newDashboardSample: DashboardSampleInput) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     const dataForDbGapUpdate = {
       primaryId: newDashboardSample.primaryId,
       dbGapStudy: newDashboardSample.dbGapStudy,
-      irbConsentProtocol: newDashboardSample.irbConsentProtocol
+      irbConsentProtocol: newDashboardSample.irbConsentProtocol,
     };
 
     publishNatsMessage(
@@ -726,7 +727,7 @@ async function updateDbGapPromise(newDashboardSample: DashboardSampleInput) {
 }
 
 async function updateTempoCohortPromise(dashboardCohort: DashboardCohort) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     const dataForTempoCohortUpdate = {
       cohortId: dashboardCohort.cohortId,
       date: dashboardCohort.initialCohortDeliveryDate,
@@ -736,7 +737,7 @@ async function updateTempoCohortPromise(dashboardCohort: DashboardCohort) {
       status: dashboardCohort.status,
       projectTitle: dashboardCohort.projectTitle,
       projectSubtitle: dashboardCohort.projectSubtitle,
-      pipelineVersion: dashboardCohort.pipelineVersion || ""
+      pipelineVersion: dashboardCohort.pipelineVersion || "",
     };
     publishNatsMessage(
       props.pub_tempo_cohort_update,
@@ -759,7 +760,7 @@ const EDITABLE_SAMPLEMETADATA_FIELDS = new Set([
   "tissueLocation",
   "sex",
   "changelog",
-  "forceCmoLabel"
+  "forceCmoLabel",
 ]);
 
 const EDITABLE_TEMPO_FIELDS = new Set([
@@ -767,7 +768,7 @@ const EDITABLE_TEMPO_FIELDS = new Set([
   "costCenter",
   "billedBy",
   "custodianInformation",
-  "accessLevel"
+  "accessLevel",
 ]);
 
 const EDITABLE_DBGAP_FIELDS = new Set(["dbGapStudy", "irbConsentProtocol"]);
@@ -784,13 +785,13 @@ async function updateAllSamplesConcurrently(
     try {
       const { changedFieldNames } = dashboardSample;
 
-      const metadataChanged = changedFieldNames.some(field =>
+      const metadataChanged = changedFieldNames.some((field) =>
         EDITABLE_SAMPLEMETADATA_FIELDS.has(field)
       );
-      const tempoChanged = changedFieldNames.some(field =>
+      const tempoChanged = changedFieldNames.some((field) =>
         EDITABLE_TEMPO_FIELDS.has(field)
       );
-      const dbGapChanged = changedFieldNames.some(field =>
+      const dbGapChanged = changedFieldNames.some((field) =>
         EDITABLE_DBGAP_FIELDS.has(field)
       );
 
@@ -827,14 +828,14 @@ async function publishNatsMessage(topic: string, message: string) {
     keyFile: props.nats_key_pem,
     certFile: props.nats_cert_pem,
     caFile: props.nats_ca_pem,
-    rejectUnauthorized: false
+    rejectUnauthorized: false,
   };
 
   const natsConnProperties = {
     servers: [props.nats_url],
     user: props.nats_username,
     pass: props.nats_password,
-    tls: tlsOptions
+    tls: tlsOptions,
   };
 
   try {
@@ -869,7 +870,7 @@ async function getCohortIdsFromNeo4j() {
     const result = await session.run(`
       MATCH (c:Cohort) RETURN DISTINCT c.cohortId AS cohortId
     `);
-    return result.records.map(record => record.get("cohortId"));
+    return result.records.map((record) => record.get("cohortId"));
   } catch (error) {
     if (error instanceof Error) {
       console.error(error.message);
@@ -893,7 +894,7 @@ function formatUsersString(val: string) {
       .split(/[\s,]+(?=(?:[^'"]|'[^']*'|"[^"]*")*$)/)
       .compact()
       .uniq()
-      .map(val => {
+      .map((val) => {
         // handle users entering full email addresses just in case
         return val.split("@")[0].trim();
       })

--- a/graphql-server/src/schemas/custom.ts
+++ b/graphql-server/src/schemas/custom.ts
@@ -10,7 +10,7 @@ import {
   QueryDashboardRequestsArgs,
   QueryDashboardSamplesArgs,
   SeqDateAccessionBySampleId,
-  TempoCohortRequestInput,
+  TempoCohortRequestInput
 } from "../generated/graphql";
 import { props } from "../utils/constants";
 import { connect, headers, StringCodec } from "nats";
@@ -22,12 +22,12 @@ import {
   queryAllAnchorSeqDateData,
   queryAnchorSeqDateData,
   queryDashboardPatients,
-  queryPatientIdsTriplets,
+  queryPatientIdsTriplets
 } from "./queries/patients";
 import {
   buildCohortsQueryBody,
   buildCohortsQueryFinal,
-  queryDashboardCohorts,
+  queryDashboardCohorts
 } from "./queries/cohorts";
 import {
   buildSampleMetadataHistoryQueryBody,
@@ -36,7 +36,7 @@ import {
   getAddlOtCodesMatchingCtOrCtdVals,
   mapPhiToSamplesData,
   queryDashboardSamples,
-  querySeqDatesByDmpSampleId,
+  querySeqDatesByDmpSampleId
 } from "./queries/samples";
 import {
   COHORTS_CACHE_KEY,
@@ -52,12 +52,12 @@ import {
   SAMPLES_CACHE_KEY,
   SamplesCache,
   updateCacheWithNewCohortUpdates,
-  updateCacheWithNewSampleUpdates,
+  updateCacheWithNewSampleUpdates
 } from "../utils/cache";
 import {
   buildRequestsQueryBody,
   buildRequestsQueryFinal,
-  queryDashboardRequests,
+  queryDashboardRequests
 } from "./queries/requests";
 import { typeDefs } from "../utils/typeDefs";
 const request = require("request-promise-native");
@@ -86,7 +86,7 @@ type AuthMiddleware = {
 function canSearchPhiData({
   phiEnabled,
   searchVals,
-  searchValsIsRequired = true,
+  searchValsIsRequired = true
 }: {
   phiEnabled?: boolean | null;
   searchVals?: string[] | null;
@@ -111,7 +111,7 @@ export async function buildCustomSchema(ogm: OGM) {
         if (
           canSearchPhiData({
             phiEnabled: args.phiEnabled,
-            searchVals: args.searchVals,
+            searchVals: args.searchVals
           }) &&
           !context.req.isAuthenticated()
         ) {
@@ -132,7 +132,7 @@ export async function buildCustomSchema(ogm: OGM) {
         if (
           canSearchPhiData({
             phiEnabled: args.phiEnabled,
-            searchVals: args.searchVals,
+            searchVals: args.searchVals
           }) &&
           !context.req.isAuthenticated()
         ) {
@@ -153,7 +153,7 @@ export async function buildCustomSchema(ogm: OGM) {
         if (
           !canSearchPhiData({
             phiEnabled: args.phiEnabled,
-            searchValsIsRequired: false,
+            searchValsIsRequired: false
           }) ||
           !context.req.isAuthenticated()
         ) {
@@ -192,8 +192,8 @@ export async function buildCustomSchema(ogm: OGM) {
           );
         }
         return await resolve(parent, args, context, info);
-      },
-    },
+      }
+    }
   };
 
   const authorizationMiddleware: AuthMiddleware = {
@@ -208,7 +208,7 @@ export async function buildCustomSchema(ogm: OGM) {
         if (
           canSearchPhiData({
             phiEnabled: args.phiEnabled,
-            searchVals: args.searchVals,
+            searchVals: args.searchVals
           }) &&
           !context.req.user.groups.includes(KEYCLOAK_PHI_ACCESS_GROUP)
         ) {
@@ -229,7 +229,7 @@ export async function buildCustomSchema(ogm: OGM) {
         if (
           canSearchPhiData({
             phiEnabled: args.phiEnabled,
-            searchVals: args.searchVals,
+            searchVals: args.searchVals
           }) &&
           !context.req.user.groups.includes(KEYCLOAK_PHI_ACCESS_GROUP)
         ) {
@@ -250,7 +250,7 @@ export async function buildCustomSchema(ogm: OGM) {
         if (
           !canSearchPhiData({
             phiEnabled: args.phiEnabled,
-            searchValsIsRequired: false,
+            searchValsIsRequired: false
           }) ||
           !context.req.user.groups.includes(KEYCLOAK_PHI_ACCESS_GROUP)
         ) {
@@ -267,8 +267,8 @@ export async function buildCustomSchema(ogm: OGM) {
 
       async dashboardCohorts(resolve, parent, args, context, info) {
         return await resolve(parent, args, context, info);
-      },
-    },
+      }
+    }
   };
 
   const resolvers = {
@@ -280,7 +280,7 @@ export async function buildCustomSchema(ogm: OGM) {
           columnFilters,
           sort,
           limit,
-          offset,
+          offset
         }: QueryDashboardRequestsArgs,
         { inMemoryCache }: ApolloServerContext
       ) {
@@ -293,7 +293,7 @@ export async function buildCustomSchema(ogm: OGM) {
           queryBody,
           sort,
           limit,
-          offset,
+          offset
         });
 
         if (requestsCache && requestsCypherQuery in requestsCache) {
@@ -304,7 +304,7 @@ export async function buildCustomSchema(ogm: OGM) {
           queryBody,
           sort,
           limit,
-          offset,
+          offset
         });
       },
 
@@ -316,7 +316,7 @@ export async function buildCustomSchema(ogm: OGM) {
           sort,
           limit,
           offset,
-          phiEnabled,
+          phiEnabled
         }: QueryDashboardPatientsArgs,
         { inMemoryCache }: ApolloServerContext
       ) {
@@ -328,9 +328,9 @@ export async function buildCustomSchema(ogm: OGM) {
         if (searchVals && canSearchPhiData({ phiEnabled, searchVals })) {
           patientIdsTriplets = await queryPatientIdsTriplets(searchVals);
           const mappedPatientIds = patientIdsTriplets
-            .flatMap((triplet) => [
+            .flatMap(triplet => [
               triplet.DMP_PATIENT_ID,
-              triplet.CMO_PATIENT_ID,
+              triplet.CMO_PATIENT_ID
             ])
             .filter((id): id is string => !!id && !searchVals.includes(id));
           searchVals.push(...mappedPatientIds);
@@ -338,13 +338,13 @@ export async function buildCustomSchema(ogm: OGM) {
 
         const queryBody = buildPatientsQueryBody({
           searchVals,
-          columnFilters,
+          columnFilters
         });
         const queryFinal = buildPatientsQueryFinal({
           queryBody,
           sort,
           limit,
-          offset,
+          offset
         });
 
         if (patientsCache && queryFinal in patientsCache) {
@@ -358,21 +358,21 @@ export async function buildCustomSchema(ogm: OGM) {
         }
 
         const allMappedPatientIds = patientIdsTriplets
-          .flatMap((triplet) => [
+          .flatMap(triplet => [
             triplet.MRN,
             triplet.DMP_PATIENT_ID,
-            triplet.CMO_PATIENT_ID,
+            triplet.CMO_PATIENT_ID
           ])
           .filter((id): id is string => !!id);
         const [patientsData, anchorSeqDateData] = await Promise.all([
           patientsDataPromise,
-          queryAnchorSeqDateData(allMappedPatientIds),
+          queryAnchorSeqDateData(allMappedPatientIds)
         ]);
 
         return mapPhiToPatientsData({
           patientsData,
           patientIdsTriplets,
-          anchorSeqDateData,
+          anchorSeqDateData
         });
       },
 
@@ -391,7 +391,7 @@ export async function buildCustomSchema(ogm: OGM) {
           columnFilters,
           sort,
           limit,
-          offset,
+          offset
         }: QueryDashboardCohortsArgs,
         { inMemoryCache }: ApolloServerContext
       ) {
@@ -404,7 +404,7 @@ export async function buildCustomSchema(ogm: OGM) {
           queryBody,
           sort,
           limit,
-          offset,
+          offset
         });
 
         if (cohortsCache && cohortsCypherQuery in cohortsCache) {
@@ -415,7 +415,7 @@ export async function buildCustomSchema(ogm: OGM) {
           queryBody,
           sort,
           limit,
-          offset,
+          offset
         });
       },
 
@@ -429,7 +429,7 @@ export async function buildCustomSchema(ogm: OGM) {
           limit,
           offset,
           phiEnabled,
-          includeDemographics,
+          includeDemographics
         }: QueryDashboardSamplesArgs,
         { inMemoryCache }: ApolloServerContext
       ) {
@@ -451,7 +451,7 @@ export async function buildCustomSchema(ogm: OGM) {
           );
           let mappedSampleIds: string[] = [];
           let toRemove: string[] = [];
-          dmpSampleSeqDateAccessions.forEach((v) => {
+          dmpSampleSeqDateAccessions.forEach(v => {
             if (
               v.DMP_SAMPLE_ID &&
               searchVals &&
@@ -468,26 +468,26 @@ export async function buildCustomSchema(ogm: OGM) {
             }
           });
           searchVals.push(...mappedSampleIds);
-          searchVals = searchVals.filter((val) => !toRemove.includes(val));
+          searchVals = searchVals.filter(val => !toRemove.includes(val));
         }
 
         const addlOncotreeCodes = getAddlOtCodesMatchingCtOrCtdVals({
           searchVals,
-          oncotreeCache,
+          oncotreeCache
         });
 
         const queryBody = buildSamplesQueryBody({
           searchVals,
           recordContexts,
           columnFilters,
-          addlOncotreeCodes,
+          addlOncotreeCodes
         });
 
         const samplesCypherQuery = buildSamplesQueryFinal({
           queryBody,
           sort,
           limit,
-          offset,
+          offset
         });
 
         if (samplesCache && samplesCypherQuery in samplesCache) {
@@ -497,7 +497,7 @@ export async function buildCustomSchema(ogm: OGM) {
         const samplesDataPromise = queryDashboardSamples({
           samplesCypherQuery,
           oncotreeCache,
-          patientDemographicsCache,
+          patientDemographicsCache
         });
 
         if (!canSearchPhiData({ phiEnabled, searchVals })) {
@@ -506,12 +506,12 @@ export async function buildCustomSchema(ogm: OGM) {
 
         const [samplesData, seqDatesBySampleId] = await Promise.all([
           samplesDataPromise,
-          querySeqDatesByDmpSampleId(searchVals!),
+          querySeqDatesByDmpSampleId(searchVals!)
         ]);
 
         return mapPhiToSamplesData({
           samplesData,
-          seqDatesBySampleId,
+          seqDatesBySampleId
         });
       },
 
@@ -528,29 +528,29 @@ export async function buildCustomSchema(ogm: OGM) {
         ) as PatientDemographicsCache;
 
         const queryBody = buildSampleMetadataHistoryQueryBody({
-          smileSampleId: searchVals ? searchVals[0] : "",
+          smileSampleId: searchVals ? searchVals[0] : ""
         });
 
         const samplesCypherQuery = buildSamplesQueryFinal({
           queryBody,
           sort,
           limit,
-          offset,
+          offset
         });
 
         return await queryDashboardSamples({
           samplesCypherQuery,
           oncotreeCache,
-          patientDemographicsCache,
+          patientDemographicsCache
         });
-      },
+      }
     },
 
     Mutation: {
       async updateDashboardSamples(
         _source: undefined,
         {
-          newDashboardSamples,
+          newDashboardSamples
         }: { newDashboardSamples: DashboardSampleInput[] },
         { inMemoryCache }: ApolloServerContext
       ) {
@@ -570,7 +570,7 @@ export async function buildCustomSchema(ogm: OGM) {
       async updateTempoCohort(
         _source: undefined,
         {
-          dashboardCohort,
+          dashboardCohort
         }: {
           dashboardCohort: DashboardCohortInput;
         },
@@ -582,19 +582,19 @@ export async function buildCustomSchema(ogm: OGM) {
       async publishNewTempoCohortRequest(
         _source: undefined,
         {
-          tempoCohortRequest,
+          tempoCohortRequest
         }: {
           tempoCohortRequest: TempoCohortRequestInput;
         }
       ) {
         await publishNewTempoCohortRequestPromise(tempoCohortRequest);
-      },
-    },
+      }
+    }
   };
 
   const executableSchema = makeExecutableSchema({
     typeDefs: typeDefs,
-    resolvers: resolvers,
+    resolvers: resolvers
   });
 
   return applyMiddleware(
@@ -613,11 +613,11 @@ async function updateSampleMetadataPromises(
     const sampleManifest = await request(
       props.smile_sample_endpoint + newDashboardSample.primaryId,
       {
-        json: true,
+        json: true
       }
     );
 
-    Object.keys(newDashboardSample).forEach((key) => {
+    Object.keys(newDashboardSample).forEach(key => {
       if (key in sampleManifest) {
         sampleManifest[key] =
           newDashboardSample[key as keyof DashboardSampleInput];
@@ -626,6 +626,11 @@ async function updateSampleMetadataPromises(
     // promote changelog to additional properties in sample manifest
     sampleManifest.additionalProperties.changelog =
       newDashboardSample.changelog || "";
+
+    // promote forceCmoLabel to additional properties when force label generation is requested
+    if (newDashboardSample.changedFieldNames.includes("forceCmoLabel")) {
+      sampleManifest.additionalProperties.forceCmoLabel = "true";
+    }
 
     // Ensure validator and label generator use latest status data added during validation
     delete sampleManifest.status;
@@ -641,10 +646,9 @@ async function updateSampleMetadataPromises(
         const requestId = sampleManifest.additionalProperties.igoRequestId;
         let requestOgm = ogm.model("Request");
         const requestOfSample = await requestOgm.find({
-          where: { igoRequestId: requestId },
+          where: { igoRequestId: requestId }
         });
-        sampleManifest.additionalProperties.isCmoSample =
-          requestOfSample[0].isCmoRequest.toString();
+        sampleManifest.additionalProperties.isCmoSample = requestOfSample[0].isCmoRequest.toString();
       }
 
       if (sampleManifest.datasource === "dmp") {
@@ -654,13 +658,13 @@ async function updateSampleMetadataPromises(
 
     await ogm.model("Sample").update({
       where: { smileSampleId: sampleManifest.smileSampleId },
-      update: { revisable: false },
+      update: { revisable: false }
     });
 
     sampleManifests.push(sampleManifest);
   }
 
-  return new Promise(async (resolve) => {
+  return new Promise(async resolve => {
     publishNatsMessage(
       props.pub_validate_sample_update,
       JSON.stringify(sampleManifests)
@@ -670,14 +674,14 @@ async function updateSampleMetadataPromises(
 }
 
 async function updateTempoPromise(newDashboardSample: DashboardSampleInput) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     const dataForTempoBillingUpdate = {
       primaryId: newDashboardSample.primaryId,
       billed: newDashboardSample.billed,
       billedBy: newDashboardSample.billedBy,
       costCenter: newDashboardSample.costCenter,
       accessLevel: newDashboardSample.accessLevel,
-      custodianInformation: newDashboardSample.custodianInformation,
+      custodianInformation: newDashboardSample.custodianInformation
     };
 
     publishNatsMessage(
@@ -694,22 +698,22 @@ async function publishNewTempoCohortRequestPromise(
 ) {
   const topics = [
     props.pub_tempo_new_cohort_submit,
-    props.pub_tempo_provisional_cohort,
+    props.pub_tempo_provisional_cohort
   ];
   for (const topic of topics) {
     publishNatsMessage(topic, JSON.stringify(tempoCohortRequest));
   }
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     resolve(null);
   });
 }
 
 async function updateDbGapPromise(newDashboardSample: DashboardSampleInput) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     const dataForDbGapUpdate = {
       primaryId: newDashboardSample.primaryId,
       dbGapStudy: newDashboardSample.dbGapStudy,
-      irbConsentProtocol: newDashboardSample.irbConsentProtocol,
+      irbConsentProtocol: newDashboardSample.irbConsentProtocol
     };
 
     publishNatsMessage(
@@ -722,7 +726,7 @@ async function updateDbGapPromise(newDashboardSample: DashboardSampleInput) {
 }
 
 async function updateTempoCohortPromise(dashboardCohort: DashboardCohort) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     const dataForTempoCohortUpdate = {
       cohortId: dashboardCohort.cohortId,
       date: dashboardCohort.initialCohortDeliveryDate,
@@ -732,7 +736,7 @@ async function updateTempoCohortPromise(dashboardCohort: DashboardCohort) {
       status: dashboardCohort.status,
       projectTitle: dashboardCohort.projectTitle,
       projectSubtitle: dashboardCohort.projectSubtitle,
-      pipelineVersion: dashboardCohort.pipelineVersion || "",
+      pipelineVersion: dashboardCohort.pipelineVersion || ""
     };
     publishNatsMessage(
       props.pub_tempo_cohort_update,
@@ -755,6 +759,7 @@ const EDITABLE_SAMPLEMETADATA_FIELDS = new Set([
   "tissueLocation",
   "sex",
   "changelog",
+  "forceCmoLabel"
 ]);
 
 const EDITABLE_TEMPO_FIELDS = new Set([
@@ -762,7 +767,7 @@ const EDITABLE_TEMPO_FIELDS = new Set([
   "costCenter",
   "billedBy",
   "custodianInformation",
-  "accessLevel",
+  "accessLevel"
 ]);
 
 const EDITABLE_DBGAP_FIELDS = new Set(["dbGapStudy", "irbConsentProtocol"]);
@@ -779,13 +784,13 @@ async function updateAllSamplesConcurrently(
     try {
       const { changedFieldNames } = dashboardSample;
 
-      const metadataChanged = changedFieldNames.some((field) =>
+      const metadataChanged = changedFieldNames.some(field =>
         EDITABLE_SAMPLEMETADATA_FIELDS.has(field)
       );
-      const tempoChanged = changedFieldNames.some((field) =>
+      const tempoChanged = changedFieldNames.some(field =>
         EDITABLE_TEMPO_FIELDS.has(field)
       );
-      const dbGapChanged = changedFieldNames.some((field) =>
+      const dbGapChanged = changedFieldNames.some(field =>
         EDITABLE_DBGAP_FIELDS.has(field)
       );
 
@@ -822,14 +827,14 @@ async function publishNatsMessage(topic: string, message: string) {
     keyFile: props.nats_key_pem,
     certFile: props.nats_cert_pem,
     caFile: props.nats_ca_pem,
-    rejectUnauthorized: false,
+    rejectUnauthorized: false
   };
 
   const natsConnProperties = {
     servers: [props.nats_url],
     user: props.nats_username,
     pass: props.nats_password,
-    tls: tlsOptions,
+    tls: tlsOptions
   };
 
   try {
@@ -864,7 +869,7 @@ async function getCohortIdsFromNeo4j() {
     const result = await session.run(`
       MATCH (c:Cohort) RETURN DISTINCT c.cohortId AS cohortId
     `);
-    return result.records.map((record) => record.get("cohortId"));
+    return result.records.map(record => record.get("cohortId"));
   } catch (error) {
     if (error instanceof Error) {
       console.error(error.message);
@@ -888,7 +893,7 @@ function formatUsersString(val: string) {
       .split(/[\s,]+(?=(?:[^'"]|'[^']*'|"[^"]*")*$)/)
       .compact()
       .uniq()
-      .map((val) => {
+      .map(val => {
         // handle users entering full email addresses just in case
         return val.split("@")[0].trim();
       })

--- a/package.json
+++ b/package.json
@@ -32,9 +32,11 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.0",
-    "node-gyp": "9.4.1"
+    "node-gyp": "9.4.1",
+    "prettier": "2.8.8"
   },
   "resolutions": {
+    "prettier": "2.8.8",
     "@whatwg-node/fetch": "0.9.16",
     "@whatwg-node/node-fetch": "0.5.18",
     "@whatwg-node/events": "0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12323,12 +12323,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
-
-prettier@^2.7.1:
+prettier@2.8.8, prettier@^2.7.1:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==


### PR DESCRIPTION
Implements https://github.com/mskcc/smile-server/issues/1854

## Description

<Include a summary of the changes. Please also include relevant motivation and context. List any external dependencies that are required for this change, like new environment variables.>

## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [x] Searching for a single term or multiple terms returns relevant results
- [x] Searching in PHI mode returns results with PHI columns
- [x] Filtering columns returns the results matching the filter
- [ ] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [x] Clicking "Download as TSV"
- [x] Searching for some terms then clicking "Download as TSV"
- [x] Filtering a column then clicking "Download as TSV"
- [x] Search in PHI mode then clicking "Download as TSV"
- [x] Clicking the dropdown download option <download option name>
- [x] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
- [x] Viewing a sample's data diff and clicking "Download as TSV"

#### AG Grid interactions

- [x] [Samples page] Editing a cell updates the value as expected
- [x] [Samples page] Pasting data into the grid works as expected
- [x] Editing a cell in a non-editable row/column is prevented
- [x] Column sorting in ascending and descending order works as expected
- [x] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [x] [Samples page] Cell changes confirmation modal appears and works as expected
- [x] [Requests page] Validation errors are displayed in the Record Validation modal
- [x] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [x] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [ ] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [ ] The GraphQL types that are auto-generated via `yarn run codegen`
- [ ] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
