### PR TITLE
PHI warning modal pop up fix

### DIFF
--- a/frontend/src/contexts/PhiEnabledContext.tsx
+++ b/frontend/src/contexts/PhiEnabledContext.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   useContext,
   useState,
+  useRef,
   ReactNode,
   Dispatch,
   SetStateAction,
@@ -12,6 +13,8 @@ import { useUserEmail } from "./UserEmailContext";
 import { openLoginPopup } from "../utils/openLoginPopup";
 import { useWarningModal } from "./WarningContext";
 import { PHI_WARNING } from "../configs/shared";
+
+const PHI_WARNING_COOLDOWN_MS = 180 * 1000;
 
 type PhiEnabledContextType = {
   phiEnabled: boolean;
@@ -26,16 +29,36 @@ export function PhiEnabledProvider({ children }: { children: ReactNode }) {
   const [phiEnabled, setPhiEnabled] = useState<boolean>(false);
   const { userEmail, setUserEmail } = useUserEmail();
   const { setWarningModalContent } = useWarningModal();
+  const lastWarningTimeRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!userEmail) {
+      lastWarningTimeRef.current = null;
+    }
+  }, [userEmail]);
 
   useEffect(() => {
     async function handleLogin(event: MessageEvent) {
       if (event.data !== "success") return;
       setUserEmail(await getUserEmail());
       setWarningModalContent(PHI_WARNING);
+      lastWarningTimeRef.current = Date.now();
     }
     if (phiEnabled) {
       window.addEventListener("message", handleLogin);
-      if (!userEmail) openLoginPopup();
+      if (!userEmail) {
+        openLoginPopup();
+      } else {
+        const now = Date.now();
+        const lastWarningTime = lastWarningTimeRef.current;
+        if (
+          lastWarningTime === null ||
+          now - lastWarningTime > PHI_WARNING_COOLDOWN_MS
+        ) {
+          setWarningModalContent(PHI_WARNING);
+          lastWarningTimeRef.current = now;
+        }
+      }
       return () => {
         window.removeEventListener("message", handleLogin);
       };


### PR DESCRIPTION
## Description

Pop up PHI warning modal for authenticated users that toggle the PHI switch.
- Added a cooldown of 3 minutes to prevent repeated warning modals
- Cooldown is reset if user logs out (warning modal will appear if user toggles PHI again)


## Manual testing checklist

Check off items under the affected features below.

### Frontend

#### Searching & filtering

- [ ] Searching for a single term or multiple terms returns relevant results
- [ ] Searching in PHI mode returns results with PHI columns
- [ ] Filtering columns returns the results matching the filter
- [ ] [Samples page] Filtering by All, WES, and ACCESS/CMO-CH returns the expected results

#### Downloading

Confirm that these download actions return a TSV file with the expected columns and record count:

- [ ] Clicking "Download as TSV"
- [ ] Searching for some terms then clicking "Download as TSV"
- [ ] Filtering a column then clicking "Download as TSV"
- [ ] Search in PHI mode then clicking "Download as TSV"
- [ ] Clicking the dropdown download option <download option name>
- [ ] [Samples page -> WES -> Cohort builder] Clicking the "Download New TEMPO Cohort File" (must populate all required fields and have at least one sample selected)
- [ ] Viewing a sample's data diff and clicking "Download as TSV"

#### AG Grid interactions

- [ ] [Samples page] Editing a cell updates the value as expected
- [ ] [Samples page] Pasting data into the grid works as expected
- [ ] Editing a cell in a non-editable row/column is prevented
- [ ] Column sorting in ascending and descending order works as expected
- [ ] PHI columns are visible only when PHI mode is enabled and search terms are present

#### Modals and popups

- [ ] [Samples page] Cell changes confirmation modal appears and works as expected
- [ ] [Requests page] Validation errors are displayed in the Record Validation modal
- [ ] [Samples page -> WES -> Cohort builder] Required fields can be populated and selected samples are displayed in the cohort builder modal
- [ ] Warning modals appear when expected and can be dismissed (e.g. PHI warning when first logged in)

### Backend

#### Schema changes

Schema changes in [typeDefs.ts](./graphql-server/src/utils/typeDefs.ts) are reflected in the following:

- [ ] The queries defined in [operations.graphql](./graphql/operations.graphql)
- [ ] The GraphQL types that are auto-generated via `yarn run codegen`
- [ ] When applicable, ensure that newly added fields are searchable (i.e. added to the "searchable fields" list for a given query)
