### PR TITLE
Consolidate use of Cohort.cohortSstatus and CohortComplete.status

### DIFF
--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -1391,7 +1391,6 @@ export type DashboardCohort = {
   _uniqueSampleCount?: Maybe<Scalars['Int']['output']>;
   billed?: Maybe<Scalars['String']['output']>;
   cohortId: Scalars['String']['output'];
-  cohortStatus?: Maybe<Scalars['String']['output']>;
   endUsers?: Maybe<Scalars['String']['output']>;
   importDate?: Maybe<Scalars['String']['output']>;
   initialCohortDeliveryDate?: Maybe<Scalars['String']['output']>;
@@ -1412,7 +1411,6 @@ export type DashboardCohortInput = {
   changedFieldNames: Array<Scalars['String']['input']>;
   changelog?: InputMaybe<Scalars['String']['input']>;
   cohortId: Scalars['String']['input'];
-  cohortStatus?: InputMaybe<Scalars['String']['input']>;
   endUsers?: InputMaybe<Scalars['String']['input']>;
   importDate?: InputMaybe<Scalars['String']['input']>;
   initialCohortDeliveryDate?: InputMaybe<Scalars['String']['input']>;
@@ -11371,7 +11369,7 @@ export type DashboardCohortsQueryVariables = Exact<{
 }>;
 
 
-export type DashboardCohortsQuery = { __typename?: 'Query', dashboardCohorts: Array<{ __typename?: 'DashboardCohort', cohortId: string, cohortStatus?: string | null, totalSampleCount?: number | null, billed?: string | null, initialCohortDeliveryDate?: string | null, importDate?: string | null, endUsers?: string | null, pmUsers?: string | null, projectTitle?: string | null, projectSubtitle?: string | null, status?: string | null, type?: string | null, pipelineVersion?: string | null, searchableSampleIds?: string | null, _total?: number | null, _uniqueSampleCount?: number | null }> };
+export type DashboardCohortsQuery = { __typename?: 'Query', dashboardCohorts: Array<{ __typename?: 'DashboardCohort', cohortId: string, totalSampleCount?: number | null, billed?: string | null, initialCohortDeliveryDate?: string | null, importDate?: string | null, endUsers?: string | null, pmUsers?: string | null, projectTitle?: string | null, projectSubtitle?: string | null, status?: string | null, type?: string | null, pipelineVersion?: string | null, searchableSampleIds?: string | null, _total?: number | null, _uniqueSampleCount?: number | null }> };
 
 export type DashboardSamplesQueryVariables = Exact<{
   searchVals?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
@@ -11716,7 +11714,6 @@ export const DashboardCohortsDocument = gql`
     offset: $offset
   ) {
     cohortId
-    cohortStatus
     totalSampleCount
     billed
     initialCohortDeliveryDate

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -376,7 +376,6 @@ export type BigIntAggregateSelection = {
 export type Cohort = {
   __typename?: 'Cohort';
   cohortId: Scalars['String']['output'];
-  cohortStatus: Scalars['String']['output'];
   hasCohortCompleteCohortCompletes: Array<CohortComplete>;
   hasCohortCompleteCohortCompletesAggregate?: Maybe<CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection>;
   hasCohortCompleteCohortCompletesConnection: CohortHasCohortCompleteCohortCompletesConnection;
@@ -432,7 +431,6 @@ export type CohortHasCohortSampleSamplesConnectionArgs = {
 export type CohortAggregateSelection = {
   __typename?: 'CohortAggregateSelection';
   cohortId: StringAggregateSelection;
-  cohortStatus: StringAggregateSelection;
   count: Scalars['Int']['output'];
 };
 
@@ -467,7 +465,7 @@ export type CohortComplete = {
   pmUsers: Scalars['String']['output'];
   projectSubtitle: Scalars['String']['output'];
   projectTitle: Scalars['String']['output'];
-  status?: Maybe<Scalars['String']['output']>;
+  status: Scalars['String']['output'];
   type: Scalars['String']['output'];
 };
 
@@ -516,7 +514,6 @@ export type CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection = {
 export type CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection = {
   __typename?: 'CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection';
   cohortId: StringAggregateSelection;
-  cohortStatus: StringAggregateSelection;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateInput = {
@@ -594,21 +591,6 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>;
   cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>;
   cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteRelationship = {
@@ -647,7 +629,7 @@ export type CohortCompleteCreateInput = {
   pmUsers: Scalars['String']['input'];
   projectSubtitle: Scalars['String']['input'];
   projectTitle: Scalars['String']['input'];
-  status?: InputMaybe<Scalars['String']['input']>;
+  status: Scalars['String']['input'];
   type: Scalars['String']['input'];
 };
 
@@ -770,7 +752,7 @@ export type CohortCompleteWhere = {
   status?: InputMaybe<Scalars['String']['input']>;
   status_CONTAINS?: InputMaybe<Scalars['String']['input']>;
   status_ENDS_WITH?: InputMaybe<Scalars['String']['input']>;
-  status_IN?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  status_IN?: InputMaybe<Array<Scalars['String']['input']>>;
   status_MATCHES?: InputMaybe<Scalars['String']['input']>;
   status_STARTS_WITH?: InputMaybe<Scalars['String']['input']>;
   type?: InputMaybe<Scalars['String']['input']>;
@@ -799,7 +781,6 @@ export type CohortConnectWhere = {
 
 export type CohortCreateInput = {
   cohortId: Scalars['String']['input'];
-  cohortStatus: Scalars['String']['input'];
   hasCohortCompleteCohortCompletes?: InputMaybe<CohortHasCohortCompleteCohortCompletesFieldInput>;
   hasCohortSampleSamples?: InputMaybe<CohortHasCohortSampleSamplesFieldInput>;
 };
@@ -1211,12 +1192,10 @@ export type CohortSampleHasCohortSampleSamplesNodeAggregateSelection = {
 /** Fields to sort Cohorts by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortSort object. */
 export type CohortSort = {
   cohortId?: InputMaybe<SortDirection>;
-  cohortStatus?: InputMaybe<SortDirection>;
 };
 
 export type CohortUpdateInput = {
   cohortId?: InputMaybe<Scalars['String']['input']>;
-  cohortStatus?: InputMaybe<Scalars['String']['input']>;
   hasCohortCompleteCohortCompletes?: InputMaybe<Array<CohortHasCohortCompleteCohortCompletesUpdateFieldInput>>;
   hasCohortSampleSamples?: InputMaybe<Array<CohortHasCohortSampleSamplesUpdateFieldInput>>;
 };
@@ -1231,12 +1210,6 @@ export type CohortWhere = {
   cohortId_IN?: InputMaybe<Array<Scalars['String']['input']>>;
   cohortId_MATCHES?: InputMaybe<Scalars['String']['input']>;
   cohortId_STARTS_WITH?: InputMaybe<Scalars['String']['input']>;
-  cohortStatus?: InputMaybe<Scalars['String']['input']>;
-  cohortStatus_CONTAINS?: InputMaybe<Scalars['String']['input']>;
-  cohortStatus_ENDS_WITH?: InputMaybe<Scalars['String']['input']>;
-  cohortStatus_IN?: InputMaybe<Array<Scalars['String']['input']>>;
-  cohortStatus_MATCHES?: InputMaybe<Scalars['String']['input']>;
-  cohortStatus_STARTS_WITH?: InputMaybe<Scalars['String']['input']>;
   hasCohortCompleteCohortCompletesAggregate?: InputMaybe<CohortHasCohortCompleteCohortCompletesAggregateInput>;
   /** Return Cohorts where all of the related CohortHasCohortCompleteCohortCompletesConnections match this filter */
   hasCohortCompleteCohortCompletesConnection_ALL?: InputMaybe<CohortHasCohortCompleteCohortCompletesConnectionWhere>;
@@ -6789,7 +6762,6 @@ export type SampleCohortCohortsHasCohortSampleAggregationSelection = {
 export type SampleCohortCohortsHasCohortSampleNodeAggregateSelection = {
   __typename?: 'SampleCohortCohortsHasCohortSampleNodeAggregateSelection';
   cohortId: StringAggregateSelection;
-  cohortStatus: StringAggregateSelection;
 };
 
 export type SampleCohortsHasCohortSampleAggregateInput = {
@@ -6867,21 +6839,6 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
   cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>;
   cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>;
   cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type SampleCohortsHasCohortSampleRelationship = {

--- a/frontend/src/pages/cohorts/config.tsx
+++ b/frontend/src/pages/cohorts/config.tsx
@@ -67,10 +67,10 @@ export const cohortColDefs: ColDef<DashboardCohort>[] = [
     headerName: "Cohort ID",
   },
   {
-    field: "cohortStatus",
-    headerName: "Cohort Status",
+    field: "status",
+    headerName: "Status",
     headerTooltip:
-      "The status of the cohort in SMILE (e.g. PROVISONAL, DELIVERED)",
+      "The status of the cohort in TEMPO (e.g. PROVISONAL, PASS, FAIL)",
     headerComponentParams: createCustomHeader(lockIcon + toolTipIcon),
     cellRenderer: (params: ICellRendererParams<DashboardCohort>) => {
       if (!params.data) return null;
@@ -125,10 +125,6 @@ export const cohortColDefs: ColDef<DashboardCohort>[] = [
   {
     field: "projectSubtitle",
     headerName: "Project Subtitle",
-  },
-  {
-    field: "status",
-    headerName: "Status",
   },
   {
     field: "type",

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -1390,7 +1390,6 @@ export type DashboardCohort = {
   _uniqueSampleCount?: Maybe<Scalars['Int']['output']>;
   billed?: Maybe<Scalars['String']['output']>;
   cohortId: Scalars['String']['output'];
-  cohortStatus?: Maybe<Scalars['String']['output']>;
   endUsers?: Maybe<Scalars['String']['output']>;
   importDate?: Maybe<Scalars['String']['output']>;
   initialCohortDeliveryDate?: Maybe<Scalars['String']['output']>;
@@ -1411,7 +1410,6 @@ export type DashboardCohortInput = {
   changedFieldNames: Array<Scalars['String']['input']>;
   changelog?: InputMaybe<Scalars['String']['input']>;
   cohortId: Scalars['String']['input'];
-  cohortStatus?: InputMaybe<Scalars['String']['input']>;
   endUsers?: InputMaybe<Scalars['String']['input']>;
   importDate?: InputMaybe<Scalars['String']['input']>;
   initialCohortDeliveryDate?: InputMaybe<Scalars['String']['input']>;
@@ -11370,7 +11368,7 @@ export type DashboardCohortsQueryVariables = Exact<{
 }>;
 
 
-export type DashboardCohortsQuery = { __typename?: 'Query', dashboardCohorts: Array<{ __typename?: 'DashboardCohort', cohortId: string, cohortStatus?: string | null, totalSampleCount?: number | null, billed?: string | null, initialCohortDeliveryDate?: string | null, importDate?: string | null, endUsers?: string | null, pmUsers?: string | null, projectTitle?: string | null, projectSubtitle?: string | null, status?: string | null, type?: string | null, pipelineVersion?: string | null, searchableSampleIds?: string | null, _total?: number | null, _uniqueSampleCount?: number | null }> };
+export type DashboardCohortsQuery = { __typename?: 'Query', dashboardCohorts: Array<{ __typename?: 'DashboardCohort', cohortId: string, totalSampleCount?: number | null, billed?: string | null, initialCohortDeliveryDate?: string | null, importDate?: string | null, endUsers?: string | null, pmUsers?: string | null, projectTitle?: string | null, projectSubtitle?: string | null, status?: string | null, type?: string | null, pipelineVersion?: string | null, searchableSampleIds?: string | null, _total?: number | null, _uniqueSampleCount?: number | null }> };
 
 export type DashboardSamplesQueryVariables = Exact<{
   searchVals?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
@@ -11636,7 +11634,6 @@ export const DashboardCohortsDocument = gql`
     offset: $offset
   ) {
     cohortId
-    cohortStatus
     totalSampleCount
     billed
     initialCohortDeliveryDate

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -375,7 +375,6 @@ export type BigIntAggregateSelection = {
 export type Cohort = {
   __typename?: 'Cohort';
   cohortId: Scalars['String']['output'];
-  cohortStatus: Scalars['String']['output'];
   hasCohortCompleteCohortCompletes: Array<CohortComplete>;
   hasCohortCompleteCohortCompletesAggregate?: Maybe<CohortCohortCompleteHasCohortCompleteCohortCompletesAggregationSelection>;
   hasCohortCompleteCohortCompletesConnection: CohortHasCohortCompleteCohortCompletesConnection;
@@ -431,7 +430,6 @@ export type CohortHasCohortSampleSamplesConnectionArgs = {
 export type CohortAggregateSelection = {
   __typename?: 'CohortAggregateSelection';
   cohortId: StringAggregateSelection;
-  cohortStatus: StringAggregateSelection;
   count: Scalars['Int']['output'];
 };
 
@@ -466,7 +464,7 @@ export type CohortComplete = {
   pmUsers: Scalars['String']['output'];
   projectSubtitle: Scalars['String']['output'];
   projectTitle: Scalars['String']['output'];
-  status?: Maybe<Scalars['String']['output']>;
+  status: Scalars['String']['output'];
   type: Scalars['String']['output'];
 };
 
@@ -515,7 +513,6 @@ export type CohortCompleteCohortCohortsHasCohortCompleteAggregationSelection = {
 export type CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection = {
   __typename?: 'CohortCompleteCohortCohortsHasCohortCompleteNodeAggregateSelection';
   cohortId: StringAggregateSelection;
-  cohortStatus: StringAggregateSelection;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteAggregateInput = {
@@ -593,21 +590,6 @@ export type CohortCompleteCohortsHasCohortCompleteNodeAggregationWhereInput = {
   cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>;
   cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>;
   cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type CohortCompleteCohortsHasCohortCompleteRelationship = {
@@ -646,7 +628,7 @@ export type CohortCompleteCreateInput = {
   pmUsers: Scalars['String']['input'];
   projectSubtitle: Scalars['String']['input'];
   projectTitle: Scalars['String']['input'];
-  status?: InputMaybe<Scalars['String']['input']>;
+  status: Scalars['String']['input'];
   type: Scalars['String']['input'];
 };
 
@@ -769,7 +751,7 @@ export type CohortCompleteWhere = {
   status?: InputMaybe<Scalars['String']['input']>;
   status_CONTAINS?: InputMaybe<Scalars['String']['input']>;
   status_ENDS_WITH?: InputMaybe<Scalars['String']['input']>;
-  status_IN?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  status_IN?: InputMaybe<Array<Scalars['String']['input']>>;
   status_MATCHES?: InputMaybe<Scalars['String']['input']>;
   status_STARTS_WITH?: InputMaybe<Scalars['String']['input']>;
   type?: InputMaybe<Scalars['String']['input']>;
@@ -798,7 +780,6 @@ export type CohortConnectWhere = {
 
 export type CohortCreateInput = {
   cohortId: Scalars['String']['input'];
-  cohortStatus: Scalars['String']['input'];
   hasCohortCompleteCohortCompletes?: InputMaybe<CohortHasCohortCompleteCohortCompletesFieldInput>;
   hasCohortSampleSamples?: InputMaybe<CohortHasCohortSampleSamplesFieldInput>;
 };
@@ -1210,12 +1191,10 @@ export type CohortSampleHasCohortSampleSamplesNodeAggregateSelection = {
 /** Fields to sort Cohorts by. The order in which sorts are applied is not guaranteed when specifying many fields in one CohortSort object. */
 export type CohortSort = {
   cohortId?: InputMaybe<SortDirection>;
-  cohortStatus?: InputMaybe<SortDirection>;
 };
 
 export type CohortUpdateInput = {
   cohortId?: InputMaybe<Scalars['String']['input']>;
-  cohortStatus?: InputMaybe<Scalars['String']['input']>;
   hasCohortCompleteCohortCompletes?: InputMaybe<Array<CohortHasCohortCompleteCohortCompletesUpdateFieldInput>>;
   hasCohortSampleSamples?: InputMaybe<Array<CohortHasCohortSampleSamplesUpdateFieldInput>>;
 };
@@ -1230,12 +1209,6 @@ export type CohortWhere = {
   cohortId_IN?: InputMaybe<Array<Scalars['String']['input']>>;
   cohortId_MATCHES?: InputMaybe<Scalars['String']['input']>;
   cohortId_STARTS_WITH?: InputMaybe<Scalars['String']['input']>;
-  cohortStatus?: InputMaybe<Scalars['String']['input']>;
-  cohortStatus_CONTAINS?: InputMaybe<Scalars['String']['input']>;
-  cohortStatus_ENDS_WITH?: InputMaybe<Scalars['String']['input']>;
-  cohortStatus_IN?: InputMaybe<Array<Scalars['String']['input']>>;
-  cohortStatus_MATCHES?: InputMaybe<Scalars['String']['input']>;
-  cohortStatus_STARTS_WITH?: InputMaybe<Scalars['String']['input']>;
   hasCohortCompleteCohortCompletesAggregate?: InputMaybe<CohortHasCohortCompleteCohortCompletesAggregateInput>;
   /** Return Cohorts where all of the related CohortHasCohortCompleteCohortCompletesConnections match this filter */
   hasCohortCompleteCohortCompletesConnection_ALL?: InputMaybe<CohortHasCohortCompleteCohortCompletesConnectionWhere>;
@@ -6788,7 +6761,6 @@ export type SampleCohortCohortsHasCohortSampleAggregationSelection = {
 export type SampleCohortCohortsHasCohortSampleNodeAggregateSelection = {
   __typename?: 'SampleCohortCohortsHasCohortSampleNodeAggregateSelection';
   cohortId: StringAggregateSelection;
-  cohortStatus: StringAggregateSelection;
 };
 
 export type SampleCohortsHasCohortSampleAggregateInput = {
@@ -6866,21 +6838,6 @@ export type SampleCohortsHasCohortSampleNodeAggregationWhereInput = {
   cohortId_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>;
   cohortId_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>;
   cohortId_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_GT?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_LT?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars['Float']['input']>;
-  cohortStatus_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_LONGEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_GT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_LT?: InputMaybe<Scalars['Int']['input']>;
-  cohortStatus_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type SampleCohortsHasCohortSampleRelationship = {

--- a/graphql-server/src/schemas/queries/cohorts.ts
+++ b/graphql-server/src/schemas/queries/cohorts.ts
@@ -24,7 +24,6 @@ const FIELDS_TO_SEARCH = [
   "type",
   "searchableSampleIds", // hidden searchable field,
   "pipelineVersion",
-  "cohortStatus",
 ];
 
 export function buildCohortsQueryBody({
@@ -128,8 +127,7 @@ export function buildCohortsQueryBody({
       totalSampleCount: totalSampleCount,
       searchableSampleIds: apoc.text.join(searchableSampleIds, ","),
       billed: billed,
-      initialCohortDeliveryDate: initialCohortDeliveryDate,
-      cohortStatus: c.cohortStatus
+      initialCohortDeliveryDate: initialCohortDeliveryDate
     }) as tempNode,
     COLLECT {
       MATCH (c)-[:HAS_COHORT_COMPLETE]->(cc: CohortComplete)

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -176,7 +176,6 @@ const QUERY_RESULT_TYPEDEFS = gql`
 
   type DashboardCohort {
     cohortId: String!
-    cohortStatus: String
     totalSampleCount: Int
     billed: String
     initialCohortDeliveryDate: String
@@ -304,7 +303,6 @@ const MUTATION_TYPEDEFS = gql`
   input DashboardCohortInput {
     changedFieldNames: [String!]!
     cohortId: String!
-    cohortStatus: String
     totalSampleCount: Int
     billed: String
     initialCohortDeliveryDate: String

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -13503,18 +13503,6 @@
             "deprecationReason": null
           },
           {
-            "name": "cohortStatus",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "endUsers",
             "description": null,
             "args": [],
@@ -13742,18 +13730,6 @@
                 "kind": "SCALAR",
                 "ofType": null
               }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -3494,22 +3494,6 @@
             "deprecationReason": null
           },
           {
-            "name": "cohortStatus",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "name": "String",
-                "kind": "SCALAR",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "hasCohortCompleteCohortCompletes",
             "description": null,
             "args": [
@@ -3889,22 +3873,6 @@
         "fields": [
           {
             "name": "cohortId",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "name": "StringAggregateSelection",
-                "kind": "OBJECT",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus",
             "description": null,
             "args": [],
             "type": {
@@ -4435,9 +4403,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "String",
+                "kind": "SCALAR",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4684,22 +4656,6 @@
         "fields": [
           {
             "name": "cohortId",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "name": "StringAggregateSelection",
-                "kind": "OBJECT",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus",
             "description": null,
             "args": [],
             "type": {
@@ -5474,186 +5430,6 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_AVERAGE_LENGTH_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_AVERAGE_LENGTH_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_AVERAGE_LENGTH_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_AVERAGE_LENGTH_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_AVERAGE_LENGTH_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_LONGEST_LENGTH_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_LONGEST_LENGTH_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_LONGEST_LENGTH_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_LONGEST_LENGTH_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_LONGEST_LENGTH_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_SHORTEST_LENGTH_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_SHORTEST_LENGTH_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_SHORTEST_LENGTH_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_SHORTEST_LENGTH_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_SHORTEST_LENGTH_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -6031,9 +5807,13 @@
             "name": "status",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "String",
+                "kind": "SCALAR",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -7302,9 +7082,13 @@
               "kind": "LIST",
               "name": null,
               "ofType": {
-                "name": "String",
-                "kind": "SCALAR",
-                "ofType": null
+                "name": null,
+                "kind": "NON_NULL",
+                "ofType": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -7577,22 +7361,6 @@
         "inputFields": [
           {
             "name": "cohortId",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "name": "String",
-                "kind": "SCALAR",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus",
             "description": null,
             "type": {
               "kind": "NON_NULL",
@@ -11954,18 +11722,6 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortDirection",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -11981,18 +11737,6 @@
         "inputFields": [
           {
             "name": "cohortId",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -12177,86 +11921,6 @@
           },
           {
             "name": "cohortId_STARTS_WITH",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_CONTAINS",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_ENDS_WITH",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_IN",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "name": null,
-                "kind": "NON_NULL",
-                "ofType": {
-                  "name": "String",
-                  "kind": "SCALAR",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_MATCHES",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_STARTS_WITH",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -65252,22 +64916,6 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "name": "StringAggregateSelection",
-                "kind": "OBJECT",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -66020,186 +65668,6 @@
           },
           {
             "name": "cohortId_SHORTEST_LENGTH_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_AVERAGE_LENGTH_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_AVERAGE_LENGTH_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_AVERAGE_LENGTH_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_AVERAGE_LENGTH_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_AVERAGE_LENGTH_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_LONGEST_LENGTH_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_LONGEST_LENGTH_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_LONGEST_LENGTH_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_LONGEST_LENGTH_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_LONGEST_LENGTH_LTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_SHORTEST_LENGTH_EQUAL",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_SHORTEST_LENGTH_GT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_SHORTEST_LENGTH_GTE",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_SHORTEST_LENGTH_LT",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cohortStatus_SHORTEST_LENGTH_LTE",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -90,7 +90,6 @@ query DashboardCohorts(
     offset: $offset
   ) {
     cohortId
-    cohortStatus
     totalSampleCount
     billed
     initialCohortDeliveryDate


### PR DESCRIPTION
Removed references of Cohort.cohortStatus and replaced with CohortComplete.status Updated types for graphql
Removed and replaced the Cohorts table Status column

## Description

<Include a summary of the changes. Please also include relevant motivation and context. List any external dependencies that are required for this change, like new environment variables.>

## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [x] Searching for a single term or multiple terms returns relevant results
- [x] Searching in PHI mode returns results with PHI columns
- [x] Filtering columns returns the results matching the filter
- [x] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [x] Clicking "Download as TSV"
- [x] Searching for some terms then clicking "Download as TSV"
- [x] Filtering a column then clicking "Download as TSV"
- [x] Search in PHI mode then clicking "Download as TSV"
- [x] Clicking the dropdown download option <download option name>
- [x] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
- [x] Viewing a sample's data diff and clicking "Download as TSV"

#### AG Grid interactions

- [x] [Samples page] Editing a cell updates the value as expected
- [x] [Samples page] Pasting data into the grid works as expected
- [x] Editing a cell in a non-editable row/column is prevented
- [x] Column sorting in ascending and descending order works as expected
- [x] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [x] [Samples page] Cell changes confirmation modal appears and works as expected
- [x] [Requests page] Validation errors are displayed in the Record Validation modal
- [x] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [x] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [x] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [x] The GraphQL types that are auto-generated via `yarn run codegen`
- [x] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
