### PR TITLE
Init commit - add redlivery button to Cohort samples view if cohort is PROVISIONAL

### DIFF
--- a/frontend/src/components/SamplesModal.tsx
+++ b/frontend/src/components/SamplesModal.tsx
@@ -4,8 +4,10 @@ import { useNavigate, useParams } from "react-router-dom";
 import {
   DashboardRecordContext,
   DashboardSample,
+  TempoCohortRequest,
   useDashboardSamplesLazyQuery,
 } from "../generated/graphql";
+import { CohortBuilderPublishButton } from "../components/CohortBuilderPublishButton";
 import { useFetchData } from "../hooks/useFetchData";
 import { useCellChanges } from "../hooks/useCellChanges";
 import { useDownload } from "../hooks/useDownload";
@@ -56,6 +58,7 @@ interface SamplesModalProps {
   parentRecordName: keyof typeof ROUTE_PARAMS;
   showPhiModeSwitch?: boolean;
   showForceLabelButton?: boolean;
+  tempoCohortRequest?: TempoCohortRequest;
 }
 
 export function SamplesModal({
@@ -64,6 +67,7 @@ export function SamplesModal({
   parentRecordName,
   showPhiModeSwitch = false,
   showForceLabelButton = false,
+  tempoCohortRequest,
 }: SamplesModalProps) {
   const [userSearchVal, setUserSearchVal] = useState("");
   const [colDefs, setColDefs] = useState(sampleColDefs);
@@ -236,6 +240,23 @@ export function SamplesModal({
                 : ""}
             </CustomTooltip>
           )}
+          {parentRecordName === "cohorts" &&
+            tempoCohortRequest &&
+            tempoCohortRequest.status === "PROVISIONAL" && (
+              <CohortBuilderPublishButton
+                tempoCohortRequest={tempoCohortRequest}
+                cohortSamples={(data?.[QUERY_NAME] ?? []).map(
+                  (s: DashboardSample) => ({
+                    primaryId: s.primaryId ?? "",
+                    cmoSampleName: s.cmoSampleName ?? "",
+                    mafCompleteStatus: s.mafCompleteStatus ?? "",
+                    sampleCohortIds: s.sampleCohortIds ?? "",
+                    initialPipelineRunDate: s.initialPipelineRunDate ?? null,
+                    embargoDate: s.embargoDate ?? null,
+                  })
+                )}
+              />
+            )}
           <DownloadButton
             downloadOptions={downloadOptions}
             onDownload={handleDownload}

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -10383,6 +10383,7 @@ export type TempoCohortRequest = {
   projectSubtitle: Scalars['String']['output'];
   projectTitle: Scalars['String']['output'];
   samples: Array<TempoCohortSample>;
+  status: Scalars['String']['output'];
   type: Scalars['String']['output'];
 };
 
@@ -10393,6 +10394,7 @@ export type TempoCohortRequestInput = {
   projectSubtitle: Scalars['String']['input'];
   projectTitle: Scalars['String']['input'];
   samples: Array<TempoCohortSampleInput>;
+  status: Scalars['String']['input'];
   type: Scalars['String']['input'];
 };
 
@@ -11397,7 +11399,7 @@ export type PublishNewTempoCohortRequestMutationVariables = Exact<{
 }>;
 
 
-export type PublishNewTempoCohortRequestMutation = { __typename?: 'Mutation', publishNewTempoCohortRequest?: { __typename?: 'TempoCohortRequest', cohortId: string, projectTitle: string, projectSubtitle: string, endUsers: string, pmUsers: string, type: string, samples: Array<{ __typename?: 'TempoCohortSample', primaryId: string, cmoId?: string | null, embargoDate?: string | null }> } | null };
+export type PublishNewTempoCohortRequestMutation = { __typename?: 'Mutation', publishNewTempoCohortRequest?: { __typename?: 'TempoCohortRequest', cohortId: string, projectTitle: string, projectSubtitle: string, endUsers: string, pmUsers: string, type: string, status: string, samples: Array<{ __typename?: 'TempoCohortSample', primaryId: string, cmoId?: string | null, embargoDate?: string | null }> } | null };
 
 export const DashboardSamplePartsFragmentDoc = gql`
     fragment DashboardSampleParts on DashboardSample {
@@ -12044,6 +12046,7 @@ export const PublishNewTempoCohortRequestDocument = gql`
     endUsers
     pmUsers
     type
+    status
     samples {
       primaryId
       cmoId

--- a/frontend/src/pages/cohorts/CohortsPage.tsx
+++ b/frontend/src/pages/cohorts/CohortsPage.tsx
@@ -1,10 +1,12 @@
-import { useRef, useState, useMemo } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import { DataGrid } from "../../components/DataGrid";
 import { AgGridReact as AgGridReactType } from "ag-grid-react/lib/agGridReact";
 import { useFetchData } from "../../hooks/useFetchData";
 import {
+  AgGridSortDirection,
   DashboardCohort,
   DashboardSample,
+  TempoCohortRequest,
   useDashboardCohortsLazyQuery,
 } from "../../generated/graphql";
 import { Title } from "../../components/Title";
@@ -39,6 +41,36 @@ export function CohortsPage() {
   const [userSearchVal, setUserSearchVal] = useState("");
   const gridRef = useRef<AgGridReactType<DashboardSample>>(null);
   const hasParams = Object.keys(useParams()).length > 0;
+  const cohortId = useParams()[ROUTE_PARAMS.cohorts];
+
+  const [fetchSelectedCohort, { data: selectedCohortData }] =
+    useDashboardCohortsLazyQuery();
+
+  useEffect(() => {
+    if (!cohortId) return;
+    fetchSelectedCohort({
+      variables: {
+        searchVals: [`"${cohortId}"`],
+        sort: { colId: "cohortId", sort: AgGridSortDirection.Asc },
+        limit: 1,
+        offset: 0,
+      },
+    });
+  }, [cohortId, fetchSelectedCohort]);
+
+  const selectedCohort = selectedCohortData?.["dashboardCohorts"]?.[0];
+  const tempoCohortRequest: TempoCohortRequest | undefined = selectedCohort
+    ? {
+        cohortId: selectedCohort.cohortId,
+        endUsers: selectedCohort.endUsers ?? "",
+        pmUsers: selectedCohort.pmUsers ?? "",
+        projectTitle: selectedCohort.projectTitle ?? "",
+        projectSubtitle: selectedCohort.projectSubtitle ?? "",
+        type: selectedCohort.type ?? "",
+        status: selectedCohort.status ?? "",
+        samples: [],
+      }
+    : undefined;
 
   const {
     refreshData,
@@ -159,6 +191,7 @@ export function CohortsPage() {
           sampleColDefs={filteredWesSampleColDefs}
           contextFieldName={ROUTE_PARAMS.cohorts}
           parentRecordName={RECORD_NAME}
+          tempoCohortRequest={tempoCohortRequest}
         />
       )}
 

--- a/frontend/src/pages/samples/SamplesPage.tsx
+++ b/frontend/src/pages/samples/SamplesPage.tsx
@@ -73,6 +73,7 @@ export function SamplesPage() {
       projectSubtitle: "",
       samples: [],
       type: "investigator",
+      status: "PROVISIONAL",
     });
 
   const showCohortBuilder = cohortBuilderMode !== "hidden";
@@ -89,6 +90,7 @@ export function SamplesPage() {
       projectSubtitle: "",
       samples: [],
       type: "investigator",
+      status: "PROVISIONAL",
     });
   }
 

--- a/graphql-server/src/generated/graphql.ts
+++ b/graphql-server/src/generated/graphql.ts
@@ -10382,6 +10382,7 @@ export type TempoCohortRequest = {
   projectSubtitle: Scalars['String']['output'];
   projectTitle: Scalars['String']['output'];
   samples: Array<TempoCohortSample>;
+  status: Scalars['String']['output'];
   type: Scalars['String']['output'];
 };
 
@@ -10392,6 +10393,7 @@ export type TempoCohortRequestInput = {
   projectSubtitle: Scalars['String']['input'];
   projectTitle: Scalars['String']['input'];
   samples: Array<TempoCohortSampleInput>;
+  status: Scalars['String']['input'];
   type: Scalars['String']['input'];
 };
 
@@ -11396,7 +11398,7 @@ export type PublishNewTempoCohortRequestMutationVariables = Exact<{
 }>;
 
 
-export type PublishNewTempoCohortRequestMutation = { __typename?: 'Mutation', publishNewTempoCohortRequest?: { __typename?: 'TempoCohortRequest', cohortId: string, projectTitle: string, projectSubtitle: string, endUsers: string, pmUsers: string, type: string, samples: Array<{ __typename?: 'TempoCohortSample', primaryId: string, cmoId?: string | null, embargoDate?: string | null }> } | null };
+export type PublishNewTempoCohortRequestMutation = { __typename?: 'Mutation', publishNewTempoCohortRequest?: { __typename?: 'TempoCohortRequest', cohortId: string, projectTitle: string, projectSubtitle: string, endUsers: string, pmUsers: string, type: string, status: string, samples: Array<{ __typename?: 'TempoCohortSample', primaryId: string, cmoId?: string | null, embargoDate?: string | null }> } | null };
 
 export const DashboardSamplePartsFragmentDoc = gql`
     fragment DashboardSampleParts on DashboardSample {
@@ -11730,6 +11732,7 @@ export const PublishNewTempoCohortRequestDocument = gql`
     endUsers
     pmUsers
     type
+    status
     samples {
       primaryId
       cmoId

--- a/graphql-server/src/utils/typeDefs.ts
+++ b/graphql-server/src/utils/typeDefs.ts
@@ -237,6 +237,7 @@ const QUERY_RESULT_TYPEDEFS = gql`
     endUsers: String!
     pmUsers: String!
     type: String!
+    status: String!
     samples: [TempoCohortSample!]!
   }
 `;
@@ -333,6 +334,7 @@ const MUTATION_TYPEDEFS = gql`
     endUsers: [String!]!
     pmUsers: [String!]!
     type: String!
+    status: String!
     samples: [TempoCohortSampleInput!]!
   }
 

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -103381,6 +103381,22 @@
             "deprecationReason": null
           },
           {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "String",
+                "kind": "SCALAR",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "type",
             "description": null,
             "args": [],
@@ -103523,6 +103539,22 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "String",
+                "kind": "SCALAR",
+                "ofType": null
               }
             },
             "defaultValue": null,

--- a/graphql/operations.graphql
+++ b/graphql/operations.graphql
@@ -343,6 +343,7 @@ mutation PublishNewTempoCohortRequest(
     endUsers
     pmUsers
     type
+    status
     samples {
       primaryId
       cmoId


### PR DESCRIPTION
…

## Description

<Include a summary of the changes. Please also include relevant motivation and context. List any external dependencies that are required for this change, like new environment variables.>

## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [x] Searching for a single term or multiple terms returns relevant results
- [x] Searching in PHI mode returns results with PHI columns
- [x] Filtering columns returns the results matching the filter
- [x] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [x] Clicking "Download as TSV"
- [x] Searching for some terms then clicking "Download as TSV"
- [x] Filtering a column then clicking "Download as TSV"
- [x] Search in PHI mode then clicking "Download as TSV"
- [x] Clicking the dropdown download option <download option name>
- [x] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
- [x] Viewing a sample's data diff and clicking "Download as TSV"

#### AG Grid interactions

- [x] [Samples page] Editing a cell updates the value as expected
- [x] [Samples page] Pasting data into the grid works as expected
- [x] Editing a cell in a non-editable row/column is prevented
- [x] Column sorting in ascending and descending order works as expected
- [x] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [x] [Samples page] Cell changes confirmation modal appears and works as expected
- [x] [Requests page] Validation errors are displayed in the Record Validation modal
- [x] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [x] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [x] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [x] The GraphQL types that are auto-generated via `yarn run codegen`
- [x] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
